### PR TITLE
Fix csv.DictWriter arg order to match CPython and improve time precision

### DIFF
--- a/lib/pyex/stdlib/csv.ex
+++ b/lib/pyex/stdlib/csv.ex
@@ -406,7 +406,10 @@ defmodule Pyex.Stdlib.Csv do
   end
 
   # Single positional arg: file handle only, fieldnames from kwarg
-  defp do_dict_writer([{:file_handle, _} = fh], %{"fieldnames" => {:py_list, reversed, _}} = kwargs) do
+  defp do_dict_writer(
+         [{:file_handle, _} = fh],
+         %{"fieldnames" => {:py_list, reversed, _}} = kwargs
+       ) do
     do_dict_writer([fh], Map.put(kwargs, "fieldnames", Enum.reverse(reversed)))
   end
 

--- a/lib/pyex/stdlib/csv.ex
+++ b/lib/pyex/stdlib/csv.ex
@@ -392,25 +392,32 @@ defmodule Pyex.Stdlib.Csv do
           optional(String.t()) => Pyex.Interpreter.pyvalue()
         }) ::
           Pyex.Interpreter.pyvalue()
+  # Unwrap py_list arguments, then re-dispatch
   defp do_dict_writer([{:py_list, reversed, _}], kwargs),
     do: do_dict_writer([Enum.reverse(reversed)], kwargs)
 
   defp do_dict_writer([{:file_handle, _} = fh, {:py_list, reversed, _}], kwargs),
     do: do_dict_writer([fh, Enum.reverse(reversed)], kwargs)
 
-  defp do_dict_writer([{:py_list, reversed, _}, {:file_handle, _} = fh], kwargs),
-    do: do_dict_writer([Enum.reverse(reversed), fh], kwargs)
-
-  defp do_dict_writer([fieldnames], kwargs) when is_list(fieldnames) do
-    build_dict_writer(nil, fieldnames, kwargs)
-  end
-
+  # CPython signature: csv.DictWriter(csvfile, fieldnames, ...)
+  # Two positional args: file handle first, fieldnames second
   defp do_dict_writer([{:file_handle, _} = fh, fieldnames], kwargs) when is_list(fieldnames) do
     build_dict_writer(fh, fieldnames, kwargs)
   end
 
-  defp do_dict_writer([fieldnames, {:file_handle, _} = fh], kwargs) when is_list(fieldnames) do
-    build_dict_writer(fh, fieldnames, kwargs)
+  # Single positional arg: file handle only, fieldnames from kwarg
+  defp do_dict_writer([{:file_handle, _} = fh], %{"fieldnames" => {:py_list, reversed, _}} = kwargs) do
+    do_dict_writer([fh], Map.put(kwargs, "fieldnames", Enum.reverse(reversed)))
+  end
+
+  defp do_dict_writer([{:file_handle, _} = fh], %{"fieldnames" => fieldnames} = kwargs)
+       when is_list(fieldnames) do
+    build_dict_writer(fh, fieldnames, Map.delete(kwargs, "fieldnames"))
+  end
+
+  # Single positional arg: fieldnames only (no file handle)
+  defp do_dict_writer([fieldnames], kwargs) when is_list(fieldnames) do
+    build_dict_writer(nil, fieldnames, kwargs)
   end
 
   defp do_dict_writer(_, _kwargs) do

--- a/lib/pyex/stdlib/time.ex
+++ b/lib/pyex/stdlib/time.ex
@@ -30,7 +30,7 @@ defmodule Pyex.Stdlib.Time do
 
   @spec do_time([Pyex.Interpreter.pyvalue()]) :: float()
   defp do_time([]) do
-    :os.system_time(:millisecond) / 1000.0
+    :os.system_time(:nanosecond) / 1.0e9
   end
 
   @spec do_time_ns([Pyex.Interpreter.pyvalue()]) :: integer()
@@ -40,7 +40,7 @@ defmodule Pyex.Stdlib.Time do
 
   @spec do_monotonic([Pyex.Interpreter.pyvalue()]) :: float()
   defp do_monotonic([]) do
-    :erlang.monotonic_time(:millisecond) / 1000.0
+    :erlang.monotonic_time(:nanosecond) / 1.0e9
   end
 
   @spec do_monotonic_ns([Pyex.Interpreter.pyvalue()]) :: integer()

--- a/test/pyex/stdlib/csv_test.exs
+++ b/test/pyex/stdlib/csv_test.exs
@@ -678,6 +678,24 @@ defmodule Pyex.Stdlib.CsvTest do
                Pyex.Filesystem.Memory.read(ctx.filesystem, "output.csv")
     end
 
+    test "csv.DictWriter with fieldnames as keyword argument" do
+      {:ok, _result, ctx} =
+        Pyex.run(
+          """
+          import csv
+          f = open("output.csv", "w")
+          writer = csv.DictWriter(f, fieldnames=["name", "age"])
+          writer.writeheader()
+          writer.writerow({"name": "Alice", "age": "30"})
+          f.close()
+          """,
+          @fs_opts
+        )
+
+      assert {:ok, "name,age\r\nAlice,30\r\n"} =
+               Pyex.Filesystem.Memory.read(ctx.filesystem, "output.csv")
+    end
+
     test "full file roundtrip: write then read" do
       result =
         Pyex.run!(


### PR DESCRIPTION
## Summary
- Fix `csv.DictWriter` to match CPython's `csv.DictWriter(csvfile, fieldnames, ...)` signature — file handle first, fieldnames second. Also adds support for `fieldnames` as a keyword argument. Fixes #14.
- Bump `time.time()` and `time.monotonic()` from millisecond to nanosecond resolution to match CPython's sub-microsecond precision, fixing a flaky SSG benchmark assertion.

## Test plan
- [x] All 66 CSV tests pass, including new test for `fieldnames` kwarg form
- [x] Full test suite passes (2691 tests, 0 failures)
- [x] Previously flaky SSG timing assertion now passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)