### PR TITLE
Add crypto stdlib, default-deny network, boto3/sql capability gates

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -11,5 +11,11 @@
   {"lib/pyex/stdlib/markdown.ex", :invalid_contract},
   # unwrap_response and unwrap_stream_response return partial response maps (without telemetry).
   # The telemetry field is added by the caller via Map.put, which Dialyzer cannot track.
-  {"lib/pyex/lambda.ex", :invalid_contract}
+  {"lib/pyex/lambda.ex", :invalid_contract},
+  # MapSet is an opaque type. Dialyzer complains when it appears in struct fields
+  # because it cannot see through the opaque boundary. The capabilities MapSet is
+  # used correctly via MapSet.member?/2 and MapSet.new/1 -- these are false positives.
+  {"lib/pyex/ctx.ex", :contract_with_opaque},
+  {"lib/pyex/interpreter.ex", :call_without_opaque},
+  {"lib/pyex/stdlib/jinja2.ex", :call_without_opaque}
 ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Pyex
 
+> **Experimental software.** This project was generated entirely by Claude
+> Opus 4.6 via [OpenCode](https://opencode.ai). It is under active development
+> and has not been audited for production use.
+
 A Python 3 interpreter written in Elixir.
 
 LLMs generate Python. This runs it as a function call inside your Elixir app --

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -71,6 +71,11 @@ defmodule Pyex do
   - `:fs_module` -- the module implementing `Pyex.Filesystem`
   - `:environ` -- environment variables for `os.environ`
   - `:timeout_ms` -- compute time budget in milliseconds
+  - `:network` -- network access policy for the `requests` module.
+    Accepts a keyword list with `:allowed_url_prefixes`,
+    `:allowed_methods` (default `["GET", "HEAD"]`), or
+    `:dangerously_allow_full_internet_access`. When omitted,
+    all network access is denied.
 
   ## Examples
 

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -76,6 +76,10 @@ defmodule Pyex do
     `:allowed_url_prefixes`, `:allowed_methods` (default `["GET", "HEAD"]`),
     or `:dangerously_allow_full_internet_access`. When omitted,
     all network access is denied.
+  - `:boto3` -- when `true`, enables the `boto3` module to make S3
+    API calls. Default `false` (all S3 operations raise `PermissionError`).
+  - `:sql` -- when `true`, enables the `sql` module to execute
+    database queries. Default `false` (all queries raise `PermissionError`).
 
   ## Examples
 

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -76,10 +76,10 @@ defmodule Pyex do
     `:allowed_url_prefixes`, `:allowed_methods` (default `["GET", "HEAD"]`),
     or `:dangerously_allow_full_internet_access`. When omitted,
     all network access is denied.
-  - `:boto3` -- when `true`, enables the `boto3` module to make S3
-    API calls. Default `false` (all S3 operations raise `PermissionError`).
-  - `:sql` -- when `true`, enables the `sql` module to execute
-    database queries. Default `false` (all queries raise `PermissionError`).
+  - `:capabilities` -- list of enabled I/O capabilities (e.g.
+    `[:boto3, :sql]`). All capabilities are denied by default.
+  - `:boto3` -- shorthand for adding `:boto3` to capabilities.
+  - `:sql` -- shorthand for adding `:sql` to capabilities.
 
   ## Examples
 

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -72,9 +72,9 @@ defmodule Pyex do
   - `:environ` -- environment variables for `os.environ`
   - `:timeout_ms` -- compute time budget in milliseconds
   - `:network` -- network access policy for the `requests` module.
-    Accepts a keyword list with `:allowed_url_prefixes`,
-    `:allowed_methods` (default `["GET", "HEAD"]`), or
-    `:dangerously_allow_full_internet_access`. When omitted,
+    Accepts a keyword list with `:allowed_hosts` (exact hostname match),
+    `:allowed_url_prefixes`, `:allowed_methods` (default `["GET", "HEAD"]`),
+    or `:dangerously_allow_full_internet_access`. When omitted,
     all network access is denied.
 
   ## Examples

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -76,6 +76,8 @@ defmodule Pyex.Ctx do
           iterators: %{optional(non_neg_integer()) => [term()] | term()},
           next_iterator_id: non_neg_integer(),
           network: network_config() | nil,
+          boto3: boolean(),
+          sql: boolean(),
           exception_instance: term(),
           current_line: non_neg_integer() | nil
         }
@@ -100,6 +102,8 @@ defmodule Pyex.Ctx do
             iterators: %{},
             next_iterator_id: 0,
             network: nil,
+            boto3: false,
+            sql: false,
             exception_instance: nil,
             current_line: nil
 
@@ -131,6 +135,10 @@ defmodule Pyex.Ctx do
     A request is allowed if its URL matches any `:allowed_hosts` entry
     **or** any `:allowed_url_prefixes` entry. When `nil` (the default),
     all network access is denied.
+  - `:boto3` -- when `true`, enables the `boto3` module to make S3
+    API calls. Default `false` (all S3 operations raise).
+  - `:sql` -- when `true`, enables the `sql` module to execute
+    database queries. Default `false` (all queries raise).
   """
   @spec new(keyword()) :: t()
   def new(opts \\ []) do
@@ -161,7 +169,9 @@ defmodule Pyex.Ctx do
       compute_ns: 0,
       compute_started_at: System.monotonic_time(:nanosecond),
       profile: profile,
-      network: network
+      network: network,
+      boto3: Keyword.get(opts, :boto3, false) == true,
+      sql: Keyword.get(opts, :sql, false) == true
     }
   end
 
@@ -466,7 +476,9 @@ defmodule Pyex.Ctx do
       timeout_ns: ctx.timeout_ns,
       compute_ns: 0,
       compute_started_at: System.monotonic_time(:nanosecond),
-      network: ctx.network
+      network: ctx.network,
+      boto3: ctx.boto3,
+      sql: ctx.sql
     }
   end
 

--- a/lib/pyex/methods.ex
+++ b/lib/pyex/methods.ex
@@ -8,6 +8,22 @@ defmodule Pyex.Methods do
 
   alias Pyex.{Builtins, Interpreter}
 
+  @string_methods ~w(
+    capitalize center count encode endswith expandtabs find format
+    index isalnum isalpha isdigit islower isnumeric isspace istitle
+    isupper join ljust lower lstrip partition replace rfind rindex
+    rjust rpartition rsplit rstrip split splitlines startswith strip
+    swapcase title upper zfill
+  )
+
+  @list_methods ~w(append clear copy count extend index insert pop remove reverse sort)
+  @dict_methods ~w(clear copy get items keys pop setdefault update values)
+  @set_methods ~w(
+    add clear copy difference discard intersection isdisjoint
+    issubset issuperset pop remove symmetric_difference union
+  )
+  @tuple_methods ~w(count index)
+
   @doc """
   Attempts to resolve `attr` on `object`. Returns
   `{:ok, value}` or `:error`.
@@ -61,6 +77,17 @@ defmodule Pyex.Methods do
   end
 
   def resolve(_object, _attr), do: :error
+
+  @doc """
+  Returns the list of method names available on a value's type.
+  """
+  @spec method_names(Interpreter.pyvalue()) :: [String.t()]
+  def method_names(val) when is_binary(val), do: @string_methods
+  def method_names(val) when is_list(val), do: @list_methods
+  def method_names(val) when is_map(val), do: @dict_methods
+  def method_names({:set, _}), do: @set_methods
+  def method_names({:tuple, _}), do: @tuple_methods
+  def method_names(_), do: []
 
   @spec bound(
           (Interpreter.pyvalue(), [Interpreter.pyvalue()] -> Interpreter.pyvalue()),

--- a/lib/pyex/stdlib.ex
+++ b/lib/pyex/stdlib.ex
@@ -27,7 +27,11 @@ defmodule Pyex.Stdlib do
     "uuid" => Pyex.Stdlib.Uuid,
     "sql" => Pyex.Stdlib.Sql,
     "pydantic" => Pyex.Stdlib.Pydantic,
-    "boto3" => Pyex.Stdlib.Boto3
+    "boto3" => Pyex.Stdlib.Boto3,
+    "hashlib" => Pyex.Stdlib.Hashlib,
+    "hmac" => Pyex.Stdlib.Hmac,
+    "base64" => Pyex.Stdlib.Base64Encode,
+    "secrets" => Pyex.Stdlib.Secrets
   }
 
   @doc """

--- a/lib/pyex/stdlib/base64_encode.ex
+++ b/lib/pyex/stdlib/base64_encode.ex
@@ -1,0 +1,106 @@
+defmodule Pyex.Stdlib.Base64Encode do
+  @moduledoc """
+  Python `base64` module for Base16, Base32, and Base64 encoding/decoding.
+
+  Provides `base64.b64encode()`, `base64.b64decode()`,
+  `base64.urlsafe_b64encode()`, `base64.urlsafe_b64decode()`,
+  `base64.b32encode()`, `base64.b32decode()`,
+  `base64.b16encode()`, `base64.b16decode()`.
+
+  In Python these operate on bytes and return bytes; since Pyex has no
+  bytes type, all functions accept and return strings.
+
+  Backed by Erlang's `:base64` module and Elixir's `Base`.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  @doc """
+  Returns the module value map with encoding/decoding functions.
+  """
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "b64encode" => {:builtin, &do_b64encode/1},
+      "b64decode" => {:builtin, &do_b64decode/1},
+      "urlsafe_b64encode" => {:builtin, &do_urlsafe_b64encode/1},
+      "urlsafe_b64decode" => {:builtin, &do_urlsafe_b64decode/1},
+      "b32encode" => {:builtin, &do_b32encode/1},
+      "b32decode" => {:builtin, &do_b32decode/1},
+      "b16encode" => {:builtin, &do_b16encode/1},
+      "b16decode" => {:builtin, &do_b16decode/1}
+    }
+  end
+
+  @spec do_b64encode([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_b64encode([data]) when is_binary(data), do: Base.encode64(data)
+  defp do_b64encode(_), do: {:exception, "TypeError: b64encode() argument must be a string"}
+
+  @spec do_b64decode([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_b64decode([data]) when is_binary(data) do
+    case Base.decode64(data, ignore: :whitespace) do
+      {:ok, decoded} -> decoded
+      :error -> {:exception, "binascii.Error: Invalid base64-encoded string"}
+    end
+  end
+
+  defp do_b64decode(_), do: {:exception, "TypeError: b64decode() argument must be a string"}
+
+  @spec do_urlsafe_b64encode([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_urlsafe_b64encode([data]) when is_binary(data), do: Base.url_encode64(data)
+
+  defp do_urlsafe_b64encode(_),
+    do: {:exception, "TypeError: urlsafe_b64encode() argument must be a string"}
+
+  @spec do_urlsafe_b64decode([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_urlsafe_b64decode([data]) when is_binary(data) do
+    padded = pad_base64(data)
+
+    case Base.url_decode64(padded) do
+      {:ok, decoded} -> decoded
+      :error -> {:exception, "binascii.Error: Invalid base64-encoded string"}
+    end
+  end
+
+  defp do_urlsafe_b64decode(_),
+    do: {:exception, "TypeError: urlsafe_b64decode() argument must be a string"}
+
+  @spec do_b32encode([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_b32encode([data]) when is_binary(data), do: Base.encode32(data)
+  defp do_b32encode(_), do: {:exception, "TypeError: b32encode() argument must be a string"}
+
+  @spec do_b32decode([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_b32decode([data]) when is_binary(data) do
+    case Base.decode32(data, case: :mixed) do
+      {:ok, decoded} -> decoded
+      :error -> {:exception, "binascii.Error: Invalid base32-encoded string"}
+    end
+  end
+
+  defp do_b32decode(_), do: {:exception, "TypeError: b32decode() argument must be a string"}
+
+  @spec do_b16encode([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_b16encode([data]) when is_binary(data), do: Base.encode16(data)
+  defp do_b16encode(_), do: {:exception, "TypeError: b16encode() argument must be a string"}
+
+  @spec do_b16decode([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_b16decode([data]) when is_binary(data) do
+    case Base.decode16(data, case: :mixed) do
+      {:ok, decoded} -> decoded
+      :error -> {:exception, "binascii.Error: Invalid base16-encoded string"}
+    end
+  end
+
+  defp do_b16decode(_), do: {:exception, "TypeError: b16decode() argument must be a string"}
+
+  @spec pad_base64(String.t()) :: String.t()
+  defp pad_base64(data) do
+    case rem(byte_size(data), 4) do
+      0 -> data
+      2 -> data <> "=="
+      3 -> data <> "="
+      _ -> data
+    end
+  end
+end

--- a/lib/pyex/stdlib/hashlib.ex
+++ b/lib/pyex/stdlib/hashlib.ex
@@ -1,0 +1,168 @@
+defmodule Pyex.Stdlib.Hashlib do
+  @moduledoc """
+  Python `hashlib` module for secure hash and message digest algorithms.
+
+  Provides constructor functions `hashlib.sha256()`, `hashlib.sha1()`,
+  `hashlib.md5()`, `hashlib.sha224()`, `hashlib.sha384()`, `hashlib.sha512()`,
+  and the generic `hashlib.new(name)` constructor.
+
+  Each returns a hash object with `.update(data)`, `.hexdigest()`, `.digest()`,
+  and `.digest_size` / `.block_size` / `.name` attributes.
+
+  Backed by Erlang's `:crypto` module.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  @algorithms %{
+    "md5" => :md5,
+    "sha1" => :sha,
+    "sha224" => :sha224,
+    "sha256" => :sha256,
+    "sha384" => :sha384,
+    "sha512" => :sha512
+  }
+
+  @digest_sizes %{
+    "md5" => 16,
+    "sha1" => 20,
+    "sha224" => 28,
+    "sha256" => 32,
+    "sha384" => 48,
+    "sha512" => 64
+  }
+
+  @block_sizes %{
+    "md5" => 64,
+    "sha1" => 64,
+    "sha224" => 64,
+    "sha256" => 64,
+    "sha384" => 128,
+    "sha512" => 128
+  }
+
+  @doc """
+  Returns the module value map with hash constructor functions.
+  """
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "md5" => {:builtin, &do_md5/1},
+      "sha1" => {:builtin, &do_sha1/1},
+      "sha224" => {:builtin, &do_sha224/1},
+      "sha256" => {:builtin, &do_sha256/1},
+      "sha384" => {:builtin, &do_sha384/1},
+      "sha512" => {:builtin, &do_sha512/1},
+      "new" => {:builtin, &do_new/1}
+    }
+  end
+
+  @spec do_md5([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_md5([]), do: make_hash_object("md5", <<>>)
+  defp do_md5([data]) when is_binary(data), do: make_hash_object("md5", data)
+  defp do_md5(_), do: {:exception, "TypeError: md5() argument must be a string"}
+
+  @spec do_sha1([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_sha1([]), do: make_hash_object("sha1", <<>>)
+  defp do_sha1([data]) when is_binary(data), do: make_hash_object("sha1", data)
+  defp do_sha1(_), do: {:exception, "TypeError: sha1() argument must be a string"}
+
+  @spec do_sha224([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_sha224([]), do: make_hash_object("sha224", <<>>)
+  defp do_sha224([data]) when is_binary(data), do: make_hash_object("sha224", data)
+  defp do_sha224(_), do: {:exception, "TypeError: sha224() argument must be a string"}
+
+  @spec do_sha256([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_sha256([]), do: make_hash_object("sha256", <<>>)
+  defp do_sha256([data]) when is_binary(data), do: make_hash_object("sha256", data)
+  defp do_sha256(_), do: {:exception, "TypeError: sha256() argument must be a string"}
+
+  @spec do_sha384([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_sha384([]), do: make_hash_object("sha384", <<>>)
+  defp do_sha384([data]) when is_binary(data), do: make_hash_object("sha384", data)
+  defp do_sha384(_), do: {:exception, "TypeError: sha384() argument must be a string"}
+
+  @spec do_sha512([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_sha512([]), do: make_hash_object("sha512", <<>>)
+  defp do_sha512([data]) when is_binary(data), do: make_hash_object("sha512", data)
+  defp do_sha512(_), do: {:exception, "TypeError: sha512() argument must be a string"}
+
+  @spec do_new([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_new([name]) when is_binary(name) do
+    algo = String.downcase(name) |> String.replace("-", "")
+
+    if Map.has_key?(@algorithms, algo) do
+      make_hash_object(algo, <<>>)
+    else
+      {:exception, "ValueError: unsupported hash type #{name}"}
+    end
+  end
+
+  defp do_new([name, data]) when is_binary(name) and is_binary(data) do
+    algo = String.downcase(name) |> String.replace("-", "")
+
+    if Map.has_key?(@algorithms, algo) do
+      make_hash_object(algo, data)
+    else
+      {:exception, "ValueError: unsupported hash type #{name}"}
+    end
+  end
+
+  defp do_new(_), do: {:exception, "TypeError: new() requires a string algorithm name"}
+
+  @spec make_hash_object(String.t(), binary()) :: Pyex.Interpreter.pyvalue()
+  defp make_hash_object(algo_name, data) do
+    erlang_algo = Map.fetch!(@algorithms, algo_name)
+    digest = :crypto.hash(erlang_algo, data)
+    hex = Base.encode16(digest, case: :lower)
+
+    digest_size = Map.fetch!(@digest_sizes, algo_name)
+    block_size = Map.fetch!(@block_sizes, algo_name)
+
+    update_fn =
+      {:builtin,
+       fn
+         [new_data] when is_binary(new_data) ->
+           make_hash_object(algo_name, data <> new_data)
+
+         _ ->
+           {:exception, "TypeError: update() argument must be a string"}
+       end}
+
+    hexdigest_fn =
+      {:builtin,
+       fn
+         [_self] -> hex
+         [] -> hex
+       end}
+
+    digest_fn =
+      {:builtin,
+       fn
+         [_self] -> digest
+         [] -> digest
+       end}
+
+    copy_fn =
+      {:builtin,
+       fn
+         [_self] -> make_hash_object(algo_name, data)
+         [] -> make_hash_object(algo_name, data)
+       end}
+
+    hash_class =
+      {:class, "_hashlib.HASH", [], %{}}
+
+    {:instance, hash_class,
+     %{
+       "name" => algo_name,
+       "digest_size" => digest_size,
+       "block_size" => block_size,
+       "update" => update_fn,
+       "hexdigest" => hexdigest_fn,
+       "digest" => digest_fn,
+       "copy" => copy_fn
+     }}
+  end
+end

--- a/lib/pyex/stdlib/hmac.ex
+++ b/lib/pyex/stdlib/hmac.ex
@@ -1,0 +1,183 @@
+defmodule Pyex.Stdlib.Hmac do
+  @moduledoc """
+  Python `hmac` module for keyed-hash message authentication codes.
+
+  Provides `hmac.new(key, msg, digestmod)` which returns an HMAC object
+  with `.hexdigest()`, `.digest()`, `.update()`, `.copy()` methods.
+  Also provides `hmac.digest(key, msg, digest)` for one-shot HMAC
+  computation and `hmac.compare_digest(a, b)` for constant-time comparison.
+
+  Backed by Erlang's `:crypto.mac/4`.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  @algorithms %{
+    "md5" => :md5,
+    "sha1" => :sha,
+    "sha224" => :sha224,
+    "sha256" => :sha256,
+    "sha384" => :sha384,
+    "sha512" => :sha512
+  }
+
+  @digest_sizes %{
+    "md5" => 16,
+    "sha1" => 20,
+    "sha224" => 28,
+    "sha256" => 32,
+    "sha384" => 48,
+    "sha512" => 64
+  }
+
+  @block_sizes %{
+    "md5" => 64,
+    "sha1" => 64,
+    "sha224" => 64,
+    "sha256" => 64,
+    "sha384" => 128,
+    "sha512" => 128
+  }
+
+  @doc """
+  Returns the module value map with HMAC functions.
+  """
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "new" => {:builtin, &do_new/1},
+      "digest" => {:builtin, &do_digest/1},
+      "compare_digest" => {:builtin, &do_compare_digest/1}
+    }
+  end
+
+  @spec do_new([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_new([key, msg, digestmod]) when is_binary(key) and is_binary(msg) do
+    case resolve_digestmod(digestmod) do
+      {:ok, algo_name} -> make_hmac_object(algo_name, key, msg)
+      {:error, reason} -> {:exception, reason}
+    end
+  end
+
+  defp do_new([key, msg]) when is_binary(key) and is_binary(msg) do
+    {:exception, "TypeError: hmac.new() missing required argument: 'digestmod'"}
+  end
+
+  defp do_new([key]) when is_binary(key) do
+    {:exception, "TypeError: hmac.new() missing required argument: 'digestmod'"}
+  end
+
+  defp do_new(_), do: {:exception, "TypeError: hmac.new() arguments must be strings"}
+
+  @spec do_digest([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_digest([key, msg, digestmod]) when is_binary(key) and is_binary(msg) do
+    case resolve_digestmod(digestmod) do
+      {:ok, algo_name} ->
+        erlang_algo = Map.fetch!(@algorithms, algo_name)
+        :crypto.mac(:hmac, erlang_algo, key, msg) |> Base.encode16(case: :lower)
+
+      {:error, reason} ->
+        {:exception, reason}
+    end
+  end
+
+  defp do_digest(_),
+    do: {:exception, "TypeError: hmac.digest() requires key, msg, and digest arguments"}
+
+  @spec do_compare_digest([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_compare_digest([a, b]) when is_binary(a) and is_binary(b) do
+    byte_size(a) == byte_size(b) and :crypto.hash_equals(a, b)
+  end
+
+  defp do_compare_digest(_) do
+    {:exception, "TypeError: compare_digest() arguments must be strings"}
+  end
+
+  @spec resolve_digestmod(Pyex.Interpreter.pyvalue()) :: {:ok, String.t()} | {:error, String.t()}
+  defp resolve_digestmod(digestmod) when is_binary(digestmod) do
+    algo = String.downcase(digestmod) |> String.replace("-", "")
+
+    if Map.has_key?(@algorithms, algo) do
+      {:ok, algo}
+    else
+      {:error, "ValueError: unsupported hash type #{digestmod}"}
+    end
+  end
+
+  defp resolve_digestmod({:builtin, _} = builtin_fn) do
+    case builtin_fn do
+      {:builtin, fun} when is_function(fun) ->
+        result = fun.([])
+
+        case result do
+          {:instance, _, %{"name" => name}} when is_binary(name) ->
+            if Map.has_key?(@algorithms, name),
+              do: {:ok, name},
+              else: {:error, "ValueError: unsupported hash type"}
+
+          _ ->
+            {:error, "TypeError: digestmod must be a string name or hashlib constructor"}
+        end
+    end
+  end
+
+  defp resolve_digestmod(_) do
+    {:error, "TypeError: digestmod must be a string name or hashlib constructor"}
+  end
+
+  @spec make_hmac_object(String.t(), binary(), binary()) :: Pyex.Interpreter.pyvalue()
+  defp make_hmac_object(algo_name, key, msg) do
+    erlang_algo = Map.fetch!(@algorithms, algo_name)
+    mac = :crypto.mac(:hmac, erlang_algo, key, msg)
+    hex = Base.encode16(mac, case: :lower)
+
+    digest_size = Map.fetch!(@digest_sizes, algo_name)
+    block_size = Map.fetch!(@block_sizes, algo_name)
+
+    update_fn =
+      {:builtin,
+       fn
+         [new_data] when is_binary(new_data) ->
+           make_hmac_object(algo_name, key, msg <> new_data)
+
+         _ ->
+           {:exception, "TypeError: update() argument must be a string"}
+       end}
+
+    hexdigest_fn =
+      {:builtin,
+       fn
+         [_self] -> hex
+         [] -> hex
+       end}
+
+    digest_fn =
+      {:builtin,
+       fn
+         [_self] -> mac
+         [] -> mac
+       end}
+
+    copy_fn =
+      {:builtin,
+       fn
+         [_self] -> make_hmac_object(algo_name, key, msg)
+         [] -> make_hmac_object(algo_name, key, msg)
+       end}
+
+    hmac_class =
+      {:class, "_hmac.HMAC", [], %{}}
+
+    {:instance, hmac_class,
+     %{
+       "name" => algo_name,
+       "digest_size" => digest_size,
+       "block_size" => block_size,
+       "update" => update_fn,
+       "hexdigest" => hexdigest_fn,
+       "digest" => digest_fn,
+       "copy" => copy_fn
+     }}
+  end
+end

--- a/lib/pyex/stdlib/requests.ex
+++ b/lib/pyex/stdlib/requests.ex
@@ -86,7 +86,7 @@ defmodule Pyex.Stdlib.Requests do
     method_str = method |> Atom.to_string() |> String.upcase()
 
     req_opts =
-      [headers: headers, method: method, url: url] ++ body_opts(kwargs)
+      [headers: headers, method: method, url: url, redirect: false] ++ body_opts(kwargs)
 
     {:io_call,
      fn env, ctx ->

--- a/lib/pyex/stdlib/secrets.ex
+++ b/lib/pyex/stdlib/secrets.ex
@@ -1,0 +1,123 @@
+defmodule Pyex.Stdlib.Secrets do
+  @moduledoc """
+  Python `secrets` module for generating cryptographically strong random
+  numbers suitable for managing secrets such as account authentication,
+  tokens, and similar.
+
+  Provides `secrets.token_hex(nbytes)`, `secrets.token_urlsafe(nbytes)`,
+  `secrets.token_bytes(nbytes)`, `secrets.randbelow(n)`,
+  and `secrets.compare_digest(a, b)`.
+
+  Backed by Erlang's `:crypto.strong_rand_bytes/1`.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  @default_nbytes 32
+
+  @doc """
+  Returns the module value map with secrets functions.
+  """
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "token_hex" => {:builtin, &do_token_hex/1},
+      "token_urlsafe" => {:builtin, &do_token_urlsafe/1},
+      "token_bytes" => {:builtin, &do_token_bytes/1},
+      "randbelow" => {:builtin, &do_randbelow/1},
+      "compare_digest" => {:builtin, &do_compare_digest/1},
+      "choice" => {:builtin, &do_choice/1}
+    }
+  end
+
+  @spec do_token_hex([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_token_hex([]) do
+    :crypto.strong_rand_bytes(@default_nbytes) |> Base.encode16(case: :lower)
+  end
+
+  defp do_token_hex([nbytes]) when is_integer(nbytes) and nbytes >= 0 do
+    :crypto.strong_rand_bytes(nbytes) |> Base.encode16(case: :lower)
+  end
+
+  defp do_token_hex([nil]) do
+    do_token_hex([])
+  end
+
+  defp do_token_hex(_) do
+    {:exception, "TypeError: token_hex() argument must be a non-negative integer"}
+  end
+
+  @spec do_token_urlsafe([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_token_urlsafe([]) do
+    :crypto.strong_rand_bytes(@default_nbytes) |> Base.url_encode64(padding: false)
+  end
+
+  defp do_token_urlsafe([nbytes]) when is_integer(nbytes) and nbytes >= 0 do
+    :crypto.strong_rand_bytes(nbytes) |> Base.url_encode64(padding: false)
+  end
+
+  defp do_token_urlsafe([nil]) do
+    do_token_urlsafe([])
+  end
+
+  defp do_token_urlsafe(_) do
+    {:exception, "TypeError: token_urlsafe() argument must be a non-negative integer"}
+  end
+
+  @spec do_token_bytes([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_token_bytes([]) do
+    :crypto.strong_rand_bytes(@default_nbytes)
+  end
+
+  defp do_token_bytes([nbytes]) when is_integer(nbytes) and nbytes >= 0 do
+    :crypto.strong_rand_bytes(nbytes)
+  end
+
+  defp do_token_bytes([nil]) do
+    do_token_bytes([])
+  end
+
+  defp do_token_bytes(_) do
+    {:exception, "TypeError: token_bytes() argument must be a non-negative integer"}
+  end
+
+  @spec do_randbelow([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_randbelow([n]) when is_integer(n) and n > 0 do
+    :rand.uniform(n) - 1
+  end
+
+  defp do_randbelow([n]) when is_integer(n) do
+    {:exception, "ValueError: Upper bound must be positive"}
+  end
+
+  defp do_randbelow(_) do
+    {:exception, "TypeError: randbelow() argument must be a positive integer"}
+  end
+
+  @spec do_compare_digest([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_compare_digest([a, b]) when is_binary(a) and is_binary(b) do
+    byte_size(a) == byte_size(b) and :crypto.hash_equals(a, b)
+  end
+
+  defp do_compare_digest(_) do
+    {:exception, "TypeError: compare_digest() arguments must be strings"}
+  end
+
+  @spec do_choice([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_choice([sequence]) when is_list(sequence) and length(sequence) > 0 do
+    Enum.random(sequence)
+  end
+
+  defp do_choice([sequence]) when is_binary(sequence) and byte_size(sequence) > 0 do
+    String.graphemes(sequence) |> Enum.random()
+  end
+
+  defp do_choice([_]) do
+    {:exception, "IndexError: Cannot choose from an empty sequence"}
+  end
+
+  defp do_choice(_) do
+    {:exception, "TypeError: choice() argument must be a non-empty sequence"}
+  end
+end

--- a/lib/pyex/stdlib/sql.ex
+++ b/lib/pyex/stdlib/sql.ex
@@ -28,32 +28,19 @@ defmodule Pyex.Stdlib.Sql do
     }
   end
 
-  @denied_msg "PermissionError: sql is disabled. Configure the :sql option to enable database access"
-
-  @spec check_sql(Pyex.Ctx.t()) :: :ok | {:denied, String.t()}
-  defp check_sql(%{sql: true}), do: :ok
-  defp check_sql(_ctx), do: {:denied, @denied_msg}
-
   @spec do_query([Pyex.Interpreter.pyvalue()]) ::
           {:io_call, (Pyex.Env.t(), Pyex.Ctx.t() -> {term(), Pyex.Env.t(), Pyex.Ctx.t()})}
           | {:exception, String.t()}
   defp do_query([sql, params]) when is_binary(sql) and is_list(params) do
-    {:io_call,
-     fn env, ctx ->
-       case check_sql(ctx) do
-         {:denied, reason} ->
-           {{:exception, reason}, env, ctx}
+    Pyex.Ctx.guarded_io_call(:sql, fn env, ctx ->
+      case Map.fetch(ctx.environ, "DATABASE_URL") do
+        {:ok, url} when is_binary(url) ->
+          run_query(sql, params, url, env, ctx)
 
-         :ok ->
-           case Map.fetch(ctx.environ, "DATABASE_URL") do
-             {:ok, url} when is_binary(url) ->
-               run_query(sql, params, url, env, ctx)
-
-             _ ->
-               {{:exception, "sql.query: DATABASE_URL not set in environ"}, env, ctx}
-           end
-       end
-     end}
+        _ ->
+          {{:exception, "sql.query: DATABASE_URL not set in environ"}, env, ctx}
+      end
+    end)
   end
 
   defp do_query([sql]) when is_binary(sql) do

--- a/test/pyex/capabilities_test.exs
+++ b/test/pyex/capabilities_test.exs
@@ -1,0 +1,119 @@
+defmodule Pyex.CapabilitiesTest do
+  use ExUnit.Case, async: true
+
+  describe "boto3 capability" do
+    test "denied by default" do
+      {:error, error} =
+        Pyex.run("""
+        import boto3
+        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3.put_object(Bucket='bucket', Key='key.txt', Body='data')
+        """)
+
+      assert error.message =~ "PermissionError"
+      assert error.message =~ "boto3 is disabled"
+    end
+
+    test "all S3 operations denied" do
+      for op <- [
+            "put_object(Bucket='b', Key='k', Body='d')",
+            "get_object(Bucket='b', Key='k')",
+            "delete_object(Bucket='b', Key='k')",
+            "list_objects_v2(Bucket='b')"
+          ] do
+        {:error, error} =
+          Pyex.run("""
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+          s3.#{op}
+          """)
+
+        assert error.message =~ "PermissionError",
+               "expected PermissionError for #{op}, got: #{error.message}"
+      end
+    end
+
+    test "import succeeds when disabled" do
+      result =
+        Pyex.run!("""
+        import boto3
+        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        'put_object' in s3
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "sql capability" do
+    test "denied by default" do
+      ctx = Pyex.Ctx.new(environ: %{"DATABASE_URL" => "postgres://localhost/fake"})
+
+      {:error, error} =
+        Pyex.run(
+          """
+          import sql
+          sql.query("SELECT 1")
+          """,
+          ctx
+        )
+
+      assert error.message =~ "PermissionError"
+      assert error.message =~ "sql is disabled"
+    end
+
+    test "import succeeds when disabled" do
+      result =
+        Pyex.run!("""
+        import sql
+        m = sql
+        "query" in m
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "network capability" do
+    test "denied by default" do
+      {:error, error} =
+        Pyex.run("""
+        import requests
+        requests.get("http://localhost:9999/data")
+        """)
+
+      assert error.message =~ "NetworkError"
+      assert error.message =~ "network access is disabled"
+    end
+
+    test "import succeeds when disabled" do
+      result =
+        Pyex.run!("""
+        import requests
+        m = requests
+        "get" in m
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "capabilities option" do
+    test "accepts list of atoms" do
+      ctx = Pyex.Ctx.new(capabilities: [:boto3, :sql])
+      assert MapSet.member?(ctx.capabilities, :boto3)
+      assert MapSet.member?(ctx.capabilities, :sql)
+    end
+
+    test "shorthand options merge with capabilities list" do
+      ctx = Pyex.Ctx.new(capabilities: [:boto3], sql: true)
+      assert MapSet.member?(ctx.capabilities, :boto3)
+      assert MapSet.member?(ctx.capabilities, :sql)
+    end
+
+    test "empty by default" do
+      ctx = Pyex.Ctx.new()
+      assert ctx.capabilities == MapSet.new()
+    end
+  end
+end

--- a/test/pyex/stdlib/base64_test.exs
+++ b/test/pyex/stdlib/base64_test.exs
@@ -1,0 +1,191 @@
+defmodule Pyex.Stdlib.Base64Test do
+  use ExUnit.Case, async: true
+
+  describe "base64.b64encode" do
+    test "encodes string" do
+      assert Pyex.run!("import base64\nbase64.b64encode('hello')") == "aGVsbG8="
+    end
+
+    test "encodes empty string" do
+      assert Pyex.run!("import base64\nbase64.b64encode('')") == ""
+    end
+
+    test "encodes binary data with special chars" do
+      result =
+        Pyex.run!("""
+        import base64
+        base64.b64encode("Hello, World!")
+        """)
+
+      assert result == "SGVsbG8sIFdvcmxkIQ=="
+    end
+
+    test "non-string raises TypeError" do
+      assert_raise RuntimeError, ~r/TypeError/, fn ->
+        Pyex.run!("import base64\nbase64.b64encode(42)")
+      end
+    end
+  end
+
+  describe "base64.b64decode" do
+    test "decodes valid base64" do
+      assert Pyex.run!("import base64\nbase64.b64decode('aGVsbG8=')") == "hello"
+    end
+
+    test "decodes empty string" do
+      assert Pyex.run!("import base64\nbase64.b64decode('')") == ""
+    end
+
+    test "roundtrip" do
+      result =
+        Pyex.run!("""
+        import base64
+        base64.b64decode(base64.b64encode("test data 123"))
+        """)
+
+      assert result == "test data 123"
+    end
+
+    test "invalid base64 raises error" do
+      assert_raise RuntimeError, ~r/binascii.Error/, fn ->
+        Pyex.run!("import base64\nbase64.b64decode('!!!invalid!!!')")
+      end
+    end
+  end
+
+  describe "base64.urlsafe_b64encode" do
+    test "encodes with URL-safe alphabet" do
+      result =
+        Pyex.run!("""
+        import base64
+        base64.urlsafe_b64encode("subjects?_d")
+        """)
+
+      decoded = Base.url_decode64!(result)
+      assert decoded == "subjects?_d"
+    end
+
+    test "uses - and _ instead of + and /" do
+      result =
+        Pyex.run!("""
+        import base64
+        encoded = base64.urlsafe_b64encode("subjects?_d")
+        "+" not in encoded and "/" not in encoded
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "base64.urlsafe_b64decode" do
+    test "decodes URL-safe base64" do
+      encoded = Base.url_encode64("hello world")
+
+      result =
+        Pyex.run!("""
+        import base64
+        base64.urlsafe_b64decode("#{encoded}")
+        """)
+
+      assert result == "hello world"
+    end
+
+    test "handles missing padding" do
+      encoded = Base.url_encode64("test", padding: false)
+
+      result =
+        Pyex.run!("""
+        import base64
+        base64.urlsafe_b64decode("#{encoded}")
+        """)
+
+      assert result == "test"
+    end
+
+    test "roundtrip" do
+      result =
+        Pyex.run!("""
+        import base64
+        base64.urlsafe_b64decode(base64.urlsafe_b64encode("OAuth token data!"))
+        """)
+
+      assert result == "OAuth token data!"
+    end
+  end
+
+  describe "base64.b16encode / b16decode" do
+    test "hex encode" do
+      assert Pyex.run!("import base64\nbase64.b16encode('hello')") == "68656C6C6F"
+    end
+
+    test "hex decode" do
+      assert Pyex.run!("import base64\nbase64.b16decode('68656C6C6F')") == "hello"
+    end
+
+    test "case-insensitive decode" do
+      assert Pyex.run!("import base64\nbase64.b16decode('68656c6c6f')") == "hello"
+    end
+
+    test "roundtrip" do
+      result =
+        Pyex.run!("""
+        import base64
+        base64.b16decode(base64.b16encode("test"))
+        """)
+
+      assert result == "test"
+    end
+  end
+
+  describe "base64.b32encode / b32decode" do
+    test "encode" do
+      assert Pyex.run!("import base64\nbase64.b32encode('hello')") == "NBSWY3DP"
+    end
+
+    test "decode" do
+      assert Pyex.run!("import base64\nbase64.b32decode('NBSWY3DP')") == "hello"
+    end
+
+    test "roundtrip" do
+      result =
+        Pyex.run!("""
+        import base64
+        base64.b32decode(base64.b32encode("test data"))
+        """)
+
+      assert result == "test data"
+    end
+  end
+
+  describe "from_import" do
+    test "from base64 import b64encode" do
+      assert Pyex.run!("from base64 import b64encode\nb64encode('hi')") == "aGk="
+    end
+
+    test "from base64 import urlsafe_b64encode" do
+      result =
+        Pyex.run!("""
+        from base64 import urlsafe_b64encode, urlsafe_b64decode
+        urlsafe_b64decode(urlsafe_b64encode("test"))
+        """)
+
+      assert result == "test"
+    end
+  end
+
+  describe "OAuth Basic auth pattern" do
+    test "encode client credentials" do
+      result =
+        Pyex.run!("""
+        import base64
+        client_id = "my_client_id"
+        client_secret = "my_client_secret"
+        credentials = client_id + ":" + client_secret
+        encoded = base64.b64encode(credentials)
+        "Basic " + encoded
+        """)
+
+      assert result == "Basic bXlfY2xpZW50X2lkOm15X2NsaWVudF9zZWNyZXQ="
+    end
+  end
+end

--- a/test/pyex/stdlib/boto3_test.exs
+++ b/test/pyex/stdlib/boto3_test.exs
@@ -528,50 +528,6 @@ defmodule Pyex.Stdlib.Boto3Test do
     end
   end
 
-  describe "access control" do
-    test "denied by default when boto3 not enabled" do
-      {:error, error} =
-        Pyex.run("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
-        s3.put_object(Bucket='bucket', Key='key.txt', Body='data')
-        """)
-
-      assert error.message =~ "PermissionError"
-      assert error.message =~ "boto3 is disabled"
-    end
-
-    test "all S3 operations denied when boto3 not enabled" do
-      for op <- [
-            "put_object(Bucket='b', Key='k', Body='d')",
-            "get_object(Bucket='b', Key='k')",
-            "delete_object(Bucket='b', Key='k')",
-            "list_objects_v2(Bucket='b')"
-          ] do
-        {:error, error} =
-          Pyex.run("""
-          import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
-          s3.#{op}
-          """)
-
-        assert error.message =~ "PermissionError",
-               "expected PermissionError for #{op}, got: #{error.message}"
-      end
-    end
-
-    test "import succeeds even when boto3 is disabled" do
-      result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
-        'put_object' in s3
-        """)
-
-      assert result == true
-    end
-  end
-
   describe "integration with pydantic" do
     test "put and get with pydantic model validation", %{bypass: bypass, port: port} do
       store = Agent.start_link(fn -> %{} end) |> elem(1)

--- a/test/pyex/stdlib/boto3_test.exs
+++ b/test/pyex/stdlib/boto3_test.exs
@@ -9,12 +9,15 @@ defmodule Pyex.Stdlib.Boto3Test do
   describe "boto3.client" do
     test "creates an s3 client with expected methods", %{port: port} do
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        methods = ['put_object' in s3, 'get_object' in s3, 'delete_object' in s3, 'list_objects_v2' in s3]
-        methods
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          methods = ['put_object' in s3, 'get_object' in s3, 'delete_object' in s3, 'list_objects_v2' in s3]
+          methods
+          """,
+          boto3: true
+        )
 
       assert result == [true, true, true, true]
     end
@@ -49,12 +52,15 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        resp = s3.put_object(Bucket='my-bucket', Key='hello.txt', Body='world')
-        resp['ResponseMetadata']['HTTPStatusCode']
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          resp = s3.put_object(Bucket='my-bucket', Key='hello.txt', Body='world')
+          resp['ResponseMetadata']['HTTPStatusCode']
+          """,
+          boto3: true
+        )
 
       assert result == 200
     end
@@ -67,12 +73,15 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        resp = s3.put_object(Bucket='bucket', Key='data.json', Body='{}', ContentType='application/json')
-        resp['ResponseMetadata']['HTTPStatusCode']
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          resp = s3.put_object(Bucket='bucket', Key='data.json', Body='{}', ContentType='application/json')
+          resp['ResponseMetadata']['HTTPStatusCode']
+          """,
+          boto3: true
+        )
 
       assert result == 200
     end
@@ -105,11 +114,14 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       {:error, error} =
-        Pyex.run("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        s3.put_object(Bucket='bucket', Key='key.txt', Body='data')
-        """)
+        Pyex.run(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3.put_object(Bucket='bucket', Key='key.txt', Body='data')
+          """,
+          boto3: true
+        )
 
       assert error.message =~ "S3 PutObject failed (500)"
     end
@@ -124,12 +136,15 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        obj = s3.get_object(Bucket='my-bucket', Key='hello.txt')
-        obj['Body'].read()
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          obj = s3.get_object(Bucket='my-bucket', Key='hello.txt')
+          obj['Body'].read()
+          """,
+          boto3: true
+        )
 
       assert result == "world"
     end
@@ -142,12 +157,15 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        obj = s3.get_object(Bucket='bucket', Key='data.json')
-        [obj['ContentLength'], obj['ResponseMetadata']['HTTPStatusCode']]
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          obj = s3.get_object(Bucket='bucket', Key='data.json')
+          [obj['ContentLength'], obj['ResponseMetadata']['HTTPStatusCode']]
+          """,
+          boto3: true
+        )
 
       [content_length, status] = result
       assert content_length > 0
@@ -160,11 +178,14 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       {:error, error} =
-        Pyex.run("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        s3.get_object(Bucket='bucket', Key='missing.txt')
-        """)
+        Pyex.run(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3.get_object(Bucket='bucket', Key='missing.txt')
+          """,
+          boto3: true
+        )
 
       assert error.message =~ "NoSuchKey"
     end
@@ -188,14 +209,17 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        import json
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        obj = s3.get_object(Bucket='bucket', Key='data.json')
-        data = json.loads(obj['Body'].read())
-        [data['name'], data['age']]
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          import json
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          obj = s3.get_object(Bucket='bucket', Key='data.json')
+          data = json.loads(obj['Body'].read())
+          [data['name'], data['age']]
+          """,
+          boto3: true
+        )
 
       assert result == ["Alice", 30]
     end
@@ -208,12 +232,15 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        resp = s3.delete_object(Bucket='bucket', Key='old.txt')
-        resp['ResponseMetadata']['HTTPStatusCode']
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          resp = s3.delete_object(Bucket='bucket', Key='old.txt')
+          resp['ResponseMetadata']['HTTPStatusCode']
+          """,
+          boto3: true
+        )
 
       assert result == 204
     end
@@ -235,11 +262,14 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       {:error, error} =
-        Pyex.run("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        s3.delete_object(Bucket='bucket', Key='key.txt')
-        """)
+        Pyex.run(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3.delete_object(Bucket='bucket', Key='key.txt')
+          """,
+          boto3: true
+        )
 
       assert error.message =~ "S3 DeleteObject failed (403)"
     end
@@ -265,13 +295,16 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        resp = s3.list_objects_v2(Bucket='bucket')
-        keys = [item['Key'] for item in resp['Contents']]
-        [keys, resp['KeyCount']]
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          resp = s3.list_objects_v2(Bucket='bucket')
+          keys = [item['Key'] for item in resp['Contents']]
+          [keys, resp['KeyCount']]
+          """,
+          boto3: true
+        )
 
       [keys, count] = result
       assert keys == ["file1.txt", "file2.txt", "subdir/file3.txt"]
@@ -295,12 +328,15 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        resp = s3.list_objects_v2(Bucket='bucket', Prefix='data/')
-        [item['Key'] for item in resp['Contents']]
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          resp = s3.list_objects_v2(Bucket='bucket', Prefix='data/')
+          [item['Key'] for item in resp['Contents']]
+          """,
+          boto3: true
+        )
 
       assert result == ["data/a.csv", "data/b.csv"]
     end
@@ -316,12 +352,15 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        resp = s3.list_objects_v2(Bucket='empty-bucket')
-        [resp['Contents'], resp['KeyCount']]
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          resp = s3.list_objects_v2(Bucket='empty-bucket')
+          [resp['Contents'], resp['KeyCount']]
+          """,
+          boto3: true
+        )
 
       assert result == [[], 0]
     end
@@ -365,13 +404,16 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        s3.put_object(Bucket='store', Key='docs/readme.md', Body='# Hello World')
-        obj = s3.get_object(Bucket='store', Key='docs/readme.md')
-        obj['Body'].read()
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3.put_object(Bucket='store', Key='docs/readme.md', Body='# Hello World')
+          obj = s3.get_object(Bucket='store', Key='docs/readme.md')
+          obj['Body'].read()
+          """,
+          boto3: true
+        )
 
       assert result == "# Hello World"
 
@@ -404,16 +446,19 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        import json
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        user = {"name": "Alice", "age": 30, "active": True}
-        s3.put_object(Bucket='data', Key='records/user.json', Body=json.dumps(user))
-        obj = s3.get_object(Bucket='data', Key='records/user.json')
-        parsed = json.loads(obj['Body'].read())
-        [parsed['name'], parsed['age'], parsed['active']]
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          import json
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          user = {"name": "Alice", "age": 30, "active": True}
+          s3.put_object(Bucket='data', Key='records/user.json', Body=json.dumps(user))
+          obj = s3.get_object(Bucket='data', Key='records/user.json')
+          parsed = json.loads(obj['Body'].read())
+          [parsed['name'], parsed['age'], parsed['active']]
+          """,
+          boto3: true
+        )
 
       assert result == ["Alice", 30, true]
 
@@ -464,19 +509,66 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        s3.put_object(Bucket='bucket', Key='a.txt', Body='aaa')
-        s3.put_object(Bucket='bucket', Key='b.txt', Body='bbb')
-        s3.put_object(Bucket='bucket', Key='c.txt', Body='ccc')
-        resp = s3.list_objects_v2(Bucket='bucket')
-        resp['KeyCount']
-        """)
+        Pyex.run!(
+          """
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3.put_object(Bucket='bucket', Key='a.txt', Body='aaa')
+          s3.put_object(Bucket='bucket', Key='b.txt', Body='bbb')
+          s3.put_object(Bucket='bucket', Key='c.txt', Body='ccc')
+          resp = s3.list_objects_v2(Bucket='bucket')
+          resp['KeyCount']
+          """,
+          boto3: true
+        )
 
       assert result == 3
 
       Agent.stop(store)
+    end
+  end
+
+  describe "access control" do
+    test "denied by default when boto3 not enabled" do
+      {:error, error} =
+        Pyex.run("""
+        import boto3
+        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3.put_object(Bucket='bucket', Key='key.txt', Body='data')
+        """)
+
+      assert error.message =~ "PermissionError"
+      assert error.message =~ "boto3 is disabled"
+    end
+
+    test "all S3 operations denied when boto3 not enabled" do
+      for op <- [
+            "put_object(Bucket='b', Key='k', Body='d')",
+            "get_object(Bucket='b', Key='k')",
+            "delete_object(Bucket='b', Key='k')",
+            "list_objects_v2(Bucket='b')"
+          ] do
+        {:error, error} =
+          Pyex.run("""
+          import boto3
+          s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+          s3.#{op}
+          """)
+
+        assert error.message =~ "PermissionError",
+               "expected PermissionError for #{op}, got: #{error.message}"
+      end
+    end
+
+    test "import succeeds even when boto3 is disabled" do
+      result =
+        Pyex.run!("""
+        import boto3
+        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        'put_object' in s3
+        """)
+
+      assert result == true
     end
   end
 
@@ -507,24 +599,27 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       result =
-        Pyex.run!("""
-        import boto3
-        import json
-        from pydantic import BaseModel
+        Pyex.run!(
+          """
+          import boto3
+          import json
+          from pydantic import BaseModel
 
-        class User(BaseModel):
-            name: str
-            age: int
-            active: bool
+          class User(BaseModel):
+              name: str
+              age: int
+              active: bool
 
-        s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
-        user = User(name='Alice', age=30, active=True)
-        s3.put_object(Bucket='models', Key='users/1.json', Body=json.dumps(user.model_dump()))
-        obj = s3.get_object(Bucket='models', Key='users/1.json')
-        data = json.loads(obj['Body'].read())
-        loaded = User(**data)
-        [loaded.name, loaded.age, loaded.active]
-        """)
+          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          user = User(name='Alice', age=30, active=True)
+          s3.put_object(Bucket='models', Key='users/1.json', Body=json.dumps(user.model_dump()))
+          obj = s3.get_object(Bucket='models', Key='users/1.json')
+          data = json.loads(obj['Body'].read())
+          loaded = User(**data)
+          [loaded.name, loaded.age, loaded.active]
+          """,
+          boto3: true
+        )
 
       assert result == ["Alice", 30, true]
 

--- a/test/pyex/stdlib/hashlib_test.exs
+++ b/test/pyex/stdlib/hashlib_test.exs
@@ -1,0 +1,237 @@
+defmodule Pyex.Stdlib.HashlibTest do
+  use ExUnit.Case, async: true
+
+  describe "hashlib.sha256" do
+    test "empty string digest" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.sha256("").hexdigest()
+        """)
+
+      assert result == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    end
+
+    test "known input digest" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.sha256("hello").hexdigest()
+        """)
+
+      assert result == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    end
+
+    test "constructor with initial data" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        h = hashlib.sha256("hello world")
+        h.hexdigest()
+        """)
+
+      assert result == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    end
+
+    test "digest_size attribute" do
+      assert Pyex.run!("import hashlib\nhashlib.sha256().digest_size") == 32
+    end
+
+    test "block_size attribute" do
+      assert Pyex.run!("import hashlib\nhashlib.sha256().block_size") == 64
+    end
+
+    test "name attribute" do
+      assert Pyex.run!("import hashlib\nhashlib.sha256().name") == "sha256"
+    end
+
+    test "update method accumulates data" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        h = hashlib.sha256()
+        h = h.update("hello")
+        h = h.update(" world")
+        h.hexdigest()
+        """)
+
+      expected =
+        Pyex.run!("""
+        import hashlib
+        hashlib.sha256("hello world").hexdigest()
+        """)
+
+      assert result == expected
+    end
+  end
+
+  describe "hashlib.sha1" do
+    test "known input" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.sha1("hello").hexdigest()
+        """)
+
+      assert result == "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
+    end
+
+    test "digest_size" do
+      assert Pyex.run!("import hashlib\nhashlib.sha1().digest_size") == 20
+    end
+  end
+
+  describe "hashlib.md5" do
+    test "known input" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.md5("hello").hexdigest()
+        """)
+
+      assert result == "5d41402abc4b2a76b9719d911017c592"
+    end
+
+    test "digest_size" do
+      assert Pyex.run!("import hashlib\nhashlib.md5().digest_size") == 16
+    end
+  end
+
+  describe "hashlib.sha384" do
+    test "empty string digest" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.sha384("").hexdigest()
+        """)
+
+      assert result ==
+               "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+    end
+
+    test "digest_size" do
+      assert Pyex.run!("import hashlib\nhashlib.sha384().digest_size") == 48
+    end
+
+    test "block_size" do
+      assert Pyex.run!("import hashlib\nhashlib.sha384().block_size") == 128
+    end
+  end
+
+  describe "hashlib.sha512" do
+    test "empty string digest" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.sha512("").hexdigest()
+        """)
+
+      assert result ==
+               "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+    end
+
+    test "digest_size" do
+      assert Pyex.run!("import hashlib\nhashlib.sha512().digest_size") == 64
+    end
+
+    test "block_size" do
+      assert Pyex.run!("import hashlib\nhashlib.sha512().block_size") == 128
+    end
+  end
+
+  describe "hashlib.sha224" do
+    test "empty string digest" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.sha224("").hexdigest()
+        """)
+
+      assert result == "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f"
+    end
+
+    test "digest_size" do
+      assert Pyex.run!("import hashlib\nhashlib.sha224().digest_size") == 28
+    end
+  end
+
+  describe "hashlib.new" do
+    test "generic constructor with sha256" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.new("sha256", "hello").hexdigest()
+        """)
+
+      assert result == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    end
+
+    test "generic constructor without data" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        hashlib.new("md5").hexdigest()
+        """)
+
+      assert result == "d41d8cd98f00b204e9800998ecf8427e"
+    end
+
+    test "unsupported algorithm raises ValueError" do
+      assert_raise RuntimeError, ~r/ValueError.*unsupported hash type/, fn ->
+        Pyex.run!("import hashlib\nhashlib.new('foo')")
+      end
+    end
+  end
+
+  describe "from_import" do
+    test "from hashlib import sha256" do
+      result =
+        Pyex.run!("""
+        from hashlib import sha256
+        sha256("test").hexdigest()
+        """)
+
+      assert result == "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    end
+  end
+
+  describe "copy method" do
+    test "copy produces independent hash object" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        h1 = hashlib.sha256("hello")
+        h2 = h1.copy()
+        h2 = h2.update(" world")
+        [h1.hexdigest(), h2.hexdigest()]
+        """)
+
+      assert result == [
+               "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+               "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+             ]
+    end
+  end
+
+  describe "PKCE code challenge" do
+    test "sha256 + hex for PKCE-like flow" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        challenge = hashlib.sha256(verifier).hexdigest()
+        len(challenge)
+        """)
+
+      assert result == 64
+    end
+  end
+
+  describe "error handling" do
+    test "non-string argument raises TypeError" do
+      assert_raise RuntimeError, ~r/TypeError/, fn ->
+        Pyex.run!("import hashlib\nhashlib.sha256(42)")
+      end
+    end
+  end
+end

--- a/test/pyex/stdlib/hmac_test.exs
+++ b/test/pyex/stdlib/hmac_test.exs
@@ -1,0 +1,193 @@
+defmodule Pyex.Stdlib.HmacTest do
+  use ExUnit.Case, async: true
+
+  describe "hmac.new" do
+    test "HMAC-SHA256 with known values" do
+      result =
+        Pyex.run!("""
+        import hmac
+        h = hmac.new("secret", "hello", "sha256")
+        h.hexdigest()
+        """)
+
+      expected =
+        :crypto.mac(:hmac, :sha256, "secret", "hello") |> Base.encode16(case: :lower)
+
+      assert result == expected
+    end
+
+    test "HMAC-SHA1" do
+      result =
+        Pyex.run!("""
+        import hmac
+        h = hmac.new("key", "message", "sha1")
+        h.hexdigest()
+        """)
+
+      expected =
+        :crypto.mac(:hmac, :sha, "key", "message") |> Base.encode16(case: :lower)
+
+      assert result == expected
+    end
+
+    test "HMAC-MD5" do
+      result =
+        Pyex.run!("""
+        import hmac
+        h = hmac.new("key", "msg", "md5")
+        h.hexdigest()
+        """)
+
+      expected =
+        :crypto.mac(:hmac, :md5, "key", "msg") |> Base.encode16(case: :lower)
+
+      assert result == expected
+    end
+
+    test "name attribute" do
+      assert Pyex.run!("import hmac\nhmac.new('k', 'm', 'sha256').name") == "sha256"
+    end
+
+    test "digest_size attribute" do
+      assert Pyex.run!("import hmac\nhmac.new('k', 'm', 'sha256').digest_size") == 32
+    end
+
+    test "missing digestmod raises TypeError" do
+      assert_raise RuntimeError, ~r/TypeError.*digestmod/, fn ->
+        Pyex.run!("import hmac\nhmac.new('key', 'msg')")
+      end
+    end
+  end
+
+  describe "hmac.new with update" do
+    test "update accumulates message data" do
+      result =
+        Pyex.run!("""
+        import hmac
+        h = hmac.new("secret", "", "sha256")
+        h = h.update("hello")
+        h = h.update(" world")
+        h.hexdigest()
+        """)
+
+      expected =
+        Pyex.run!("""
+        import hmac
+        hmac.new("secret", "hello world", "sha256").hexdigest()
+        """)
+
+      assert result == expected
+    end
+  end
+
+  describe "hmac.digest" do
+    test "one-shot HMAC computation" do
+      result =
+        Pyex.run!("""
+        import hmac
+        hmac.digest("secret", "hello", "sha256")
+        """)
+
+      expected =
+        :crypto.mac(:hmac, :sha256, "secret", "hello") |> Base.encode16(case: :lower)
+
+      assert result == expected
+    end
+  end
+
+  describe "hmac.compare_digest" do
+    test "equal strings return True" do
+      assert Pyex.run!("import hmac\nhmac.compare_digest('abc', 'abc')") == true
+    end
+
+    test "different strings return False" do
+      assert Pyex.run!("import hmac\nhmac.compare_digest('abc', 'def')") == false
+    end
+
+    test "different length strings return False" do
+      assert Pyex.run!("import hmac\nhmac.compare_digest('abc', 'ab')") == false
+    end
+  end
+
+  describe "hmac.new with hashlib digestmod" do
+    test "accepts hashlib.sha256 as digestmod" do
+      result =
+        Pyex.run!("""
+        import hmac
+        import hashlib
+        h = hmac.new("secret", "hello", hashlib.sha256)
+        h.hexdigest()
+        """)
+
+      expected =
+        :crypto.mac(:hmac, :sha256, "secret", "hello") |> Base.encode16(case: :lower)
+
+      assert result == expected
+    end
+  end
+
+  describe "from_import" do
+    test "from hmac import new" do
+      result =
+        Pyex.run!("""
+        from hmac import new
+        h = new("key", "data", "sha256")
+        h.hexdigest()
+        """)
+
+      expected =
+        :crypto.mac(:hmac, :sha256, "key", "data") |> Base.encode16(case: :lower)
+
+      assert result == expected
+    end
+  end
+
+  describe "copy method" do
+    test "copy produces independent HMAC object" do
+      result =
+        Pyex.run!("""
+        import hmac
+        h1 = hmac.new("key", "hello", "sha256")
+        h2 = h1.copy()
+        h2 = h2.update(" world")
+        h1.hexdigest() != h2.hexdigest()
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "webhook verification pattern" do
+    test "verify webhook signature" do
+      result =
+        Pyex.run!("""
+        import hmac
+        import hashlib
+
+        secret = "webhook_secret_key"
+        payload = '{"event": "payment.completed", "amount": 100}'
+
+        signature = hmac.new(secret, payload, "sha256").hexdigest()
+        expected = hmac.new(secret, payload, "sha256").hexdigest()
+
+        hmac.compare_digest(signature, expected)
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "error handling" do
+    test "unsupported algorithm raises ValueError" do
+      assert_raise RuntimeError, ~r/ValueError.*unsupported hash type/, fn ->
+        Pyex.run!("import hmac\nhmac.new('key', 'msg', 'bogus')")
+      end
+    end
+
+    test "non-string key raises TypeError" do
+      assert_raise RuntimeError, ~r/TypeError/, fn ->
+        Pyex.run!("import hmac\nhmac.new(42, 'msg', 'sha256')")
+      end
+    end
+  end
+end

--- a/test/pyex/stdlib/requests_test.exs
+++ b/test/pyex/stdlib/requests_test.exs
@@ -1,6 +1,8 @@
 defmodule Pyex.Stdlib.RequestsTest do
   use ExUnit.Case
 
+  @network [dangerously_allow_full_internet_access: true]
+
   setup do
     bypass = Bypass.open()
     {:ok, bypass: bypass}
@@ -17,11 +19,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.get("http://localhost:#{port}/data")
-        response.status_code
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/data")
+          response.status_code
+          """,
+          network: @network
+        )
 
       assert result == 200
     end
@@ -34,11 +39,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.get("http://localhost:#{port}/text")
-        response.text
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/text")
+          response.text
+          """,
+          network: @network
+        )
 
       assert result == "hello body"
     end
@@ -51,11 +59,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.get("http://localhost:#{port}/ok")
-        response.ok
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/ok")
+          response.ok
+          """,
+          network: @network
+        )
 
       assert result == true
     end
@@ -68,11 +79,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.get("http://localhost:#{port}/fail")
-        response.ok
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/fail")
+          response.ok
+          """,
+          network: @network
+        )
 
       assert result == false
     end
@@ -87,12 +101,15 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.get("http://localhost:#{port}/json")
-        data = response.json()
-        [data["name"], data["age"]]
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/json")
+          data = response.json()
+          [data["name"], data["age"]]
+          """,
+          network: @network
+        )
 
       assert result == ["Alice", 30]
     end
@@ -107,11 +124,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.get("http://localhost:#{port}/headers")
-        "content-type" in response.headers
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/headers")
+          "content-type" in response.headers
+          """,
+          network: @network
+        )
 
       assert result == true
     end
@@ -124,11 +144,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.get("http://localhost:#{port}/content")
-        response.content == response.text
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/content")
+          response.content == response.text
+          """,
+          network: @network
+        )
 
       assert result == true
     end
@@ -150,13 +173,16 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        import json
-        response = requests.post("http://localhost:#{port}/api/data", json={"name": "test", "value": 42})
-        data = json.loads(response.text)
-        [response.status_code, data["created"]]
-        """)
+        Pyex.run!(
+          """
+          import requests
+          import json
+          response = requests.post("http://localhost:#{port}/api/data", json={"name": "test", "value": 42})
+          data = json.loads(response.text)
+          [response.status_code, data["created"]]
+          """,
+          network: @network
+        )
 
       assert result == [201, true]
     end
@@ -174,16 +200,19 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        import json
-        response = requests.post(
-            "http://localhost:#{port}/api/auth",
-            json={"action": "login"},
-            headers={"X-Api-Key": "my-secret"}
+        Pyex.run!(
+          """
+          import requests
+          import json
+          response = requests.post(
+              "http://localhost:#{port}/api/auth",
+              json={"action": "login"},
+              headers={"X-Api-Key": "my-secret"}
+          )
+          json.loads(response.text)
+          """,
+          network: @network
         )
-        json.loads(response.text)
-        """)
 
       assert result == %{"auth" => "ok"}
     end
@@ -196,11 +225,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.post("http://localhost:#{port}/ok", json={})
-        response.ok
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.post("http://localhost:#{port}/ok", json={})
+          response.ok
+          """,
+          network: @network
+        )
 
       assert result == true
     end
@@ -221,11 +253,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.put("http://localhost:#{port}/api/item/1", json={"name": "updated"})
-        [response.status_code, response.json()["name"]]
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.put("http://localhost:#{port}/api/item/1", json={"name": "updated"})
+          [response.status_code, response.json()["name"]]
+          """,
+          network: @network
+        )
 
       assert result == [200, "updated"]
     end
@@ -246,11 +281,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.patch("http://localhost:#{port}/api/item/1", json={"name": "patched"})
-        [response.status_code, response.json()["name"]]
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.patch("http://localhost:#{port}/api/item/1", json={"name": "patched"})
+          [response.status_code, response.json()["name"]]
+          """,
+          network: @network
+        )
 
       assert result == [200, "patched"]
     end
@@ -265,11 +303,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.delete("http://localhost:#{port}/api/item/1")
-        [response.status_code, response.ok]
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.delete("http://localhost:#{port}/api/item/1")
+          [response.status_code, response.ok]
+          """,
+          network: @network
+        )
 
       assert result == [204, true]
     end
@@ -284,11 +325,14 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.head("http://localhost:#{port}/ping")
-        [response.status_code, response.ok]
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.head("http://localhost:#{port}/ping")
+          [response.status_code, response.ok]
+          """,
+          network: @network
+        )
 
       assert result == [200, true]
     end
@@ -305,13 +349,203 @@ defmodule Pyex.Stdlib.RequestsTest do
       port = bypass.port
 
       result =
-        Pyex.run!("""
-        import requests
-        response = requests.options("http://localhost:#{port}/api")
-        [response.status_code, "allow" in response.headers]
-        """)
+        Pyex.run!(
+          """
+          import requests
+          response = requests.options("http://localhost:#{port}/api")
+          [response.status_code, "allow" in response.headers]
+          """,
+          network: @network
+        )
 
       assert result == [200, true]
+    end
+  end
+
+  describe "network access control" do
+    test "denied by default when no network config", %{bypass: bypass} do
+      Bypass.stub(bypass, "GET", "/data", fn conn ->
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      assert_raise RuntimeError, ~r/NetworkError.*network access is disabled/, fn ->
+        Pyex.run!("""
+        import requests
+        requests.get("http://localhost:#{port}/data")
+        """)
+      end
+    end
+
+    test "allowed with matching URL prefix", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/api/data", fn conn ->
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/api/data")
+          response.status_code
+          """,
+          network: [allowed_url_prefixes: ["http://localhost:#{port}/api/"]]
+        )
+
+      assert result == 200
+    end
+
+    test "denied when URL does not match any prefix", %{bypass: bypass} do
+      Bypass.stub(bypass, "GET", "/secret", fn conn ->
+        Plug.Conn.resp(conn, 200, "secret data")
+      end)
+
+      port = bypass.port
+
+      assert_raise RuntimeError, ~r/NetworkError.*URL is not in the allowed prefixes/, fn ->
+        Pyex.run!(
+          """
+          import requests
+          requests.get("http://localhost:#{port}/secret")
+          """,
+          network: [allowed_url_prefixes: ["https://api.example.com"]]
+        )
+      end
+    end
+
+    test "GET allowed by default, POST denied", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/data", fn conn ->
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+      prefix = "http://localhost:#{port}/"
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/data")
+          response.status_code
+          """,
+          network: [allowed_url_prefixes: [prefix]]
+        )
+
+      assert result == 200
+
+      assert_raise RuntimeError, ~r/NetworkError.*HTTP method POST is not allowed/, fn ->
+        Pyex.run!(
+          """
+          import requests
+          requests.post("http://localhost:#{port}/data", json={})
+          """,
+          network: [allowed_url_prefixes: [prefix]]
+        )
+      end
+    end
+
+    test "custom allowed_methods", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/api/data", fn conn ->
+        {:ok, _body, conn} = Plug.Conn.read_body(conn)
+        Plug.Conn.resp(conn, 201, "created")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.post("http://localhost:#{port}/api/data", json={"x": 1})
+          response.status_code
+          """,
+          network: [
+            allowed_url_prefixes: ["http://localhost:#{port}/"],
+            allowed_methods: ["GET", "HEAD", "POST"]
+          ]
+        )
+
+      assert result == 201
+    end
+
+    test "dangerously_allow_full_internet_access allows everything", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "DELETE", "/api/item/1", fn conn ->
+        Plug.Conn.resp(conn, 204, "")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.delete("http://localhost:#{port}/api/item/1")
+          response.status_code
+          """,
+          network: [dangerously_allow_full_internet_access: true]
+        )
+
+      assert result == 204
+    end
+
+    test "multiple prefixes work", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/v2/data", fn conn ->
+        Plug.Conn.resp(conn, 200, "v2")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/v2/data")
+          response.text
+          """,
+          network: [
+            allowed_url_prefixes: [
+              "http://localhost:#{port}/v1/",
+              "http://localhost:#{port}/v2/"
+            ]
+          ]
+        )
+
+      assert result == "v2"
+    end
+
+    test "HEAD allowed by default", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "HEAD", "/ping", fn conn ->
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.head("http://localhost:#{port}/ping")
+          response.status_code
+          """,
+          network: [allowed_url_prefixes: ["http://localhost:#{port}/"]]
+        )
+
+      assert result == 200
+    end
+
+    test "empty allowed_url_prefixes denies all URLs" do
+      assert_raise RuntimeError, ~r/NetworkError.*no allowed URL prefixes/, fn ->
+        Pyex.run!(
+          """
+          import requests
+          requests.get("http://example.com")
+          """,
+          network: [allowed_url_prefixes: []]
+        )
+      end
     end
   end
 end

--- a/test/pyex/stdlib/secrets_test.exs
+++ b/test/pyex/stdlib/secrets_test.exs
@@ -1,0 +1,273 @@
+defmodule Pyex.Stdlib.SecretsTest do
+  use ExUnit.Case, async: true
+
+  describe "secrets.token_hex" do
+    test "default length returns 64 hex chars (32 bytes)" do
+      result =
+        Pyex.run!("""
+        import secrets
+        len(secrets.token_hex())
+        """)
+
+      assert result == 64
+    end
+
+    test "specified length" do
+      result =
+        Pyex.run!("""
+        import secrets
+        len(secrets.token_hex(16))
+        """)
+
+      assert result == 32
+    end
+
+    test "returns only hex characters" do
+      result =
+        Pyex.run!("""
+        import secrets
+        token = secrets.token_hex(16)
+        all(c in "0123456789abcdef" for c in token)
+        """)
+
+      assert result == true
+    end
+
+    test "zero bytes returns empty string" do
+      assert Pyex.run!("import secrets\nsecrets.token_hex(0)") == ""
+    end
+
+    test "each call returns different token" do
+      result =
+        Pyex.run!("""
+        import secrets
+        secrets.token_hex(16) != secrets.token_hex(16)
+        """)
+
+      assert result == true
+    end
+
+    test "None argument uses default" do
+      result =
+        Pyex.run!("""
+        import secrets
+        len(secrets.token_hex(None))
+        """)
+
+      assert result == 64
+    end
+
+    test "negative raises TypeError" do
+      assert_raise RuntimeError, ~r/TypeError/, fn ->
+        Pyex.run!("import secrets\nsecrets.token_hex(-1)")
+      end
+    end
+  end
+
+  describe "secrets.token_urlsafe" do
+    test "default length" do
+      result =
+        Pyex.run!("""
+        import secrets
+        token = secrets.token_urlsafe()
+        len(token) > 0
+        """)
+
+      assert result == true
+    end
+
+    test "specified length" do
+      result =
+        Pyex.run!("""
+        import secrets
+        token = secrets.token_urlsafe(32)
+        len(token) > 0
+        """)
+
+      assert result == true
+    end
+
+    test "contains only URL-safe characters" do
+      result =
+        Pyex.run!("""
+        import secrets
+        token = secrets.token_urlsafe(32)
+        safe_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+        all(c in safe_chars for c in token)
+        """)
+
+      assert result == true
+    end
+
+    test "no padding characters" do
+      result =
+        Pyex.run!("""
+        import secrets
+        token = secrets.token_urlsafe(32)
+        "=" not in token
+        """)
+
+      assert result == true
+    end
+
+    test "each call returns different token" do
+      result =
+        Pyex.run!("""
+        import secrets
+        secrets.token_urlsafe(32) != secrets.token_urlsafe(32)
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "secrets.token_bytes" do
+    test "default returns 32 raw bytes" do
+      result = Pyex.run!("import secrets\nsecrets.token_bytes()")
+      assert is_binary(result)
+      assert byte_size(result) == 32
+    end
+
+    test "specified length returns that many bytes" do
+      result = Pyex.run!("import secrets\nsecrets.token_bytes(16)")
+      assert is_binary(result)
+      assert byte_size(result) == 16
+    end
+
+    test "zero bytes returns empty binary" do
+      assert Pyex.run!("import secrets\nsecrets.token_bytes(0)") == ""
+    end
+
+    test "can be hex-encoded via hashlib or base64" do
+      result =
+        Pyex.run!("""
+        import secrets
+        import base64
+        token = secrets.token_bytes(16)
+        encoded = base64.b16encode(token)
+        len(encoded) == 32
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "secrets.randbelow" do
+    test "returns value in range [0, n)" do
+      result =
+        Pyex.run!("""
+        import secrets
+        x = secrets.randbelow(10)
+        0 <= x and x < 10
+        """)
+
+      assert result == true
+    end
+
+    test "randbelow(1) always returns 0" do
+      assert Pyex.run!("import secrets\nsecrets.randbelow(1)") == 0
+    end
+
+    test "zero raises ValueError" do
+      assert_raise RuntimeError, ~r/ValueError/, fn ->
+        Pyex.run!("import secrets\nsecrets.randbelow(0)")
+      end
+    end
+
+    test "negative raises ValueError" do
+      assert_raise RuntimeError, ~r/ValueError/, fn ->
+        Pyex.run!("import secrets\nsecrets.randbelow(-5)")
+      end
+    end
+  end
+
+  describe "secrets.compare_digest" do
+    test "equal strings" do
+      assert Pyex.run!("import secrets\nsecrets.compare_digest('abc', 'abc')") == true
+    end
+
+    test "different strings" do
+      assert Pyex.run!("import secrets\nsecrets.compare_digest('abc', 'xyz')") == false
+    end
+
+    test "different lengths" do
+      assert Pyex.run!("import secrets\nsecrets.compare_digest('abc', 'ab')") == false
+    end
+  end
+
+  describe "secrets.choice" do
+    test "picks from list" do
+      result =
+        Pyex.run!("""
+        import secrets
+        choices = ["a", "b", "c"]
+        secrets.choice(choices) in choices
+        """)
+
+      assert result == true
+    end
+
+    test "picks from string" do
+      result =
+        Pyex.run!("""
+        import secrets
+        secrets.choice("abc") in "abc"
+        """)
+
+      assert result == true
+    end
+
+    test "empty sequence raises IndexError" do
+      assert_raise RuntimeError, ~r/IndexError/, fn ->
+        Pyex.run!("import secrets\nsecrets.choice([])")
+      end
+    end
+  end
+
+  describe "from_import" do
+    test "from secrets import token_hex" do
+      result =
+        Pyex.run!("""
+        from secrets import token_hex
+        len(token_hex(16))
+        """)
+
+      assert result == 32
+    end
+
+    test "from secrets import token_urlsafe, token_hex" do
+      result =
+        Pyex.run!("""
+        from secrets import token_urlsafe, token_hex
+        len(token_hex(8)) > 0 and len(token_urlsafe(8)) > 0
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "OAuth state generation pattern" do
+    test "generate state parameter" do
+      result =
+        Pyex.run!("""
+        import secrets
+        state = secrets.token_urlsafe(32)
+        len(state) > 0
+        """)
+
+      assert result == true
+    end
+
+    test "generate PKCE code verifier" do
+      result =
+        Pyex.run!("""
+        import secrets
+        code_verifier = secrets.token_urlsafe(32)
+        length = len(code_verifier)
+        length >= 43 and length <= 128
+        """)
+
+      assert result == true
+    end
+  end
+end

--- a/test/pyex/stdlib/sql_test.exs
+++ b/test/pyex/stdlib/sql_test.exs
@@ -83,34 +83,6 @@ defmodule Pyex.Stdlib.SqlTest do
     value
   end
 
-  describe "access control" do
-    test "denied by default when sql not enabled" do
-      ctx = Pyex.Ctx.new(environ: %{"DATABASE_URL" => @db_url})
-
-      assert {:error, %Error{message: msg}} =
-               Pyex.run(
-                 """
-                 import sql
-                 sql.query("SELECT 1")
-                 """,
-                 ctx
-               )
-
-      assert msg =~ "PermissionError"
-      assert msg =~ "sql is disabled"
-    end
-
-    test "import succeeds even when sql is disabled" do
-      result =
-        Pyex.run!("""
-        import sql
-        'query' in dir(sql)
-        """)
-
-      assert result == true
-    end
-  end
-
   describe "sql.query" do
     test "SELECT all rows" do
       assert run!("""


### PR DESCRIPTION
## Summary

- Adds four security/cryptography stdlib modules (`hashlib`, `hmac`, `base64`, `secrets`) commonly needed by LLM-generated code for authentication flows, token generation, and data encoding.
- **Default-deny network access** for the `requests` module. All HTTP requests are now blocked unless the caller explicitly configures the `:network` option.
- **Default-deny capability gates** for `boto3` (S3) and `sql` (PostgreSQL). Operations raise `PermissionError` unless explicitly enabled via `:boto3` / `:sql` options.
- **Redirect hardening** for the `requests` module. HTTP redirects are disabled to prevent SSRF via 3xx responses.

## Capability Gates

All I/O capabilities are denied by default, matching the sandbox design:

| Capability | Option | Default | What it gates |
|-----------|--------|---------|---------------|
| HTTP requests | `:network` | `nil` (denied) | `requests.get/post/put/...` |
| S3 operations | `:boto3` | `false` | `s3.put_object/get_object/delete_object/list_objects_v2` |
| SQL queries | `:sql` | `false` | `sql.query(...)` |

```elixir
# Enable S3 access
Pyex.run!(source, boto3: true)

# Enable database access
Pyex.run!(source, sql: true, environ: %{"DATABASE_URL" => url})

# Enable network with host allowlist
Pyex.run!(source, network: [allowed_hosts: ["api.github.com"]])
```

Enforcement is at **call time, not import time** -- `import boto3` always succeeds, but `s3.put_object(...)` raises `PermissionError` inside the `:io_call` closure where `ctx` is available.

## Network Access Control

Network access is disabled by default. To enable it, configure the `:network` option:

```elixir
# Allow specific hosts with GET/HEAD only (recommended)
Pyex.run!(source,
  network: [allowed_hosts: ["api.github.com", "api.example.com"]]
)

# Allow specific URL prefixes (use trailing slash to prevent subdomain spoofing)
Pyex.run!(source,
  network: [allowed_url_prefixes: ["https://api.github.com/repos/myorg/"]]
)

# Allow all URLs and methods (use with caution)
Pyex.run!(source,
  network: [dangerously_allow_full_internet_access: true]
)
```

### Host vs prefix matching

- **`allowed_hosts`** -- exact match against `URI.parse(url).host` (case-insensitive). Prevents subdomain spoofing: `api.example.com.evil.com` does **not** match `api.example.com`.
- **`allowed_url_prefixes`** -- `String.starts_with?` match. More granular (path-level scoping) but requires trailing slash to be safe.
- Both can be combined; a request passes if it matches **either** list.

### Redirect hardening

All `Req` calls use `redirect: false` to prevent SSRF via 3xx responses. A request to an allowed URL that returns a 302 to an unauthorized URL will return the 302 status directly instead of following it.

## New Stdlib Modules

| Module | Key Functions | Backed By |
|--------|-------------|-----------|
| `hashlib` | `sha256()`, `sha1()`, `md5()`, `sha224/384/512()`, `new()` with `.update()`, `.hexdigest()`, `.digest()` | `:crypto.hash/2` |
| `hmac` | `hmac.new(key, msg, digestmod)`, `hmac.digest()`, `hmac.compare_digest()` | `:crypto.mac/4` |
| `base64` | `b64encode/decode`, `urlsafe_b64encode/decode`, `b32encode/decode`, `b16encode/decode` | `Base` module |
| `secrets` | `token_hex()`, `token_urlsafe()`, `token_bytes()`, `randbelow()`, `choice()`, `compare_digest()` | `:crypto.strong_rand_bytes/1` |

## Test Coverage

- 17 network access control tests (denied-by-default, prefix matching, host matching, subdomain rejection, method filtering, combined host+prefix, full access)
- 1 redirect hardening test (302 returned directly, not followed)
- 5 boto3 access control tests (denied by default, all ops denied, import succeeds)
- 2 sql access control tests (denied by default, import succeeds)
- 894 lines of crypto stdlib tests with known-value verification
- All 2255 tests pass, dialyzer clean