### PR TITLE
Stabilize core interpreter architecture ahead of pre-alpha release

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,8 +1,4 @@
 [
-  # call_dunder wraps {:exception, _} as a return value inside {:ok, ...}
-  # which dialyzer sees as impossible since {:exception, _} is a signal, not a pyvalue.
-  # This is a deliberate design choice for distinguishing "not found" from "found but errored".
-  {"lib/pyex/interpreter.ex", :pattern_match},
   # call_function returns {:mutate, ...} tuples at runtime that Dialyzer
   # cannot track through the union type -- same issue as the main interpreter.
   {"lib/pyex/interpreter/unittest.ex", :pattern_match},
@@ -25,18 +21,24 @@
   # but Dialyzer cannot narrow the union type through pattern matching on
   # {:with, _, [expr, as_name, body]} and thinks expr could be an atom.
   {"lib/pyex/interpreter.ex", :call},
+  # defaultdict auto-insert returns a 5-tuple {:defaultdict_auto_insert, ...} from
+  # eval_subscript. Dialyzer cannot trace this tagged tuple through the case match.
+  {"lib/pyex/interpreter.ex", :pattern_match},
   # extract_exception_type_name/1 and with_update_cm/3 are called from the
   # {:with, ...} eval clause but Dialyzer's call graph analysis cannot trace
   # through the complex union-typed control flow. Both are genuinely reachable.
   {"lib/pyex/interpreter.ex", :unused_fun},
-  # bound_kw/2 wraps a method function with receiver binding. Dialyzer traces
-  # through the single call site (list_sort/3) and infers the args pattern must
-  # be [], but the anonymous function accepts any args list. False positive.
-  {"lib/pyex/methods.ex", :no_return},
-  # Dialyzer cannot see that {:py_list, _, _} is a valid Interpreter.pyvalue().
-  # The bound/2 and bound_kw/2 calls with py_list receivers are safe at runtime.
-  {"lib/pyex/methods.ex", :call},
-  # Dialyzer cannot infer that {:py_list, _, _} is in Interpreter.pyvalue() union
-  # at jinja2.ex call sites. The pattern matches are reachable at runtime.
-  {"lib/pyex/stdlib/jinja2.ex", :pattern_match}
+  # call_dunder/call_dunder_mut return {:exception, _} inside the {:ok, ...} tuple.
+  # {:exception, _} is a control-flow signal, not a pyvalue(), so Dialyzer sees
+  # the pattern match as impossible. These are reachable at runtime.
+  {"lib/pyex/interpreter/builtin_results.ex", :pattern_match},
+  {"lib/pyex/interpreter/iterables.ex", :pattern_match},
+  # call_function returns 3- or 4-element tuples at runtime that Dialyzer
+  # cannot track through the union type. do_aug_subscript and do_nested_aug_inner
+  # are genuinely called from the defaultdict lambda factory handling paths.
+  {"lib/pyex/interpreter/assignments.ex", :unused_fun},
+  # defaultdict auto-insert returns {:defaultdict_auto_insert, ...} 5-tuple and
+  # {:defaultdict_call_needed, ...} from get_subscript_value. Dialyzer cannot
+  # trace these tagged tuples through the control flow.
+  {"lib/pyex/interpreter/assignments.ex", :pattern_match}
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,4 +40,4 @@ unittest, uuid
 - `:telemetry` events for `run`, `request`, and `query`
 - `Pyex.Trace` — dev tool that attaches to telemetry events and prints a timing tree
 - Structured `Pyex.Error` with kind-based classification
-- Append-only event log in `Pyex.Ctx`
+- Output capture and execution counters in `Pyex.Ctx`

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -3,7 +3,8 @@ defmodule Pyex do
   A Python 3 interpreter written in Elixir.
 
   Pyex lexes, parses, and evaluates Python source code entirely
-  within the BEAM -- no external runtime, no NIFs, no ports.
+  within the BEAM -- no external runtime, no ports, and no Python
+  runtime dependency.
   It is designed as a capabilities-based sandbox for running
   LLM-generated compute safely: every I/O operation (network,
   filesystem, database) is denied by default and must be
@@ -110,7 +111,10 @@ defmodule Pyex do
     :telemetry.execute([:pyex, :run, :start], %{system_time: System.system_time()}, %{})
 
     ctx = %{ctx | compute: 0.0, compute_started_at: System.monotonic_time()}
-    result = Interpreter.run_with_ctx(ast, Builtins.env(), ctx)
+
+    env = Builtins.runtime_env(ctx)
+
+    result = Interpreter.run_with_ctx(ast, env, ctx)
 
     case result do
       {:ok, value, _env, final_ctx} ->

--- a/lib/pyex/builtins.ex
+++ b/lib/pyex/builtins.ex
@@ -9,7 +9,7 @@ defmodule Pyex.Builtins do
   and `append()` (as a method-like helper).
   """
 
-  alias Pyex.{Env, Interpreter}
+  alias Pyex.{Ctx, Env, Interpreter}
 
   @doc """
   Returns an environment pre-populated with all builtins.
@@ -23,6 +23,23 @@ defmodule Pyex.Builtins do
     case :persistent_term.get({__MODULE__, :env}, :miss) do
       :miss -> build_env()
       cached -> cached
+    end
+  end
+
+  @doc """
+  Returns a top-level runtime environment for executing user code.
+
+  Includes the builtins plus `__name__ == "__main__"` and, when present,
+  `__file__` from the provided context.
+  """
+  @spec runtime_env(Ctx.t()) :: Env.t()
+  def runtime_env(%Ctx{} = ctx) do
+    env = Env.put(env(), "__name__", "__main__")
+
+    if is_binary(ctx.file) do
+      Env.put(env, "__file__", ctx.file)
+    else
+      env
     end
   end
 
@@ -75,7 +92,7 @@ defmodule Pyex.Builtins do
       {"issubclass", &builtin_issubclass/1},
       {"round", &builtin_round/1},
       {"input", &builtin_input/1},
-      {"open", &builtin_open/1},
+      {"open", {:kw, &builtin_open/2}},
       {"any", &builtin_any/1},
       {"all", &builtin_all/1},
       {"map", &builtin_map/1},
@@ -876,12 +893,87 @@ defmodule Pyex.Builtins do
     {:exception, "RuntimeError: input() is not supported in the sandbox"}
   end
 
-  @spec builtin_open([Interpreter.pyvalue()]) ::
+  @spec builtin_open(
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()}
+        ) ::
           {:ctx_call, (Pyex.Env.t(), Pyex.Ctx.t() -> term())}
           | {:exception, String.t()}
-  defp builtin_open([path]) when is_binary(path), do: builtin_open([path, "r"])
+  defp builtin_open(args, kwargs) do
+    with :ok <- validate_open_kwargs(kwargs),
+         {:ok, path} <- resolve_open_path(args, kwargs),
+         {:ok, mode_str} <- resolve_open_mode(args, kwargs) do
+      open_file_handle(path, mode_str)
+    else
+      {:exception, _} = error -> error
+    end
+  end
 
-  defp builtin_open([path, mode_str]) when is_binary(path) and is_binary(mode_str) do
+  @open_supported_kwargs ["file", "mode", "encoding", "newline"]
+
+  @spec validate_open_kwargs(%{optional(String.t()) => Interpreter.pyvalue()}) ::
+          :ok | {:exception, String.t()}
+  defp validate_open_kwargs(kwargs) do
+    case Map.keys(kwargs) -- @open_supported_kwargs do
+      [] -> :ok
+      [name | _] -> {:exception, "TypeError: open() got an unexpected keyword argument '#{name}'"}
+    end
+  end
+
+  @spec resolve_open_path([Interpreter.pyvalue()], %{
+          optional(String.t()) => Interpreter.pyvalue()
+        }) ::
+          {:ok, String.t()} | {:exception, String.t()}
+  defp resolve_open_path(args, kwargs) do
+    cond do
+      length(args) > 2 ->
+        {:exception,
+         "TypeError: open() takes from 1 to 2 positional arguments but #{length(args)} were given"}
+
+      length(args) >= 1 and Map.has_key?(kwargs, "file") ->
+        {:exception, "TypeError: argument for open() given by name ('file') and position (1)"}
+
+      match?([path | _] when is_binary(path), args) ->
+        {:ok, hd(args)}
+
+      match?(%{"file" => path} when is_binary(path), kwargs) ->
+        {:ok, Map.fetch!(kwargs, "file")}
+
+      args == [] and not Map.has_key?(kwargs, "file") ->
+        {:exception, "TypeError: open() missing required argument 'file' (pos 1)"}
+
+      true ->
+        {:exception, "TypeError: invalid arguments"}
+    end
+  end
+
+  @spec resolve_open_mode([Interpreter.pyvalue()], %{
+          optional(String.t()) => Interpreter.pyvalue()
+        }) ::
+          {:ok, String.t()} | {:exception, String.t()}
+  defp resolve_open_mode(args, kwargs) do
+    cond do
+      length(args) >= 2 and Map.has_key?(kwargs, "mode") ->
+        {:exception, "TypeError: argument for open() given by name ('mode') and position (2)"}
+
+      match?([_, mode] when is_binary(mode), args) ->
+        {:ok, Enum.at(args, 1)}
+
+      match?(%{"mode" => mode} when is_binary(mode), kwargs) ->
+        {:ok, Map.fetch!(kwargs, "mode")}
+
+      length(args) <= 1 and not Map.has_key?(kwargs, "mode") ->
+        {:ok, "r"}
+
+      true ->
+        {:exception, "TypeError: invalid arguments"}
+    end
+  end
+
+  @spec open_file_handle(String.t(), String.t()) ::
+          {:ctx_call, (Pyex.Env.t(), Pyex.Ctx.t() -> term())}
+          | {:exception, String.t()}
+  defp open_file_handle(path, mode_str) do
     case mode_str do
       m when m in ["r", "w", "a"] ->
         mode = %{"r" => :read, "w" => :write, "a" => :append} |> Map.fetch!(m)
@@ -1369,6 +1461,8 @@ defmodule Pyex.Builtins do
   def truthy?({:range, start, stop, step}),
     do: range_length({:range, start, stop, step}) > 0
 
+  def truthy?({:pyex_decimal, d}), do: not Decimal.equal?(d, Decimal.new(0))
+
   def truthy?(_), do: true
 
   @spec pytype(Interpreter.pyvalue()) :: String.t()
@@ -1460,6 +1554,7 @@ defmodule Pyex.Builtins do
   def py_repr({:function, name, _, _, _}), do: "<function #{name}>"
   def py_repr({:builtin, _}), do: "<built-in function>"
   def py_repr({:builtin_kw, _}), do: "<built-in function>"
+  def py_repr({:pyex_decimal, d}), do: Decimal.to_string(d)
   def py_repr(_), do: "<object>"
 
   @spec py_repr_quoted(Interpreter.pyvalue()) :: String.t()

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -71,7 +71,8 @@ defmodule Pyex.Ctx do
           output_buffer: [String.t()],
           event_count: non_neg_integer(),
           file_ops: non_neg_integer(),
-          duration_ms: float() | nil
+          duration_ms: float() | nil,
+          file: String.t() | nil
         }
 
   defstruct filesystem: nil,
@@ -97,10 +98,11 @@ defmodule Pyex.Ctx do
             current_line: nil,
             call_depth: 0,
             max_call_depth: 500,
-            duration_ms: nil
+            duration_ms: nil,
+            file: nil
 
   @doc """
-  Creates a fresh live context that records all events.
+  Creates a fresh live context that captures output and execution counters.
 
   Options:
   - `:filesystem` -- a filesystem backend struct (e.g. `Pyex.Filesystem.Memory.new()`).
@@ -142,7 +144,8 @@ defmodule Pyex.Ctx do
     :network,
     :capabilities,
     :boto3,
-    :sql
+    :sql,
+    :file
   ]
 
   @spec new(keyword()) :: t()
@@ -172,6 +175,7 @@ defmodule Pyex.Ctx do
 
     network = normalize_network(Keyword.get(opts, :network))
     capabilities = normalize_capabilities(opts)
+    file = Keyword.get(opts, :file)
 
     %__MODULE__{
       filesystem: fs,
@@ -182,7 +186,8 @@ defmodule Pyex.Ctx do
       compute_started_at: System.monotonic_time(),
       profile: profile,
       network: network,
-      capabilities: capabilities
+      capabilities: capabilities,
+      file: file
     }
   end
 

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -8,15 +8,34 @@ defmodule Pyex.Interpreter do
   exceptions are `{:exception, message}` tuples that propagate
   identically -- no Elixir raise/rescue for Python error semantics.
 
-  Every execution is instrumented via `Pyex.Ctx`. Decision points
-  (branches, loop iterations, side effects) are recorded as events
-  in an append-only log for observability and debugging.
+  Every execution is instrumented via `Pyex.Ctx`. The context tracks
+  output plus lightweight counters for events, file operations, and
+  compute time so callers can inspect execution without a separate
+  runtime process.
   """
 
-  import Bitwise, only: [band: 2, bor: 2, bxor: 2, bsl: 2, bsr: 2, bnot: 1]
+  import Bitwise, only: [bnot: 1]
 
   alias Pyex.{Builtins, Ctx, Env, Methods, Parser}
-  alias Pyex.Interpreter.{Format, Helpers, Import, Iteration, Match, Unittest}
+
+  alias Pyex.Interpreter.{
+    Assignments,
+    BinaryOps,
+    Bindings,
+    ClassLookup,
+    Calls,
+    Collections,
+    ControlFlow,
+    Dunder,
+    Exceptions,
+    Helpers,
+    Import,
+    Invocation,
+    Iterables,
+    Match,
+    Protocols,
+    Statements
+  }
 
   @type pyvalue ::
           integer()
@@ -28,6 +47,7 @@ defmodule Pyex.Interpreter do
           | boolean()
           | nil
           | [pyvalue()]
+          | {:py_list, [pyvalue()], non_neg_integer()}
           | %{optional(pyvalue()) => pyvalue()}
           | {:tuple, [pyvalue()]}
           | {:set, MapSet.t(pyvalue())}
@@ -49,6 +69,7 @@ defmodule Pyex.Interpreter do
           | {:pandas_series, Explorer.Series.t()}
           | {:pandas_rolling, Explorer.Series.t(), pos_integer()}
           | {:pandas_dataframe, Explorer.DataFrame.t()}
+          | {:pyex_decimal, Decimal.t()}
 
   @typep signal ::
            {:returned, pyvalue()}
@@ -110,8 +131,7 @@ defmodule Pyex.Interpreter do
 
   @doc """
   Evaluates an AST with a provided context, returning
-  the value, final environment, and context (with full
-  event log).
+  the value, final environment, and updated context.
   """
   @spec run_with_ctx(Parser.ast_node(), Env.t(), Ctx.t()) ::
           {:ok, pyvalue(), Env.t(), Ctx.t()}
@@ -200,7 +220,7 @@ defmodule Pyex.Interpreter do
 
       {context_val, env, ctx} ->
         {enter_val, context_val, env, ctx} =
-          case call_dunder_mut(context_val, "__enter__", [], env, ctx) do
+          case Dunder.call_dunder_mut(context_val, "__enter__", [], env, ctx) do
             {:ok, new_obj, val, env, ctx} ->
               env = with_update_cm(env, cm_var, new_obj)
               {val, new_obj, env, ctx}
@@ -222,7 +242,7 @@ defmodule Pyex.Interpreter do
           {:exception, msg} ->
             exc_type = extract_exception_type_name(msg)
 
-            case call_dunder_mut(context_val, "__exit__", [exc_type, msg, nil], env, ctx) do
+            case Dunder.call_dunder_mut(context_val, "__exit__", [exc_type, msg, nil], env, ctx) do
               {:ok, new_obj, suppress, env, ctx} ->
                 env = with_update_cm(env, cm_var, new_obj)
 
@@ -237,7 +257,7 @@ defmodule Pyex.Interpreter do
             end
 
           _ ->
-            case call_dunder_mut(context_val, "__exit__", [nil, nil, nil], env, ctx) do
+            case Dunder.call_dunder_mut(context_val, "__exit__", [nil, nil, nil], env, ctx) do
               {:ok, new_obj, _, env, ctx} ->
                 env = with_update_cm(env, cm_var, new_obj)
                 {result, env, ctx}
@@ -302,131 +322,43 @@ defmodule Pyex.Interpreter do
   end
 
   def eval({:attr_assign, _, [target, expr]}, env, ctx) do
-    case eval(expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {value, env, ctx} ->
-        setattr(target, value, env, ctx)
-    end
+    Assignments.eval_attr_assign(target, expr, env, ctx)
   end
 
   def eval({:aug_attr_assign, _, [target, op, expr]}, env, ctx) do
-    case eval(target, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {old_value, env, ctx} ->
-        case eval(expr, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {rhs, env, ctx} ->
-            new_value = safe_binop(op, old_value, rhs)
-
-            case new_value do
-              {:exception, _} = signal -> {signal, env, ctx}
-              _ -> setattr(target, new_value, env, ctx)
-            end
-        end
-    end
+    Assignments.eval_aug_attr_assign(target, op, expr, env, ctx)
   end
 
   def eval({:global, _, [names]}, env, ctx) do
-    env = Enum.reduce(names, env, &Env.declare_global(&2, &1))
-    {nil, env, ctx}
+    Bindings.eval_global(names, env, ctx)
   end
 
   def eval({:nonlocal, _, [names]}, env, ctx) do
-    env = Enum.reduce(names, env, &Env.declare_nonlocal(&2, &1))
-    {nil, env, ctx}
+    Bindings.eval_nonlocal(names, env, ctx)
   end
 
   def eval({:assign, _, [name, expr]}, env, ctx) do
-    case eval(expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {value, env, ctx} ->
-        {value, Env.smart_put(env, name, value), ctx}
-    end
+    Bindings.eval_assign(name, expr, env, ctx)
   end
 
   def eval({:annotated_assign, _, [name, type_str, nil]}, env, ctx) do
-    annotations =
-      case Env.get(env, "__annotations__") do
-        {:ok, map} when is_map(map) -> map
-        _ -> %{}
-      end
-
-    resolved = resolve_annotation(type_str, env)
-    env = Env.smart_put(env, "__annotations__", Map.put(annotations, name, resolved))
-    {nil, env, ctx}
+    Bindings.eval_annotated_declaration(name, type_str, env, ctx)
   end
 
   def eval({:annotated_assign, _, [name, type_str, expr]}, env, ctx) do
-    case eval(expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {value, env, ctx} ->
-        annotations =
-          case Env.get(env, "__annotations__") do
-            {:ok, map} when is_map(map) -> map
-            _ -> %{}
-          end
-
-        resolved = resolve_annotation(type_str, env)
-        env = Env.smart_put(env, "__annotations__", Map.put(annotations, name, resolved))
-        {value, Env.smart_put(env, name, value), ctx}
-    end
+    Bindings.eval_annotated_assign(name, type_str, expr, env, ctx)
   end
 
   def eval({:walrus, _, [name, expr]}, env, ctx) do
-    case eval(expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {value, env, ctx} ->
-        {value, Env.smart_put(env, name, value), ctx}
-    end
+    Bindings.eval_walrus(name, expr, env, ctx)
   end
 
   def eval({:chained_assign, _, [names, expr]}, env, ctx) do
-    case eval(expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {value, env, ctx} ->
-        {env, ctx} =
-          Enum.reduce(names, {env, ctx}, fn name, {env, ctx} ->
-            {Env.smart_put(env, name, value), ctx}
-          end)
-
-        {value, env, ctx}
-    end
+    Bindings.eval_chained_assign(names, expr, env, ctx)
   end
 
   def eval({:multi_assign, _, [names, exprs]}, env, ctx) do
-    case eval_list(exprs, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {values, env, ctx} ->
-        case unpack_iterable_safe(Enum.reverse(values), names) do
-          {:ok, pairs} ->
-            {env, ctx} =
-              Enum.reduce(pairs, {env, ctx}, fn {name, val}, {env, ctx} ->
-                {Env.smart_put(env, name, val), ctx}
-              end)
-
-            {_, last_val} = List.last(pairs)
-            {last_val, env, ctx}
-
-          {:exception, msg} ->
-            {{:exception, msg}, env, ctx}
-        end
-    end
+    Bindings.eval_multi_assign(names, exprs, env, ctx)
   end
 
   def eval(
@@ -435,57 +367,18 @@ defmodule Pyex.Interpreter do
         env,
         ctx
       ) do
-    with {container, env, ctx} when not is_tuple(container) or elem(container, 0) != :exception <-
-           eval(container_expr, env, ctx),
-         {outer_key, env, ctx} when not is_tuple(outer_key) or elem(outer_key, 0) != :exception <-
-           eval(outer_key_expr, env, ctx),
-         {inner_key, env, ctx} when not is_tuple(inner_key) or elem(inner_key, 0) != :exception <-
-           eval(inner_key_expr, env, ctx),
-         {val, env, ctx} when not is_tuple(val) or elem(val, 0) != :exception <-
-           eval(val_expr, env, ctx) do
-      inner_container = get_subscript_value(container, outer_key)
-
-      case inner_container do
-        {:exception, msg} ->
-          {{:exception, msg}, env, ctx}
-
-        _ ->
-          updated_inner = set_subscript_value(inner_container, inner_key, val)
-          updated_outer = set_subscript_value(container, outer_key, updated_inner)
-          write_back_subscript(container_expr, updated_outer, env, ctx)
-      end
-    else
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-    end
+    Assignments.eval_nested_subscript_assign(
+      container_expr,
+      outer_key_expr,
+      inner_key_expr,
+      val_expr,
+      env,
+      ctx
+    )
   end
 
   def eval({:subscript_assign, _, [{:getattr, _, _} = target_expr, key_expr, val_expr]}, env, ctx) do
-    with {container, env, ctx} when not is_tuple(container) or elem(container, 0) != :exception <-
-           eval(target_expr, env, ctx),
-         {key, env, ctx} when not is_tuple(key) or elem(key, 0) != :exception <-
-           eval(key_expr, env, ctx),
-         {val, env, ctx} when not is_tuple(val) or elem(val, 0) != :exception <-
-           eval(val_expr, env, ctx) do
-      case container do
-        %{} = map ->
-          updated = Map.put(map, key, val)
-          setattr_nested(target_expr, updated, env, ctx)
-
-        {:py_list, reversed, len} when is_integer(key) ->
-          real_idx = if key < 0, do: len + key, else: key
-          updated = {:py_list, List.replace_at(reversed, len - 1 - real_idx, val), len}
-          setattr_nested(target_expr, updated, env, ctx)
-
-        list when is_list(list) and is_integer(key) ->
-          updated = List.replace_at(list, key, val)
-          setattr_nested(target_expr, updated, env, ctx)
-
-        _ ->
-          {{:exception, "TypeError: object does not support item assignment"}, env, ctx}
-      end
-    else
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-    end
+    Assignments.eval_attr_subscript_assign(target_expr, key_expr, val_expr, env, ctx)
   end
 
   def eval(
@@ -499,42 +392,15 @@ defmodule Pyex.Interpreter do
         env,
         ctx
       ) do
-    with {container, env, ctx} when not is_tuple(container) or elem(container, 0) != :exception <-
-           eval(container_expr, env, ctx),
-         {outer_key, env, ctx} when not is_tuple(outer_key) or elem(outer_key, 0) != :exception <-
-           eval(outer_key_expr, env, ctx),
-         {inner_key, env, ctx} when not is_tuple(inner_key) or elem(inner_key, 0) != :exception <-
-           eval(inner_key_expr, env, ctx),
-         {val, env, ctx} when not is_tuple(val) or elem(val, 0) != :exception <-
-           eval(val_expr, env, ctx) do
-      inner_container = get_subscript_value(container, outer_key)
-
-      case inner_container do
-        {:exception, msg} ->
-          {{:exception, msg}, env, ctx}
-
-        _ ->
-          old_val = get_subscript_value(inner_container, inner_key)
-
-          case old_val do
-            {:exception, msg} ->
-              {{:exception, msg}, env, ctx}
-
-            _ ->
-              case safe_binop(op, old_val, val) do
-                {:exception, msg} ->
-                  {{:exception, msg}, env, ctx}
-
-                new_val ->
-                  updated_inner = set_subscript_value(inner_container, inner_key, new_val)
-                  updated_outer = set_subscript_value(container, outer_key, updated_inner)
-                  write_back_subscript(container_expr, updated_outer, env, ctx)
-              end
-          end
-      end
-    else
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-    end
+    Assignments.eval_nested_aug_subscript_assign(
+      container_expr,
+      outer_key_expr,
+      inner_key_expr,
+      op,
+      val_expr,
+      env,
+      ctx
+    )
   end
 
   def eval(
@@ -542,71 +408,15 @@ defmodule Pyex.Interpreter do
         env,
         ctx
       ) do
-    with {container, env, ctx} when not is_tuple(container) or elem(container, 0) != :exception <-
-           eval(target_expr, env, ctx),
-         {key, env, ctx} when not is_tuple(key) or elem(key, 0) != :exception <-
-           eval(key_expr, env, ctx),
-         {val, env, ctx} when not is_tuple(val) or elem(val, 0) != :exception <-
-           eval(val_expr, env, ctx) do
-      case container do
-        %{} = map ->
-          old_val = Map.get(map, key, 0)
-          new_val = safe_binop(op, old_val, val)
-          updated = Map.put(map, key, new_val)
-          setattr_nested(target_expr, updated, env, ctx)
-
-        _ ->
-          {{:exception, "TypeError: object does not support item assignment"}, env, ctx}
-      end
-    else
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-    end
+    Assignments.eval_attr_aug_subscript_assign(target_expr, key_expr, op, val_expr, env, ctx)
   end
 
   def eval({:subscript_assign, _, [name, key_expr, val_expr]}, env, ctx) do
-    with {container, env, ctx} when not is_tuple(container) or elem(container, 0) != :exception <-
-           eval({:var, [line: 1], [name]}, env, ctx),
-         {key, env, ctx} when not is_tuple(key) or elem(key, 0) != :exception <-
-           eval(key_expr, env, ctx),
-         {val, env, ctx} when not is_tuple(val) or elem(val, 0) != :exception <-
-           eval(val_expr, env, ctx) do
-      case container do
-        %{} = map ->
-          updated = Map.put(map, key, val)
-          {val, Env.put_at_source(env, name, updated), ctx}
-
-        {:py_list, reversed, len} when is_integer(key) ->
-          real_idx = if key < 0, do: len + key, else: key
-          updated = {:py_list, List.replace_at(reversed, len - 1 - real_idx, val), len}
-          {val, Env.put_at_source(env, name, updated), ctx}
-
-        list when is_list(list) and is_integer(key) ->
-          updated = List.replace_at(list, key, val)
-          {val, Env.put_at_source(env, name, updated), ctx}
-
-        {:instance, _, _} = inst ->
-          case call_dunder_mut(inst, "__setitem__", [key, val], env, ctx) do
-            {:ok, updated_inst, _return_val, env, ctx} ->
-              {val, Env.put_at_source(env, name, updated_inst), ctx}
-
-            :not_found ->
-              {{:exception,
-                "TypeError: '#{Helpers.py_type(inst)}' object does not support item assignment"},
-               env, ctx}
-          end
-
-        _ ->
-          {{:exception, "TypeError: object does not support item assignment"}, env, ctx}
-      end
-    else
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-    end
+    Assignments.eval_name_subscript_assign(name, key_expr, val_expr, env, ctx)
   end
 
   def eval({:aug_assign, meta, [name, op, expr]}, env, ctx) do
-    var_node = {:var, meta, [name]}
-    binop_node = {:binop, meta, [op, var_node, expr]}
-    eval({:assign, meta, [name, binop_node]}, env, ctx)
+    Bindings.eval_aug_assign(meta, name, op, expr, env, ctx)
   end
 
   def eval({:return, _, [expr]}, env, ctx) do
@@ -676,246 +486,56 @@ defmodule Pyex.Interpreter do
   end
 
   def eval({:if, _, clauses}, env, ctx) do
-    eval_if_clauses(clauses, env, ctx)
+    ControlFlow.eval_if(clauses, env, ctx)
   end
 
   def eval({:while, _, [condition, body, else_body]}, env, ctx) do
-    eval_while(condition, body, else_body, env, ctx)
+    ControlFlow.eval_while(condition, body, else_body, env, ctx)
   end
 
   def eval({:for, _, [var_name, iterable_expr, body, else_body]}, env, ctx) do
-    case eval(iterable_expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {{:generator_error, items, exception_msg}, env, ctx} ->
-        case eval_for(var_name, items, body, else_body, env, ctx) do
-          {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-          {{:returned, _} = signal, env, ctx} -> {signal, env, ctx}
-          {{:break}, env, ctx} -> {{:exception, exception_msg}, env, ctx}
-          {_, env, ctx} -> {{:exception, exception_msg}, env, ctx}
-        end
-
-      {iterable, env, ctx} ->
-        case to_iterable(iterable, env, ctx) do
-          {:ok, items, env, ctx} -> eval_for(var_name, items, body, else_body, env, ctx)
-          {:exception, msg} -> {{:exception, msg}, env, ctx}
-        end
-    end
+    ControlFlow.eval_for(var_name, iterable_expr, body, else_body, env, ctx)
   end
 
   def eval({:import, _, imports}, env, ctx) when is_list(imports) do
-    Enum.reduce_while(imports, {nil, env, ctx}, fn import_spec, {_, env, ctx} ->
-      {module_name, alias_name} =
-        case import_spec do
-          {m, a} -> {m, a}
-          m when is_binary(m) -> {m, nil}
-        end
-
-      bind_as = alias_name || module_name
-
-      case Import.resolve_module(module_name, env, ctx) do
-        {:ok, module_value, ctx} ->
-          {:cont, {nil, Env.put(env, bind_as, module_value), ctx}}
-
-        {:import_error, msg, ctx} ->
-          {:halt, {{:exception, msg}, env, ctx}}
-
-        {:unknown_module, ctx} ->
-          {:halt,
-           {{:exception,
-             "ImportError: no module named '#{module_name}'#{Import.import_hint(module_name)}"},
-            env, ctx}}
-      end
-    end)
+    Import.eval_import(imports, env, ctx)
   end
 
   def eval({:from_import, _, [module_name, names]}, env, ctx) do
-    case Import.resolve_module(module_name, env, ctx) do
-      {:ok, module_value, ctx} when is_map(module_value) ->
-        Enum.reduce_while(names, {nil, env, ctx}, fn {name, alias_name}, {_, env, ctx} ->
-          bind_as = alias_name || name
-
-          case Map.fetch(module_value, name) do
-            {:ok, value} ->
-              {:cont, {nil, Env.put(env, bind_as, value), ctx}}
-
-            :error ->
-              {:halt,
-               {{:exception, "ImportError: cannot import name '#{name}' from '#{module_name}'"},
-                env, ctx}}
-          end
-        end)
-
-      {:import_error, msg, ctx} ->
-        {{:exception, msg}, env, ctx}
-
-      {:unknown_module, ctx} ->
-        {{:exception,
-          "ImportError: no module named '#{module_name}'#{Import.import_hint(module_name)}"}, env,
-         ctx}
-    end
+    Import.eval_from_import(module_name, names, env, ctx)
   end
 
   def eval({:try, _, [body, handlers, else_body, finally_body]}, env, ctx) do
-    eval_try(body, handlers, else_body, finally_body, env, ctx)
+    ControlFlow.eval_try(body, handlers, else_body, finally_body, env, ctx)
   end
 
-  def eval({:raise, _meta, [nil]}, env, ctx) do
-    case Env.get(env, "__current_exception__") do
-      {:ok, msg} ->
-        {{:exception, msg}, env, ctx}
-
-      :undefined ->
-        {{:exception, "RuntimeError: No active exception to re-raise"}, env, ctx}
-    end
+  def eval({:raise, meta, [nil]}, env, ctx) do
+    Exceptions.eval_raise(nil, meta, env, ctx)
   end
 
   def eval({:raise, meta, [expr]}, env, ctx) do
-    case expr do
-      {:call, _, [{:var, _, [exc_name]}, args]} when is_list(args) ->
-        eval_raise_exc_class(exc_name, args, meta, env, ctx)
-
-      {:call, _, [{:var, _, [exc_name]}, args, _kwargs]} when is_list(args) ->
-        eval_raise_exc_class(exc_name, args, meta, env, ctx)
-
-      {:var, _, [exc_name]} ->
-        {{:exception, exc_name}, env, ctx}
-
-      _ ->
-        case eval(expr, env, ctx) do
-          {{:exception, _} = signal, _env, _ctx} ->
-            {signal, env, ctx}
-
-          {value, env, ctx} ->
-            msg =
-              case value do
-                msg when is_binary(msg) -> "Exception: #{msg}"
-                _ -> "Exception: #{inspect(value)}"
-              end
-
-            {{:exception, msg}, env, ctx}
-        end
-    end
+    Exceptions.eval_raise(expr, meta, env, ctx)
   end
 
   def eval({:assert, _, [condition, msg_expr]}, env, ctx) do
-    case eval(condition, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {value, env, ctx} ->
-        {taken, env, ctx} = eval_truthy(value, env, ctx)
-
-        if taken do
-          {nil, env, ctx}
-        else
-          case msg_expr do
-            nil ->
-              {{:exception, "AssertionError"}, env, ctx}
-
-            _ ->
-              case eval(msg_expr, env, ctx) do
-                {{:exception, _} = signal, env, ctx} ->
-                  {signal, env, ctx}
-
-                {msg_val, env, ctx} ->
-                  {{:exception, "AssertionError: #{Helpers.py_str(msg_val)}"}, env, ctx}
-              end
-          end
-        end
-    end
+    Statements.eval_assert(condition, msg_expr, env, ctx)
   end
 
   def eval({:del, _, [:var, var_name]}, env, ctx) do
-    {nil, Env.delete(env, var_name), ctx}
+    Statements.eval_del_var(var_name, env, ctx)
   end
 
   def eval({:del, _, [:subscript, var_name, key_expr]}, env, ctx) do
-    case Env.get(env, var_name) do
-      {:ok, obj} when is_map(obj) ->
-        case eval(key_expr, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {key, env, ctx} ->
-            {nil, Env.put(env, var_name, Map.delete(obj, key)), ctx}
-        end
-
-      {:ok, {:py_list, reversed, len}} ->
-        case eval(key_expr, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {idx, env, ctx} when is_integer(idx) ->
-            real_idx = if idx < 0, do: len + idx, else: idx
-            new_reversed = List.delete_at(reversed, len - 1 - real_idx)
-            {nil, Env.put(env, var_name, {:py_list, new_reversed, len - 1}), ctx}
-
-          {_, env, ctx} ->
-            {{:exception, "TypeError: list indices must be integers"}, env, ctx}
-        end
-
-      {:ok, obj} when is_list(obj) ->
-        case eval(key_expr, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {idx, env, ctx} when is_integer(idx) ->
-            {nil, Env.put(env, var_name, List.delete_at(obj, idx)), ctx}
-
-          {_, env, ctx} ->
-            {{:exception, "TypeError: list indices must be integers"}, env, ctx}
-        end
-
-      {:ok, _} ->
-        {{:exception, "TypeError: object does not support item deletion"}, env, ctx}
-
-      :undefined ->
-        {{:exception, "NameError: name '#{var_name}' is not defined"}, env, ctx}
-    end
+    Statements.eval_del_subscript(var_name, key_expr, env, ctx)
   end
 
   def eval({:aug_subscript_assign, _, [var_name, key_expr, op, val_expr]}, env, ctx) do
-    case Env.get(env, var_name) do
-      {:ok, obj} ->
-        case eval(key_expr, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {key, env, ctx} ->
-            case eval(val_expr, env, ctx) do
-              {{:exception, _} = signal, env, ctx} ->
-                {signal, env, ctx}
-
-              {val, env, ctx} ->
-                current = get_subscript_value(obj, key)
-
-                case current do
-                  {:exception, msg} ->
-                    {{:exception, msg}, env, ctx}
-
-                  current_val ->
-                    case safe_binop(op, current_val, val) do
-                      {:exception, msg} ->
-                        {{:exception, msg}, env, ctx}
-
-                      new_val ->
-                        new_obj = set_subscript_value(obj, key, new_val)
-                        {new_val, Env.put_at_source(env, var_name, new_obj), ctx}
-                    end
-                end
-            end
-        end
-
-      :undefined ->
-        {{:exception, "NameError: name '#{var_name}' is not defined"}, env, ctx}
-    end
+    Assignments.eval_name_aug_subscript_assign(var_name, key_expr, op, val_expr, env, ctx)
   end
 
-  def eval({:pass, _, _}, env, ctx), do: {nil, env, ctx}
-  def eval({:break, _, _}, env, ctx), do: {{:break}, env, ctx}
-  def eval({:continue, _, _}, env, ctx), do: {{:continue}, env, ctx}
+  def eval({:pass, _, _}, env, ctx), do: Statements.eval_pass(env, ctx)
+  def eval({:break, _, _}, env, ctx), do: Statements.eval_break(env, ctx)
+  def eval({:continue, _, _}, env, ctx), do: Statements.eval_continue(env, ctx)
 
   def eval({:expr, _, [expr]}, env, ctx) do
     eval(expr, env, ctx)
@@ -926,73 +546,11 @@ defmodule Pyex.Interpreter do
         env,
         ctx
       ) do
-    case eval(func_expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {func, env, ctx} ->
-        case eval_call_args(arg_exprs, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {args, kwargs, env, ctx} ->
-            case call_function(func, args, kwargs, env, ctx) do
-              {:mutate, new_object, return_value, new_env, ctx} ->
-                {return_value, Env.put_at_source(new_env, var_name, new_object), ctx}
-
-              {:mutate, new_object, return_value, ctx} ->
-                {return_value, Env.put_at_source(env, var_name, new_object), ctx}
-
-              {{:exception, _} = signal, env, ctx} ->
-                {signal, env, ctx}
-
-              {result, env, ctx, _updated_func} ->
-                env = maybe_update_instance_var(env, var_name)
-                {result, env, ctx}
-
-              {result, env, ctx} ->
-                env = maybe_update_instance_var(env, var_name)
-                {result, env, ctx}
-            end
-        end
-    end
+    Calls.eval_var_attr_call(func_expr, arg_exprs, var_name, env, ctx)
   end
 
   def eval({:call, _, [func_expr, arg_exprs]}, env, ctx) do
-    case eval(func_expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {func, env, ctx} ->
-        case eval_call_args(arg_exprs, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {args, kwargs, env, ctx} ->
-            case call_function(func, args, kwargs, env, ctx) do
-              {:mutate, new_object, return_value, new_env, ctx} ->
-                # For builtins like setattr, the first arg_expr is the target
-                target = mutate_target_expr(func_expr, arg_exprs)
-                new_env = mutate_target(target, new_object, new_env, ctx)
-                {return_value, new_env, ctx}
-
-              {:mutate, new_object, return_value, ctx} ->
-                target = mutate_target_expr(func_expr, arg_exprs)
-                env = mutate_target(target, new_object, env, ctx)
-                {return_value, env, ctx}
-
-              {{:exception, _} = signal, env, ctx} ->
-                {signal, env, ctx}
-
-              {result, env, ctx, updated_func} ->
-                env = Helpers.rebind_var(env, func_expr, updated_func)
-                {result, env, ctx}
-
-              {result, env, ctx} ->
-                {result, env, ctx}
-            end
-        end
-    end
+    Calls.eval_call_expr(func_expr, arg_exprs, env, ctx)
   end
 
   def eval({:getattr, _, [expr, attr]}, env, ctx) do
@@ -1008,7 +566,7 @@ defmodule Pyex.Interpreter do
                 {value, env, ctx}
 
               :error ->
-                case resolve_class_attr_with_owner(class, attr) do
+                case ClassLookup.resolve_class_attr_with_owner(class, attr) do
                   {:ok, {:function, _, _, _, _} = func, owner_class} ->
                     {{:bound_method, object, func, owner_class}, env, ctx}
 
@@ -1034,7 +592,7 @@ defmodule Pyex.Interpreter do
           {:super_proxy, instance, bases} ->
             result =
               Enum.find_value(bases, :error, fn base ->
-                case resolve_class_attr_with_owner(base, attr) do
+                case ClassLookup.resolve_class_attr_with_owner(base, attr) do
                   {:ok, _, _} = found -> found
                   :error -> nil
                 end
@@ -1055,7 +613,7 @@ defmodule Pyex.Interpreter do
           {:class, class_name, _, class_attrs} = class_val ->
             case Map.get(class_attrs, attr) do
               nil ->
-                case resolve_class_attr_with_owner(class_val, attr) do
+                case ClassLookup.resolve_class_attr_with_owner(class_val, attr) do
                   {:ok, {:function, _, _, _, _} = func, _owner} ->
                     {{:bound_method, class_val, func}, env, ctx}
 
@@ -1111,6 +669,29 @@ defmodule Pyex.Interpreter do
     end
   end
 
+  def eval({:subscript, _, [{:var, _, [var_name]} = expr, key_expr]}, env, ctx) do
+    case eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {object, env, ctx} ->
+        case eval(key_expr, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {key, env, ctx} ->
+            case eval_subscript(object, key, env, ctx) do
+              {:defaultdict_auto_insert, default_val, new_obj, env, ctx} ->
+                env = Env.put_at_source(env, var_name, new_obj)
+                {default_val, env, ctx}
+
+              other ->
+                other
+            end
+        end
+    end
+  end
+
   def eval({:subscript, _, [expr, key_expr]}, env, ctx) do
     case eval(expr, env, ctx) do
       {{:exception, _} = signal, env, ctx} ->
@@ -1145,11 +726,7 @@ defmodule Pyex.Interpreter do
   end
 
   def eval({:tuple, _, [elements]}, env, ctx) do
-    case eval_list(elements, env, ctx) do
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-      # eval_list returns reversed order, so reverse back for tuples
-      {values, env, ctx} -> {{:tuple, Enum.reverse(values)}, env, ctx}
-    end
+    Collections.eval_tuple(elements, env, ctx)
   end
 
   def eval({:ternary, _, [condition, true_expr, false_expr]}, env, ctx) do
@@ -1169,51 +746,31 @@ defmodule Pyex.Interpreter do
   end
 
   def eval({:list_comp, _, [expr, clauses]}, env, ctx) do
-    case eval_comp_clauses(:list, expr, clauses, [], env, ctx) do
-      {result, env, ctx} when is_list(result) ->
-        items = Enum.reverse(result)
-        {{:py_list, Enum.reverse(items), length(items)}, env, ctx}
-
-      other ->
-        other
-    end
+    Collections.eval_list_comp(expr, clauses, env, ctx)
   end
 
   def eval({:gen_expr, _, [expr, clauses]}, env, ctx) do
-    case eval_comp_clauses(:list, expr, clauses, [], env, ctx) do
-      {result, env, ctx} when is_list(result) -> {{:generator, Enum.reverse(result)}, env, ctx}
-      other -> other
-    end
+    Collections.eval_gen_expr(expr, clauses, env, ctx)
   end
 
   def eval({:dict_comp, _, [key_expr, val_expr, clauses]}, env, ctx) do
-    eval_comp_clauses(:dict, {key_expr, val_expr}, clauses, %{}, env, ctx)
+    Collections.eval_dict_comp(key_expr, val_expr, clauses, env, ctx)
   end
 
   def eval({:set_comp, _, [expr, clauses]}, env, ctx) do
-    case eval_comp_clauses(:set, expr, clauses, MapSet.new(), env, ctx) do
-      {{:exception, _}, _, _} = result -> result
-      {set, env, ctx} -> {{:set, set}, env, ctx}
-    end
+    Collections.eval_set_comp(expr, clauses, env, ctx)
   end
 
   def eval({:list, _, [elements]}, env, ctx) do
-    case eval_list(elements, env, ctx) do
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-      # Store in reverse order for O(1) append
-      {values, env, ctx} -> {{:py_list, values, length(values)}, env, ctx}
-    end
+    Collections.eval_list_literal(elements, env, ctx)
   end
 
   def eval({:dict, _, [entries]}, env, ctx) do
-    eval_dict(entries, env, ctx)
+    Collections.eval_dict_literal(entries, env, ctx)
   end
 
   def eval({:set, _, [elements]}, env, ctx) do
-    case eval_list(elements, env, ctx) do
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-      {values, env, ctx} -> {{:set, MapSet.new(values)}, env, ctx}
-    end
+    Collections.eval_set_literal(elements, env, ctx)
   end
 
   def eval({:binop, _, [op, left, right]}, env, ctx) when op in [:and, :or] do
@@ -1269,7 +826,7 @@ defmodule Pyex.Interpreter do
         {-val, env, ctx}
 
       {{:instance, _, _} = inst, env, ctx} ->
-        case call_dunder(inst, "__neg__", [], env, ctx) do
+        case Dunder.call_dunder(inst, "__neg__", [], env, ctx) do
           {:ok, result, env, ctx} ->
             {result, env, ctx}
 
@@ -1293,7 +850,7 @@ defmodule Pyex.Interpreter do
         {val, env, ctx}
 
       {{:instance, _, _} = inst, env, ctx} ->
-        case call_dunder(inst, "__pos__", [], env, ctx) do
+        case Dunder.call_dunder(inst, "__pos__", [], env, ctx) do
           {:ok, result, env, ctx} ->
             {result, env, ctx}
 
@@ -1317,7 +874,7 @@ defmodule Pyex.Interpreter do
         {bnot(val), env, ctx}
 
       {{:instance, _, _} = inst, env, ctx} ->
-        case call_dunder(inst, "__invert__", [], env, ctx) do
+        case Dunder.call_dunder(inst, "__invert__", [], env, ctx) do
           {:ok, result, env, ctx} ->
             {result, env, ctx}
 
@@ -1405,15 +962,6 @@ defmodule Pyex.Interpreter do
     %{ctx | profile: %{line_counts: %{}, call_counts: %{}, call: %{}}}
   end
 
-  @spec profile_record_call(Ctx.t(), String.t(), float()) :: Ctx.t()
-  defp profile_record_call(%Ctx{profile: nil} = ctx, _name, _elapsed_ms), do: ctx
-
-  defp profile_record_call(%Ctx{profile: profile} = ctx, name, elapsed_ms) do
-    call_counts = Map.update(profile.call_counts, name, 1, &(&1 + 1))
-    call = Map.update(profile.call, name, elapsed_ms, &(&1 + elapsed_ms))
-    %{ctx | profile: %{profile | call_counts: call_counts, call: call}}
-  end
-
   @spec track_line(Parser.ast_node(), Ctx.t()) :: Ctx.t()
   defp track_line({_tag, meta, _children}, ctx) when is_list(meta) do
     case Keyword.get(meta, :line) do
@@ -1436,8 +984,9 @@ defmodule Pyex.Interpreter do
   defp track_line(_, ctx), do: ctx
 
   @primitive_type_names ~w(str int float bool list dict tuple set)
+  @doc false
   @spec resolve_annotation(String.t(), Env.t()) :: String.t() | pyvalue()
-  defp resolve_annotation(type_str, env) do
+  def resolve_annotation(type_str, env) do
     if type_str in @primitive_type_names or String.contains?(type_str, "[") do
       type_str
     else
@@ -1468,312 +1017,11 @@ defmodule Pyex.Interpreter do
   def call_function(func, args, kwargs, env, ctx)
 
   def call_function({:function, name, params, body, closure_env} = func, args, kwargs, env, ctx) do
-    if ctx.call_depth >= ctx.max_call_depth do
-      {{:exception, "RecursionError: maximum recursion depth exceeded"}, env, ctx}
-    else
-      ctx = %{ctx | call_depth: ctx.call_depth + 1}
-
-      fresh_closure = Env.put_global_scope(closure_env, Env.global_scope(env))
-      base_env = Env.push_scope(Env.put(fresh_closure, name, func))
-
-      case bind_params(params, args, kwargs, base_env, ctx) do
-        {:exception, msg, ctx} ->
-          ctx = %{ctx | call_depth: ctx.call_depth - 1}
-          {{:exception, msg}, env, ctx}
-
-        {call_env, ctx} ->
-          t0 = if ctx.profile, do: System.monotonic_time(:microsecond)
-
-          result =
-            if contains_yield?(body) do
-              case ctx.generator_mode do
-                :defer ->
-                  gen_ctx = %{ctx | generator_mode: :defer_inner}
-
-                  case eval_statements(body, call_env, gen_ctx) do
-                    {{:yielded, val, cont}, gen_env, gen_ctx} ->
-                      ctx = %{
-                        ctx
-                        | compute: gen_ctx.compute,
-                          compute_started_at: gen_ctx.compute_started_at,
-                          event_count: gen_ctx.event_count,
-                          file_ops: gen_ctx.file_ops
-                      }
-
-                      {{:generator_suspended, val, cont, gen_env}, env, ctx}
-
-                    {{:exception, _} = signal, _post_env, gen_ctx} ->
-                      ctx = %{
-                        ctx
-                        | compute: gen_ctx.compute,
-                          compute_started_at: gen_ctx.compute_started_at,
-                          event_count: gen_ctx.event_count,
-                          file_ops: gen_ctx.file_ops
-                      }
-
-                      {signal, env, ctx}
-
-                    {_, _post_env, gen_ctx} ->
-                      ctx = %{
-                        ctx
-                        | compute: gen_ctx.compute,
-                          compute_started_at: gen_ctx.compute_started_at,
-                          event_count: gen_ctx.event_count,
-                          file_ops: gen_ctx.file_ops
-                      }
-
-                      {{:generator, []}, env, ctx}
-                  end
-
-                _ ->
-                  prev_acc = ctx.generator_acc
-                  gen_ctx = %{ctx | generator_mode: :accumulate, generator_acc: []}
-                  {result, _post_call_env, gen_ctx} = eval_statements(body, call_env, gen_ctx)
-                  yields = Enum.reverse(gen_ctx.generator_acc || [])
-
-                  ctx = %{
-                    ctx
-                    | compute: gen_ctx.compute,
-                      compute_started_at: gen_ctx.compute_started_at,
-                      generator_mode: ctx.generator_mode,
-                      generator_acc: prev_acc,
-                      event_count: gen_ctx.event_count,
-                      file_ops: gen_ctx.file_ops
-                  }
-
-                  case result do
-                    {:exception, "TimeoutError:" <> _ = msg} ->
-                      {{:exception, msg}, env, ctx}
-
-                    {:exception, msg} ->
-                      {{:generator_error, yields, msg}, env, ctx}
-
-                    _ ->
-                      {{:generator, yields}, env, ctx}
-                  end
-              end
-            else
-              {result, post_call_env, ctx} = eval_statements(body, call_env, ctx)
-              env = Env.propagate_scopes(env, fresh_closure, post_call_env)
-              return_val = Helpers.unwrap(result)
-
-              if Helpers.has_scope_declarations?(post_call_env) do
-                return_val = Helpers.refresh_closure(return_val, post_call_env)
-                updated_func = Helpers.refresh_closure(func, post_call_env)
-                {return_val, env, ctx, updated_func}
-              else
-                updated_func = Helpers.update_closure_env(func, post_call_env)
-                {return_val, env, ctx, updated_func}
-              end
-            end
-
-          result =
-            if t0 do
-              elapsed_us = System.monotonic_time(:microsecond) - t0
-              elapsed_ms = elapsed_us / 1000.0
-              update_profile_in_result(result, name, elapsed_ms)
-            else
-              result
-            end
-
-          decrement_depth(result)
-      end
-    end
+    Invocation.call_user_function(func, name, params, body, closure_env, args, kwargs, env, ctx)
   end
 
   def call_function({:builtin, fun}, args, _kwargs, env, ctx) do
-    result =
-      try do
-        fun.(args)
-      rescue
-        FunctionClauseError ->
-          {:exception, "TypeError: invalid arguments"}
-
-        e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
-          {:exception, "TypeError: #{Exception.message(e)}"}
-      end
-
-    case result do
-      {:ctx_call, ctx_fun} ->
-        ctx_fun.(env, ctx)
-
-      {:io_call, io_fun} ->
-        ctx = Ctx.pause_compute(ctx)
-        {result, env, ctx} = io_fun.(env, ctx)
-        ctx = Ctx.resume_compute(ctx)
-        {result, env, ctx}
-
-      {:mutate, new_object, return_value} ->
-        {:mutate, new_object, return_value, ctx}
-
-      {:method_call, instance, func, method_args} ->
-        call_method(instance, func, method_args, %{}, env, ctx)
-
-      {:dunder_call, instance, dunder_name, dunder_args} ->
-        case call_dunder(instance, dunder_name, dunder_args, env, ctx) do
-          {:ok, result, env, ctx} ->
-            {result, env, ctx}
-
-          :not_found ->
-            case dunder_str_fallback(instance, dunder_name, env, ctx) do
-              {:ok, result, env, ctx} -> {result, env, ctx}
-              :error -> {{:exception, "TypeError: object has no #{dunder_name}"}, env, ctx}
-            end
-        end
-
-      {:iter_to_list, val} ->
-        case to_iterable(val, env, ctx) do
-          {:ok, items, env, ctx} -> {items, env, ctx}
-          {:exception, _} = signal -> {signal, env, ctx}
-        end
-
-      {:iter_to_tuple, val} ->
-        case to_iterable(val, env, ctx) do
-          {:ok, items, env, ctx} -> {{:tuple, items}, env, ctx}
-          {:exception, _} = signal -> {signal, env, ctx}
-        end
-
-      {:iter_to_set, val} ->
-        case to_iterable(val, env, ctx) do
-          {:ok, items, env, ctx} -> {{:set, MapSet.new(items)}, env, ctx}
-          {:exception, _} = signal -> {signal, env, ctx}
-        end
-
-      {:iter_to_frozenset, val} ->
-        case to_iterable(val, env, ctx) do
-          {:ok, items, env, ctx} -> {{:frozenset, MapSet.new(items)}, env, ctx}
-          {:exception, _} = signal -> {signal, env, ctx}
-        end
-
-      {:iter_instance, inst} ->
-        case call_dunder(inst, "__iter__", [], env, ctx) do
-          {:ok, {:instance, _, _} = iter_inst, env, ctx} ->
-            {token, ctx} = Ctx.new_instance_iterator(ctx, iter_inst)
-            {token, env, ctx}
-
-          {:ok, {:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {:ok, other, env, ctx} ->
-            case Builtins.materialize_iterable(other) do
-              {:ok, items} ->
-                {token, ctx} = Ctx.new_iterator(ctx, items)
-                {token, env, ctx}
-
-              {:pass, iter} ->
-                {iter, env, ctx}
-
-              :error ->
-                {{:exception, "TypeError: iter() returned non-iterator"}, env, ctx}
-            end
-
-          :not_found ->
-            {{:exception, "TypeError: '#{Helpers.py_type(inst)}' object is not iterable"}, env,
-             ctx}
-        end
-
-      {:make_iter, items} ->
-        {token, ctx} = Ctx.new_iterator(ctx, items)
-        {token, env, ctx}
-
-      {:iter_next, id} ->
-        case Ctx.iter_next(ctx, id) do
-          {:ok, item, ctx} -> {item, env, ctx}
-          :exhausted -> {{:exception, "StopIteration"}, env, ctx}
-          {:instance, inst} -> eval_instance_next(inst, id, :no_default, env, ctx)
-        end
-
-      {:iter_next_default, id, default} ->
-        case Ctx.iter_next(ctx, id) do
-          {:ok, item, ctx} -> {item, env, ctx}
-          :exhausted -> {default, env, ctx}
-          {:instance, inst} -> eval_instance_next(inst, id, {:default, default}, env, ctx)
-        end
-
-      {:next_instance_iter, id, default_opt} ->
-        case Ctx.iter_next(ctx, id) do
-          {:instance, inst} ->
-            eval_instance_next(inst, id, default_opt, env, ctx)
-
-          {:ok, item, ctx} ->
-            {item, env, ctx}
-
-          :exhausted ->
-            case default_opt do
-              {:default, default} -> {default, env, ctx}
-              :no_default -> {{:exception, "StopIteration"}, env, ctx}
-            end
-        end
-
-      {:next_with_default, inst, default} ->
-        case call_dunder_mut(inst, "__next__", [], env, ctx) do
-          {:ok, _new_inst, {:exception, "StopIteration" <> _}, env, ctx} ->
-            {default, env, ctx}
-
-          {:ok, _new_inst, {:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {:ok, _new_inst, value, env, ctx} ->
-            {value, env, ctx}
-
-          :not_found ->
-            {{:exception, "TypeError: object has no __next__"}, env, ctx}
-        end
-
-      {:iter_sum, val} ->
-        case to_iterable(val, env, ctx) do
-          {:ok, items, env, ctx} ->
-            if Enum.all?(items, &is_number/1) do
-              {Enum.sum(items), env, ctx}
-            else
-              {{:exception,
-                "TypeError: unsupported operand type(s) for +: sum() requires numeric items"},
-               env, ctx}
-            end
-
-          {:exception, _} = signal ->
-            {signal, env, ctx}
-        end
-
-      {:print_call, print_args, sep, end_str} ->
-        eval_print_call(print_args, sep, end_str, env, ctx)
-
-      {:map_call, func, list} ->
-        Iteration.eval_map_call(func, list, env, ctx)
-
-      {:filter_call, func, list} ->
-        Iteration.eval_filter_call(func, list, env, ctx)
-
-      {:super_call} ->
-        eval_super(env, ctx)
-
-      {:starmap_call, func, items} ->
-        Iteration.eval_starmap(func, items, env, ctx)
-
-      {:takewhile_call, predicate, items} ->
-        Iteration.eval_takewhile(predicate, items, env, ctx)
-
-      {:dropwhile_call, predicate, items} ->
-        Iteration.eval_dropwhile(predicate, items, env, ctx)
-
-      {:filterfalse_call, predicate, items} ->
-        Iteration.eval_filterfalse(predicate, items, env, ctx)
-
-      {:unittest_main} ->
-        Unittest.eval_unittest_main(env, ctx)
-
-      {:assert_raises, exc_type} ->
-        {{:assert_raises, exc_type}, env, ctx}
-
-      {:register_route, _method, _path, _handler} = signal ->
-        {signal, env, ctx}
-
-      {:exception, _msg} = signal ->
-        {signal, env, ctx}
-
-      value ->
-        {value, env, ctx}
-    end
+    Invocation.call_builtin(fun, args, env, ctx)
   end
 
   def call_function({:builtin_type, _name, fun}, args, kwargs, env, ctx) do
@@ -1781,75 +1029,7 @@ defmodule Pyex.Interpreter do
   end
 
   def call_function({:builtin_kw, fun}, args, kwargs, env, ctx) do
-    result =
-      try do
-        fun.(args, kwargs)
-      rescue
-        FunctionClauseError ->
-          {:exception, "TypeError: invalid arguments"}
-
-        e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
-          {:exception, "TypeError: #{Exception.message(e)}"}
-      end
-
-    case result do
-      {:exception, _msg} = signal ->
-        {signal, env, ctx}
-
-      {:mutate, new_object, return_value} ->
-        {:mutate, new_object, return_value, ctx}
-
-      {:io_call, io_fun} ->
-        ctx = Ctx.pause_compute(ctx)
-        {result, env, ctx} = io_fun.(env, ctx)
-        ctx = Ctx.resume_compute(ctx)
-        {result, env, ctx}
-
-      {:print_call, print_args, sep, end_str} ->
-        eval_print_call(print_args, sep, end_str, env, ctx)
-
-      {:sort_call, items, key_fn, reverse} ->
-        eval_sort(items, key_fn, reverse, env, ctx)
-
-      {:list_sort_call, items, key_fn, reverse} ->
-        case eval_sort(items, key_fn, reverse, env, ctx) do
-          {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-          {sorted, env, ctx} -> {{:mutate, sorted, nil}, env, ctx}
-        end
-
-      {:iter_sorted, val, key_fn, reverse} ->
-        case to_iterable(val, env, ctx) do
-          {:ok, items, env, ctx} -> eval_sort(items, key_fn, reverse, env, ctx)
-          {:exception, _} = signal -> {signal, env, ctx}
-        end
-
-      {:min_call, items, key_fn} ->
-        eval_minmax(items, key_fn, :min, env, ctx)
-
-      {:max_call, items, key_fn} ->
-        eval_minmax(items, key_fn, :max, env, ctx)
-
-      {:accumulate_call, items, func} ->
-        Iteration.eval_accumulate(items, func, env, ctx)
-
-      {:groupby_call, items, key_func} ->
-        Iteration.eval_groupby(items, key_func, env, ctx)
-
-      {:starmap_call, func, items} ->
-        Iteration.eval_starmap(func, items, env, ctx)
-
-      {:takewhile_call, predicate, items} ->
-        Iteration.eval_takewhile(predicate, items, env, ctx)
-
-      {:dropwhile_call, predicate, items} ->
-        Iteration.eval_dropwhile(predicate, items, env, ctx)
-
-      {:filterfalse_call, predicate, items} ->
-        Iteration.eval_filterfalse(predicate, items, env, ctx)
-
-      result ->
-        {result, env, ctx}
-    end
+    Invocation.call_builtin_kw(fun, args, kwargs, env, ctx)
   end
 
   def call_function(
@@ -1859,7 +1039,7 @@ defmodule Pyex.Interpreter do
         env,
         ctx
       ) do
-    call_bound_method(instance, func, defining_class, args, kwargs, env, ctx)
+    Invocation.call_bound_method(instance, func, defining_class, args, kwargs, env, ctx)
   end
 
   def call_function(
@@ -1869,7 +1049,7 @@ defmodule Pyex.Interpreter do
         env,
         ctx
       ) do
-    call_bound_method(instance, func, nil, args, kwargs, env, ctx)
+    Invocation.call_bound_method(instance, func, nil, args, kwargs, env, ctx)
   end
 
   def call_function(
@@ -1879,16 +1059,7 @@ defmodule Pyex.Interpreter do
         env,
         ctx
       ) do
-    case fun.([instance | args], kwargs) do
-      {:exception, _} = signal ->
-        {signal, env, ctx}
-
-      {:mutate, new_obj, return_val, new_ctx} ->
-        {:mutate, new_obj, return_val, new_ctx}
-
-      result ->
-        {result, env, ctx}
-    end
+    Invocation.call_bound_builtin_kw(instance, fun, args, kwargs, env, ctx)
   end
 
   def call_function(
@@ -1898,231 +1069,26 @@ defmodule Pyex.Interpreter do
         env,
         ctx
       ) do
-    case fun.([instance | args]) do
-      {:exception, _} = signal ->
-        {signal, env, ctx}
-
-      result ->
-        {result, env, ctx}
-    end
+    Invocation.call_bound_builtin(instance, fun, args, env, ctx)
   end
 
   def call_function({:class, name, _bases, _class_attrs} = class, args, kwargs, env, ctx) do
-    instance = {:instance, class, %{}}
-
-    case resolve_class_attr_with_owner(class, "__init__") do
-      {:ok, {:function, init_name, params, body, closure_env}, defining_class} ->
-        init_args = [instance | args]
-        fresh_closure = Env.put_global_scope(closure_env, Env.global_scope(env))
-        init_fn = {:function, init_name, params, body, closure_env}
-        base_env = Env.push_scope(Env.put(fresh_closure, init_name, init_fn))
-        base_env = Env.put(base_env, "__class__", defining_class)
-
-        case bind_params(params, init_args, kwargs, base_env, ctx) do
-          {:exception, msg, ctx} ->
-            {{:exception, msg}, env, ctx}
-
-          {call_env, ctx} ->
-            {result, post_call_env, ctx} = eval_statements(body, call_env, ctx)
-            env = Env.propagate_scopes(env, fresh_closure, post_call_env)
-
-            case result do
-              {:exception, _} = signal ->
-                {signal, env, ctx}
-
-              _ ->
-                final_self =
-                  case Env.get(post_call_env, "self") do
-                    {:ok, {:instance, _, _} = updated} -> updated
-                    _ -> instance
-                  end
-
-                {final_self, env, ctx}
-            end
-        end
-
-      {:ok, {:builtin_kw, fun}, _defining_class} ->
-        case fun.([instance | args], kwargs) do
-          {:instance, _, _} = updated_instance ->
-            {updated_instance, env, ctx}
-
-          {:exception, _} = signal ->
-            {signal, env, ctx}
-        end
-
-      :error ->
-        if args == [] do
-          {instance, env, ctx}
-        else
-          {{:exception, "TypeError: #{name}() takes 0 arguments but #{length(args)} were given"},
-           env, ctx}
-        end
-    end
+    Invocation.call_class(class, name, args, kwargs, env, ctx)
   end
 
   def call_function({:instance, {:class, _, _, _} = class, _} = instance, args, kwargs, env, ctx) do
-    case resolve_class_attr(class, "__call__") do
-      {:ok, {:function, _, _, _, _} = func} ->
-        call_function({:bound_method, instance, func}, args, kwargs, env, ctx)
-
-      _ ->
-        {{:exception, "TypeError: '#{Helpers.py_type(instance)}' object is not callable"}, env,
-         ctx}
-    end
+    Invocation.call_callable_instance(instance, class, args, kwargs, env, ctx)
   end
 
   def call_function(val, _args, _kwargs, env, ctx) do
     {{:exception, "TypeError: '#{Helpers.py_type(val)}' object is not callable"}, env, ctx}
   end
 
-  @spec update_profile_in_result(call_result(), String.t(), float()) :: call_result()
-  defp update_profile_in_result({val, env, ctx}, name, elapsed_ms) do
-    {val, env, profile_record_call(ctx, name, elapsed_ms)}
-  end
-
-  defp update_profile_in_result({val, env, ctx, extra}, name, elapsed_ms) do
-    {val, env, profile_record_call(ctx, name, elapsed_ms), extra}
-  end
-
-  @spec call_bound_method(
-          pyvalue(),
-          pyvalue(),
-          pyvalue() | nil,
-          [pyvalue()],
-          %{optional(String.t()) => pyvalue()},
-          Env.t(),
-          Ctx.t()
-        ) :: call_result()
-  defp call_bound_method(
-         instance,
-         {:function, fname, params, body, closure_env},
-         defining_class,
-         args,
-         kwargs,
-         env,
-         ctx
-       ) do
-    method_args = [instance | args]
-    fresh_closure = Env.put_global_scope(closure_env, Env.global_scope(env))
-    func = {:function, fname, params, body, closure_env}
-    base_env = Env.push_scope(Env.put(fresh_closure, fname, func))
-
-    base_env =
-      if defining_class, do: Env.put(base_env, "__class__", defining_class), else: base_env
-
-    case bind_params(params, method_args, kwargs, base_env, ctx) do
-      {:exception, msg, ctx} ->
-        {{:exception, msg}, env, ctx}
-
-      {call_env, ctx} ->
-        {result, post_call_env, ctx} = eval_statements(body, call_env, ctx)
-        env = Env.propagate_scopes(env, fresh_closure, post_call_env)
-        return_val = Helpers.unwrap(result)
-
-        updated_self =
-          case Env.get(post_call_env, "self") do
-            {:ok, {:instance, _, _} = updated} -> updated
-            _ -> instance
-          end
-
-        {:mutate, updated_self, return_val, env, ctx}
-    end
-  end
-
-  @spec bind_params(
-          [Parser.param()],
-          [pyvalue()],
-          %{optional(String.t()) => pyvalue()},
-          Env.t(),
-          Ctx.t()
-        ) :: {Env.t(), Ctx.t()} | {:exception, String.t(), Ctx.t()}
-  defp bind_params(params, args, kwargs, env, ctx) do
-    {regular, star_param, dstar_param} = split_variadic_params(params)
-    regular_names = Enum.map(regular, &elem(&1, 0))
-    defaults = Enum.map(regular, &elem(&1, 1))
-    n_regular = length(regular)
-    n_args = length(args)
-
-    has_star = star_param != nil
-    has_dstar = dstar_param != nil
-
-    if n_args > n_regular and not has_star do
-      {:exception,
-       "TypeError: function takes #{n_regular} positional arguments but #{n_args} were given",
-       ctx}
-    else
-      positional = Enum.take(args, n_regular)
-      extra_args = Enum.drop(args, n_regular)
-      padded = positional ++ List.duplicate(:__unset__, max(n_regular - n_args, 0))
-
-      consumed_kwargs =
-        MapSet.new(regular_names)
-        |> MapSet.intersection(MapSet.new(Map.keys(kwargs)))
-
-      result =
-        [regular_names, padded, defaults]
-        |> Enum.zip()
-        |> Enum.reduce_while({env, ctx}, fn {name, arg, default}, {env, ctx} ->
-          cond do
-            arg != :__unset__ ->
-              {:cont, {Env.put(env, name, arg), ctx}}
-
-            Map.has_key?(kwargs, name) ->
-              {:cont, {Env.put(env, name, Map.fetch!(kwargs, name)), ctx}}
-
-            default != nil ->
-              {val, _env, ctx} = eval(default, env, ctx)
-              {:cont, {Env.put(env, name, val), ctx}}
-
-            true ->
-              {:halt, {:exception, "TypeError: missing required argument: '#{name}'", ctx}}
-          end
-        end)
-
-      case result do
-        {:exception, _, _} = err ->
-          err
-
-        {env, ctx} ->
-          env = if has_star, do: Env.put(env, star_name(star_param), extra_args), else: env
-
-          extra_kwargs = Map.drop(kwargs, MapSet.to_list(consumed_kwargs))
-
-          env =
-            if has_dstar, do: Env.put(env, dstar_name(dstar_param), extra_kwargs), else: env
-
-          {env, ctx}
-      end
-    end
-  end
-
-  @spec split_variadic_params([Parser.param()]) ::
-          {[Parser.param()], Parser.param() | nil, Parser.param() | nil}
-  defp split_variadic_params(params) do
-    {regular_rev, star, dstar} =
-      Enum.reduce(params, {[], nil, nil}, fn param, {regular, star, dstar} ->
-        name = elem(param, 0)
-
-        cond do
-          String.starts_with?(name, "**") -> {regular, star, param}
-          String.starts_with?(name, "*") -> {regular, param, dstar}
-          true -> {[param | regular], star, dstar}
-        end
-      end)
-
-    {Enum.reverse(regular_rev), star, dstar}
-  end
-
-  @spec star_name(Parser.param()) :: String.t()
-  defp star_name(param), do: String.trim_leading(elem(param, 0), "*")
-
-  @spec dstar_name(Parser.param()) :: String.t()
-  defp dstar_name(param), do: String.trim_leading(elem(param, 0), "*")
-
+  @doc false
   @spec eval_call_args([Parser.ast_node()], Env.t(), Ctx.t()) ::
           {[pyvalue()], %{optional(String.t()) => pyvalue()}, Env.t(), Ctx.t()}
           | {{:exception, String.t()}, Env.t(), Ctx.t()}
-  defp eval_call_args(arg_exprs, env, ctx) do
+  def eval_call_args(arg_exprs, env, ctx) do
     Enum.reduce_while(arg_exprs, {[], %{}, env, ctx}, fn
       {:kwarg, _, [name, expr]}, {pos, kw, env, ctx} ->
         case eval(expr, env, ctx) do
@@ -2177,9 +1143,10 @@ defmodule Pyex.Interpreter do
     end
   end
 
+  @doc false
   @spec eval_list([Parser.ast_node()], Env.t(), Ctx.t()) ::
           {[pyvalue()], Env.t(), Ctx.t()} | {{:exception, String.t()}, Env.t(), Ctx.t()}
-  defp eval_list(exprs, env, ctx) do
+  def eval_list(exprs, env, ctx) do
     Enum.reduce_while(exprs, {[], env, ctx}, fn expr, {acc, env, ctx} ->
       case eval(expr, env, ctx) do
         {{:exception, _} = signal, env, ctx} -> {:halt, {signal, env, ctx}}
@@ -2190,298 +1157,6 @@ defmodule Pyex.Interpreter do
       # Return reversed list (stored in reverse order for O(1) append)
       {values, env, ctx} when is_list(values) -> {values, env, ctx}
       {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-    end
-  end
-
-  @spec eval_if_clauses(
-          [{Parser.ast_node(), [Parser.ast_node()]} | {:else, [Parser.ast_node()]}],
-          Env.t(),
-          Ctx.t()
-        ) :: eval_result()
-  defp eval_if_clauses([], env, ctx), do: {nil, env, ctx}
-
-  defp eval_if_clauses([{:else, body} | _], env, ctx) do
-    eval_statements(body, env, ctx)
-  end
-
-  defp eval_if_clauses([{condition, body} | rest], env, ctx) do
-    case eval(condition, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {value, env, ctx} ->
-        {taken, env, ctx} = eval_truthy(value, env, ctx)
-
-        if taken do
-          eval_statements(body, env, ctx)
-        else
-          eval_if_clauses(rest, env, ctx)
-        end
-    end
-  end
-
-  @spec eval_while(
-          Parser.ast_node(),
-          [Parser.ast_node()],
-          [Parser.ast_node()] | nil,
-          Env.t(),
-          Ctx.t()
-        ) :: eval_result()
-  defp eval_while(condition, body, else_body, env, ctx) do
-    case Ctx.check_deadline(ctx) do
-      {:exceeded, _} ->
-        {{:exception, "TimeoutError: execution exceeded time limit"}, env, ctx}
-
-      :ok ->
-        eval_while_body(condition, body, else_body, env, ctx)
-    end
-  end
-
-  defp eval_while_body(condition, body, else_body, env, ctx) do
-    case eval(condition, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {value, env, ctx} ->
-        {taken, env, ctx} = eval_truthy(value, env, ctx)
-
-        if taken do
-          case eval_statements(body, env, ctx) do
-            {{:returned, _} = signal, env, ctx} ->
-              {signal, env, ctx}
-
-            {{:break}, env, ctx} ->
-              {nil, env, ctx}
-
-            {{:exception, _} = signal, env, ctx} ->
-              {signal, env, ctx}
-
-            {{:yielded, val, cont}, env, ctx} ->
-              {{:yielded, val, cont ++ [{:cont_while, condition, body, else_body}]}, env, ctx}
-
-            {{:continue}, env, ctx} ->
-              eval_while(condition, body, else_body, env, ctx)
-
-            {_, env, ctx} ->
-              eval_while(condition, body, else_body, env, ctx)
-          end
-        else
-          eval_loop_else(else_body, env, ctx)
-        end
-    end
-  end
-
-  @spec eval_for(
-          String.t() | [String.t()],
-          [pyvalue()],
-          [Parser.ast_node()],
-          [Parser.ast_node()] | nil,
-          Env.t(),
-          Ctx.t()
-        ) :: eval_result()
-  defp eval_for(_var_name, [], _body, else_body, env, ctx) do
-    eval_loop_else(else_body, env, ctx)
-  end
-
-  defp eval_for(var_names, [item | rest], body, else_body, env, ctx)
-       when is_list(var_names) do
-    case Ctx.check_deadline(ctx) do
-      {:exceeded, _} ->
-        {{:exception, "TimeoutError: execution exceeded time limit"}, env, ctx}
-
-      :ok ->
-        ctx = Ctx.record(ctx, :loop, nil)
-
-        case unpack_for_item(var_names, item) do
-          {:ok, bindings} ->
-            env =
-              Enum.reduce(bindings, env, fn {name, val}, env -> Env.smart_put(env, name, val) end)
-
-            case eval_statements(body, env, ctx) do
-              {{:returned, _} = signal, env, ctx} ->
-                {signal, env, ctx}
-
-              {{:break}, env, ctx} ->
-                {nil, env, ctx}
-
-              {{:exception, _} = signal, env, ctx} ->
-                {signal, env, ctx}
-
-              {{:yielded, val, cont}, env, ctx} ->
-                {{:yielded, val, cont ++ [{:cont_for, var_names, rest, body, else_body}]}, env,
-                 ctx}
-
-              {{:continue}, env, ctx} ->
-                eval_for(var_names, rest, body, else_body, env, ctx)
-
-              {_, env, ctx} ->
-                eval_for(var_names, rest, body, else_body, env, ctx)
-            end
-
-          {:exception, msg} ->
-            {{:exception, msg}, env, ctx}
-        end
-    end
-  end
-
-  defp eval_for(var_name, [item | rest], body, else_body, env, ctx) do
-    case Ctx.check_deadline(ctx) do
-      {:exceeded, _} ->
-        {{:exception, "TimeoutError: execution exceeded time limit"}, env, ctx}
-
-      :ok ->
-        ctx = Ctx.record(ctx, :loop, nil)
-        env = Env.smart_put(env, var_name, item)
-
-        case eval_statements(body, env, ctx) do
-          {{:returned, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {{:break}, env, ctx} ->
-            {nil, env, ctx}
-
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {{:yielded, val, cont}, env, ctx} ->
-            {{:yielded, val, cont ++ [{:cont_for, var_name, rest, body, else_body}]}, env, ctx}
-
-          {{:continue}, env, ctx} ->
-            eval_for(var_name, rest, body, else_body, env, ctx)
-
-          {_, env, ctx} ->
-            eval_for(var_name, rest, body, else_body, env, ctx)
-        end
-    end
-  end
-
-  @spec eval_loop_else([Parser.ast_node()] | nil, Env.t(), Ctx.t()) :: eval_result()
-  defp eval_loop_else(nil, env, ctx), do: {nil, env, ctx}
-  defp eval_loop_else(else_body, env, ctx), do: eval_statements(else_body, env, ctx)
-
-  @spec bind_loop_var(String.t() | [String.t()], pyvalue(), Env.t()) ::
-          Env.t() | {:exception, String.t()}
-  defp bind_loop_var(var_name, item, env) when is_binary(var_name) do
-    Env.smart_put(env, var_name, item)
-  end
-
-  defp bind_loop_var(var_names, item, env) when is_list(var_names) do
-    case unpack_for_item(var_names, item) do
-      {:ok, bindings} ->
-        Enum.reduce(bindings, env, fn {name, val}, env -> Env.smart_put(env, name, val) end)
-
-      {:exception, _} = error ->
-        error
-    end
-  end
-
-  @spec unpack_for_item([String.t()], pyvalue()) ::
-          {:ok, [{String.t(), pyvalue()}]} | {:exception, String.t()}
-  defp unpack_for_item(names, {:tuple, items}), do: unpack_for_list(names, items)
-
-  defp unpack_for_item(names, {:py_list, reversed, _}),
-    do: unpack_for_list(names, Enum.reverse(reversed))
-
-  defp unpack_for_item(names, items) when is_list(items), do: unpack_for_list(names, items)
-
-  defp unpack_for_item(_names, val),
-    do: {:exception, "TypeError: cannot unpack non-iterable #{Helpers.py_type(val)} object"}
-
-  @spec unpack_for_list([String.t()], [pyvalue()]) ::
-          {:ok, [{String.t(), pyvalue()}]} | {:exception, String.t()}
-  defp unpack_for_list(names, items) do
-    if length(names) == length(items) do
-      {:ok, Enum.zip(names, items)}
-    else
-      {:exception,
-       "ValueError: not enough values to unpack (expected #{length(names)}, got #{length(items)})"}
-    end
-  end
-
-  @spec eval_try(
-          [Parser.ast_node()],
-          [{String.t() | nil, String.t() | nil, [Parser.ast_node()]}],
-          [Parser.ast_node()] | nil,
-          [Parser.ast_node()] | nil,
-          Env.t(),
-          Ctx.t()
-        ) :: eval_result()
-  defp eval_try(body, handlers, else_body, finally_body, env, ctx) do
-    result =
-      case eval_statements(body, env, ctx) do
-        {{:exception, msg}, body_env, ctx} ->
-          match_handler(handlers, msg, body_env, ctx)
-
-        {val, env, ctx} ->
-          if else_body do
-            eval_statements(else_body, env, ctx)
-          else
-            {val, env, ctx}
-          end
-      end
-
-    run_finally(result, finally_body)
-  end
-
-  @spec run_finally(eval_result(), [Parser.ast_node()] | nil) :: eval_result()
-  defp run_finally(result, nil), do: result
-
-  defp run_finally({original_signal, env, ctx}, finally_body) do
-    case eval_statements(finally_body, env, ctx) do
-      {{:exception, _} = new_signal, env, ctx} ->
-        {new_signal, env, ctx}
-
-      {{:returned, _} = new_signal, env, ctx} ->
-        {new_signal, env, ctx}
-
-      {_val, env, ctx} ->
-        {original_signal, env, ctx}
-    end
-  end
-
-  @spec match_handler(
-          [{String.t() | [String.t()] | nil, String.t() | nil, [Parser.ast_node()]}],
-          String.t(),
-          Env.t(),
-          Ctx.t()
-        ) :: eval_result()
-  defp match_handler([], message, env, ctx) do
-    {{:exception, message}, env, ctx}
-  end
-
-  defp match_handler([{nil, nil, handler_body} | _], message, env, ctx) do
-    env = Env.put(env, "__current_exception__", message)
-    ctx = %{ctx | exception_instance: nil}
-    eval_statements(handler_body, env, ctx)
-  end
-
-  defp match_handler([{exc_names, var_name, handler_body} | rest], message, env, ctx) do
-    matches =
-      case exc_names do
-        names when is_list(names) -> Enum.any?(names, &exception_matches?(&1, message))
-        name -> exception_matches?(name, message)
-      end
-
-    if matches do
-      env = Env.put(env, "__current_exception__", message)
-
-      env =
-        if var_name do
-          exc_value =
-            case ctx.exception_instance do
-              {:instance, _, _} = inst -> inst
-              _ -> synthesize_exception_instance(message)
-            end
-
-          Env.put(env, var_name, exc_value)
-        else
-          env
-        end
-
-      ctx = %{ctx | exception_instance: nil}
-      eval_statements(handler_body, env, ctx)
-    else
-      match_handler(rest, message, env, ctx)
     end
   end
 
@@ -2551,7 +1226,7 @@ defmodule Pyex.Interpreter do
         end
 
       {:instance, _, _} = inst ->
-        case call_dunder(inst, "__getitem__", [key], env, ctx) do
+        case Dunder.call_dunder(inst, "__getitem__", [key], env, ctx) do
           {:ok, result, env, ctx} ->
             {result, env, ctx}
 
@@ -2589,10 +1264,12 @@ defmodule Pyex.Interpreter do
             {signal, env, ctx}
 
           {default_val, env, ctx, _updated_func} ->
-            {default_val, env, ctx}
+            new_dict = Map.put(dict, key, default_val)
+            {:defaultdict_auto_insert, default_val, new_dict, env, ctx}
 
           {default_val, env, ctx} ->
-            {default_val, env, ctx}
+            new_dict = Map.put(dict, key, default_val)
+            {:defaultdict_auto_insert, default_val, new_dict, env, ctx}
         end
 
       val when is_integer(val) or is_float(val) or is_boolean(val) or val == nil ->
@@ -2605,58 +1282,6 @@ defmodule Pyex.Interpreter do
       _ ->
         {{:exception, "KeyError: #{inspect(key)}"}, env, ctx}
     end
-  end
-
-  @spec get_subscript_value(pyvalue(), pyvalue()) :: pyvalue() | {:exception, String.t()}
-  defp get_subscript_value(obj, key) when is_map(obj) do
-    case Map.fetch(obj, key) do
-      {:ok, val} ->
-        val
-
-      :error ->
-        case Map.fetch(obj, "__defaultdict_factory__") do
-          {:ok, {:builtin_type, _, func}} -> func.([])
-          {:ok, {:builtin, func}} -> func.([])
-          _ -> {:exception, "KeyError: #{inspect(key)}"}
-        end
-    end
-  end
-
-  defp get_subscript_value({:py_list, reversed, len}, key) when is_integer(key) do
-    idx = if key < 0, do: len + key, else: key
-
-    if idx < 0 or idx >= len do
-      {:exception, "IndexError: list index out of range"}
-    else
-      Enum.at(reversed, len - 1 - idx)
-    end
-  end
-
-  defp get_subscript_value(obj, key) when is_list(obj) and is_integer(key) do
-    len = length(obj)
-    idx = if key < 0, do: len + key, else: key
-
-    if idx < 0 or idx >= len do
-      {:exception, "IndexError: list index out of range"}
-    else
-      Enum.at(obj, idx)
-    end
-  end
-
-  defp get_subscript_value(_, _), do: {:exception, "TypeError: object is not subscriptable"}
-
-  @spec set_subscript_value(pyvalue(), pyvalue(), pyvalue()) :: pyvalue()
-  defp set_subscript_value(obj, key, val) when is_map(obj), do: Map.put(obj, key, val)
-
-  defp set_subscript_value({:py_list, reversed, len}, key, val) when is_integer(key) do
-    idx = if key < 0, do: len + key, else: key
-    new_reversed = List.replace_at(reversed, len - 1 - idx, val)
-    {:py_list, new_reversed, len}
-  end
-
-  defp set_subscript_value(obj, key, val) when is_list(obj) and is_integer(key) do
-    idx = if key < 0, do: length(obj) + key, else: key
-    List.replace_at(obj, idx, val)
   end
 
   @spec eval_slice(pyvalue(), pyvalue(), pyvalue(), pyvalue(), Env.t(), Ctx.t()) :: eval_result()
@@ -2700,163 +1325,6 @@ defmodule Pyex.Interpreter do
     end
   end
 
-  @spec eval_comp_clauses(
-          :list | :dict | :set,
-          Parser.ast_node() | {Parser.ast_node(), Parser.ast_node()},
-          [
-            {:comp_for, String.t() | [String.t()], Parser.ast_node()}
-            | {:comp_if, Parser.ast_node()}
-          ],
-          [pyvalue()] | map() | MapSet.t(),
-          Env.t(),
-          Ctx.t()
-        ) :: eval_result()
-  @dialyzer {:nowarn_function, eval_comp_clauses: 6}
-  defp eval_comp_clauses(:list, expr, [], acc, env, ctx) do
-    case eval(expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-      {val, env, ctx} -> {[val | acc], env, ctx}
-    end
-  end
-
-  defp eval_comp_clauses(:dict, {key_expr, val_expr}, [], acc, env, ctx) do
-    case eval(key_expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {key, env, ctx} ->
-        case eval(val_expr, env, ctx) do
-          {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-          {val, env, ctx} -> {Map.put(acc, key, val), env, ctx}
-        end
-    end
-  end
-
-  defp eval_comp_clauses(:set, expr, [], acc, env, ctx) do
-    case eval(expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-      {val, env, ctx} -> {MapSet.put(acc, val), env, ctx}
-    end
-  end
-
-  defp eval_comp_clauses(kind, expr, [{:comp_if, condition} | rest_clauses], acc, env, ctx) do
-    case eval(condition, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {cond_val, env, ctx} ->
-        {taken, env, ctx} = eval_truthy(cond_val, env, ctx)
-
-        if taken do
-          eval_comp_clauses(kind, expr, rest_clauses, acc, env, ctx)
-        else
-          {acc, env, ctx}
-        end
-    end
-  end
-
-  defp eval_comp_clauses(
-         kind,
-         expr,
-         [{:comp_for, var_name, iterable_expr} | rest_clauses],
-         acc,
-         env,
-         ctx
-       ) do
-    case eval(iterable_expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {iterable, env, ctx} ->
-        case to_iterable(iterable, env, ctx) do
-          {:ok, items, env, ctx} ->
-            eval_comp_for_loop(kind, expr, var_name, items, rest_clauses, acc, env, ctx)
-
-          {:exception, msg} ->
-            {{:exception, msg}, env, ctx}
-        end
-    end
-  end
-
-  @spec eval_comp_for_loop(
-          :list | :dict | :set,
-          Parser.ast_node() | {Parser.ast_node(), Parser.ast_node()},
-          String.t() | [String.t()],
-          [pyvalue()],
-          [
-            {:comp_for, String.t() | [String.t()], Parser.ast_node()}
-            | {:comp_if, Parser.ast_node()}
-          ],
-          [pyvalue()] | map() | MapSet.t(),
-          Env.t(),
-          Ctx.t()
-        ) :: eval_result()
-  defp eval_comp_for_loop(_kind, _expr, _var_name, [], _rest_clauses, acc, env, ctx) do
-    {acc, env, ctx}
-  end
-
-  defp eval_comp_for_loop(kind, expr, var_name, [item | rest_items], rest_clauses, acc, env, ctx) do
-    case Ctx.check_deadline(ctx) do
-      {:exceeded, _} ->
-        {{:exception, "TimeoutError: execution exceeded time limit"}, env, ctx}
-
-      :ok ->
-        case bind_loop_var(var_name, item, env) do
-          {:exception, msg} ->
-            {{:exception, msg}, env, ctx}
-
-          bound_env ->
-            case eval_comp_clauses(kind, expr, rest_clauses, acc, bound_env, ctx) do
-              {{:exception, _}, _, _} = error ->
-                error
-
-              {new_acc, _inner_env, ctx} ->
-                eval_comp_for_loop(
-                  kind,
-                  expr,
-                  var_name,
-                  rest_items,
-                  rest_clauses,
-                  new_acc,
-                  env,
-                  ctx
-                )
-            end
-        end
-    end
-  end
-
-  @spec eval_dict(
-          [{Parser.ast_node(), Parser.ast_node()}],
-          Env.t(),
-          Ctx.t()
-        ) :: eval_result()
-  defp eval_dict(entries, env, ctx) do
-    Enum.reduce_while(entries, {%{}, env, ctx}, fn {key_expr, val_expr}, {map, env, ctx} ->
-      case eval(key_expr, env, ctx) do
-        {{:exception, _} = signal, env, ctx} ->
-          {:halt, {signal, env, ctx}}
-
-        {key, env, ctx} ->
-          if unhashable?(key) do
-            {:halt,
-             {{:exception, "TypeError: unhashable type: '#{Helpers.py_type(key)}'"}, env, ctx}}
-          else
-            case eval(val_expr, env, ctx) do
-              {{:exception, _} = signal, env, ctx} -> {:halt, {signal, env, ctx}}
-              {val, env, ctx} -> {:cont, {Map.put(map, key, val), env, ctx}}
-            end
-          end
-      end
-    end)
-  end
-
-  @spec unhashable?(pyvalue()) :: boolean()
-  defp unhashable?(val) when is_list(val), do: true
-  defp unhashable?({:py_list, _, _}), do: true
-  defp unhashable?({:set, _}), do: true
-  defp unhashable?(_), do: false
-
   @spec eval_fstring(
           [{:lit, String.t()} | {:expr, Parser.ast_node()}],
           binary(),
@@ -2881,204 +1349,40 @@ defmodule Pyex.Interpreter do
     end
   end
 
-  @spec eval_raise_exc_class(String.t(), [Parser.ast_node()], Parser.meta(), Env.t(), Ctx.t()) ::
-          eval_result()
-  defp eval_raise_exc_class(exc_name, args, _meta, env, ctx) do
-    case Env.get(env, exc_name) do
-      {:ok, {:class, _, _, _} = class} ->
-        case eval_list(args, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
+  defp eval_fstring([{:expr, expr, format_spec} | rest], acc, env, ctx) do
+    case eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {val, env, ctx} ->
+        case Pyex.Interpreter.FstringFormat.apply_format_spec(val, format_spec) do
+          {:exception, _} = signal ->
             {signal, env, ctx}
 
-          {rev_values, env, ctx} ->
-            values = Enum.reverse(rev_values)
-            msg = format_exc_msg(exc_name, values)
-
-            case call_function(class, values, %{}, env, ctx) do
-              {{:exception, _}, env, ctx} ->
-                instance = {:instance, class, %{"args" => {:tuple, values}}}
-                ctx = %{ctx | exception_instance: instance}
-                {{:exception, msg}, env, ctx}
-
-              {instance, env, ctx} ->
-                ctx = %{ctx | exception_instance: instance}
-                {{:exception, msg}, env, ctx}
-            end
-        end
-
-      _ ->
-        case eval_list(args, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {rev_values, env, ctx} ->
-            values = Enum.reverse(rev_values)
-            msg = format_exc_msg(exc_name, values)
-
-            instance =
-              {:instance, {:class, exc_name, [], %{}}, %{"args" => {:tuple, values}}}
-
-            ctx = %{ctx | exception_instance: instance}
-            {{:exception, msg}, env, ctx}
+          formatted ->
+            eval_fstring(rest, <<acc::binary, formatted::binary>>, env, ctx)
         end
     end
-  end
-
-  @spec format_exc_msg(String.t(), [pyvalue()]) :: String.t()
-  defp format_exc_msg(exc_name, values) do
-    case values do
-      [] -> exc_name
-      [m] when is_binary(m) -> "#{exc_name}: #{m}"
-      [m] -> "#{exc_name}: #{Helpers.py_str(m)}"
-      _ -> "#{exc_name}: #{values |> Enum.map(&Helpers.py_str/1) |> Enum.join(", ")}"
-    end
-  end
-
-  @spec synthesize_exception_instance(String.t()) :: pyvalue()
-  defp synthesize_exception_instance(message) do
-    {class_name, msg} =
-      case String.split(message, ": ", parts: 2) do
-        [name, m] -> {name, m}
-        [name] -> {name, ""}
-      end
-
-    {:instance, {:class, class_name, [], %{}}, %{"args" => {:tuple, [msg]}}}
-  end
-
-  @spec exception_matches?(String.t(), String.t()) :: boolean()
-  defp exception_matches?("Exception", _message), do: true
-
-  defp exception_matches?(exc_name, message) do
-    message == exc_name or String.starts_with?(message, exc_name <> ":")
   end
 
   @spec eval_py_str(pyvalue(), Env.t(), Ctx.t()) :: {String.t(), Env.t(), Ctx.t()}
-  defp eval_py_str({:instance, _, _} = inst, env, ctx) do
-    case call_dunder(inst, "__str__", [], env, ctx) do
-      {:ok, str, env, ctx} when is_binary(str) ->
-        {str, env, ctx}
-
-      _ ->
-        case call_dunder(inst, "__repr__", [], env, ctx) do
-          {:ok, str, env, ctx} when is_binary(str) -> {str, env, ctx}
-          _ -> {Helpers.py_str(inst), env, ctx}
-        end
-    end
-  end
-
-  defp eval_py_str(val, env, ctx), do: {Helpers.py_str(val), env, ctx}
+  defp eval_py_str(val, env, ctx), do: Protocols.eval_py_str(val, env, ctx)
 
   @spec dunder_str_fallback(pyvalue(), String.t(), Env.t(), Ctx.t()) ::
           {:ok, String.t(), Env.t(), Ctx.t()} | :error
-  defp dunder_str_fallback({:instance, _, attrs} = inst, "__str__", env, ctx) do
-    case call_dunder(inst, "__repr__", [], env, ctx) do
-      {:ok, str, env, ctx} when is_binary(str) ->
-        {:ok, str, env, ctx}
+  @doc false
+  def dunder_str_fallback(val, dunder_name, env, ctx),
+    do: Protocols.dunder_str_fallback(val, dunder_name, env, ctx)
 
-      _ ->
-        case Map.get(attrs, "args") do
-          {:tuple, [single]} when is_binary(single) ->
-            {:ok, single, env, ctx}
-
-          {:tuple, items} when is_list(items) and items != [] ->
-            {:ok, items |> Enum.map(&Helpers.py_str/1) |> Enum.join(", "), env, ctx}
-
-          _ ->
-            {:ok, Helpers.py_str(inst), env, ctx}
-        end
-    end
-  end
-
-  defp dunder_str_fallback({:instance, _, _} = inst, "__repr__", env, ctx) do
-    {:ok, Helpers.py_str(inst), env, ctx}
-  end
-
-  defp dunder_str_fallback(inst, "__bool__", env, ctx) do
-    case call_dunder(inst, "__len__", [], env, ctx) do
-      {:ok, len, env, ctx} when is_integer(len) ->
-        {:ok, len > 0, env, ctx}
-
-      _ ->
-        {:ok, true, env, ctx}
-    end
-  end
-
-  defp dunder_str_fallback(_, _, _, _), do: :error
-
+  @doc false
   @spec to_iterable(pyvalue(), Env.t(), Ctx.t()) ::
           {:ok, [pyvalue()], Env.t(), Ctx.t()} | {:exception, String.t()}
-  defp to_iterable({:py_list, reversed, _len}, env, ctx),
-    do: {:ok, Enum.reverse(reversed), env, ctx}
+  def to_iterable(val, env, ctx), do: Iterables.to_iterable(val, env, ctx)
 
-  defp to_iterable(list, env, ctx) when is_list(list), do: {:ok, list, env, ctx}
-  defp to_iterable(str, env, ctx) when is_binary(str), do: {:ok, String.codepoints(str), env, ctx}
-
-  defp to_iterable(map, env, ctx) when is_map(map),
-    do: {:ok, map |> Builtins.visible_dict() |> Map.keys(), env, ctx}
-
-  defp to_iterable({:tuple, elements}, env, ctx), do: {:ok, elements, env, ctx}
-  defp to_iterable({:set, s}, env, ctx), do: {:ok, MapSet.to_list(s), env, ctx}
-  defp to_iterable({:frozenset, s}, env, ctx), do: {:ok, MapSet.to_list(s), env, ctx}
-
-  defp to_iterable({:range, _, _, _} = r, env, ctx) do
-    case Builtins.range_to_list(r) do
-      {:exception, _} = err -> err
-      list -> {:ok, list, env, ctx}
-    end
-  end
-
-  defp to_iterable({:generator, items}, env, ctx), do: {:ok, items, env, ctx}
-  defp to_iterable({:generator_error, items, _msg}, env, ctx), do: {:ok, items, env, ctx}
-
-  defp to_iterable({:iterator, id}, env, ctx) do
-    {:ok, Ctx.iter_items(ctx, id), env, ctx}
-  end
-
-  defp to_iterable({:instance, _, _} = inst, env, ctx) do
-    case call_dunder(inst, "__iter__", [], env, ctx) do
-      {:ok, result, env, ctx} ->
-        case result do
-          {:exception, _} = signal ->
-            signal
-
-          {:instance, _, _} = iter ->
-            drain_iterator(iter, [], env, ctx)
-
-          other ->
-            to_iterable(other, env, ctx)
-        end
-
-      :not_found ->
-        {:exception, "TypeError: '#{Helpers.py_type(inst)}' object is not iterable"}
-    end
-  end
-
-  defp to_iterable(val, _env, _ctx) do
-    {:exception, "TypeError: '#{Helpers.py_type(val)}' object is not iterable"}
-  end
-
-  @spec drain_iterator(pyvalue(), [pyvalue()], Env.t(), Ctx.t()) ::
-          {:ok, [pyvalue()], Env.t(), Ctx.t()} | {:exception, String.t()}
-  defp drain_iterator(iter, acc, env, ctx) do
-    case call_dunder_mut(iter, "__next__", [], env, ctx) do
-      {:ok, new_iter, {:exception, "StopIteration" <> _}, env, ctx} ->
-        _ = new_iter
-        {:ok, Enum.reverse(acc), env, ctx}
-
-      {:ok, _new_iter, {:exception, _} = signal, _env, _ctx} ->
-        signal
-
-      {:ok, new_iter, value, env, ctx} ->
-        drain_iterator(new_iter, [value | acc], env, ctx)
-
-      :not_found ->
-        {:exception, "TypeError: '#{Helpers.py_type(iter)}' object is not an iterator"}
-    end
-  end
-
+  @doc false
   @spec unpack_iterable_safe([pyvalue()], [String.t() | {:starred, String.t()}]) ::
           {:ok, [{String.t(), pyvalue()}]} | {:exception, String.t()}
-  defp unpack_iterable_safe([single], names) do
+  def unpack_iterable_safe([single], names) do
     case single do
       {:py_list, reversed, _} ->
         check_unpack_length(Enum.reverse(reversed), names)
@@ -3103,7 +1407,7 @@ defmodule Pyex.Interpreter do
     end
   end
 
-  defp unpack_iterable_safe(values, names) do
+  def unpack_iterable_safe(values, names) do
     check_unpack_length(values, names)
   end
 
@@ -3177,553 +1481,70 @@ defmodule Pyex.Interpreter do
 
   @doc false
   @spec eval_truthy(pyvalue(), Env.t(), Ctx.t()) :: {boolean(), Env.t(), Ctx.t()}
-  def eval_truthy({:instance, _, _} = inst, env, ctx) do
-    case call_dunder(inst, "__bool__", [], env, ctx) do
-      {:ok, result, env, ctx} ->
-        {Helpers.truthy?(result), env, ctx}
-
-      :not_found ->
-        case call_dunder(inst, "__len__", [], env, ctx) do
-          {:ok, result, env, ctx} when is_integer(result) -> {result != 0, env, ctx}
-          {:ok, _, env, ctx} -> {true, env, ctx}
-          :not_found -> {true, env, ctx}
-        end
-    end
-  end
-
-  def eval_truthy(val, env, ctx), do: {Helpers.truthy?(val), env, ctx}
+  def eval_truthy(val, env, ctx), do: Protocols.eval_truthy(val, env, ctx)
 
   @spec eval_binop(atom(), pyvalue(), pyvalue(), Env.t(), Ctx.t()) :: eval_result()
   defp eval_binop(op, {:instance, _, _} = l, r, env, ctx) do
-    case dunder_for_op(op) do
+    case BinaryOps.dunder_for_op(op) do
       nil ->
-        binop_result(safe_binop(op, l, r), env, ctx)
+        BinaryOps.binop_result(safe_binop(op, l, r), env, ctx)
 
       dunder ->
-        case call_dunder(l, dunder, [r], env, ctx) do
+        case Dunder.call_dunder(l, dunder, [r], env, ctx) do
           {:ok, result, env, ctx} ->
             {result, env, ctx}
 
           :not_found ->
-            binop_result(safe_binop(op, l, r), env, ctx)
+            BinaryOps.binop_result(safe_binop(op, l, r), env, ctx)
         end
     end
   end
 
   defp eval_binop(:in, l, {:instance, _, _} = r, env, ctx) do
-    case call_dunder(r, "__contains__", [l], env, ctx) do
+    case Dunder.call_dunder(r, "__contains__", [l], env, ctx) do
       {:ok, result, env, ctx} -> {Helpers.truthy?(result), env, ctx}
-      :not_found -> binop_result(safe_binop(:in, l, r), env, ctx)
+      :not_found -> BinaryOps.binop_result(safe_binop(:in, l, r), env, ctx)
     end
   end
 
   defp eval_binop(:not_in, l, {:instance, _, _} = r, env, ctx) do
-    case call_dunder(r, "__contains__", [l], env, ctx) do
+    case Dunder.call_dunder(r, "__contains__", [l], env, ctx) do
       {:ok, result, env, ctx} -> {!Helpers.truthy?(result), env, ctx}
-      :not_found -> binop_result(safe_binop(:not_in, l, r), env, ctx)
+      :not_found -> BinaryOps.binop_result(safe_binop(:not_in, l, r), env, ctx)
     end
   end
 
   defp eval_binop(op, l, {:instance, _, _} = r, env, ctx) do
-    case rdunder_for_op(op) do
+    case BinaryOps.rdunder_for_op(op) do
       nil ->
-        binop_result(safe_binop(op, l, r), env, ctx)
+        BinaryOps.binop_result(safe_binop(op, l, r), env, ctx)
 
       rdunder ->
-        case call_dunder(r, rdunder, [l], env, ctx) do
+        case Dunder.call_dunder(r, rdunder, [l], env, ctx) do
           {:ok, result, env, ctx} ->
             {result, env, ctx}
 
           :not_found ->
-            binop_result(safe_binop(op, l, r), env, ctx)
+            BinaryOps.binop_result(safe_binop(op, l, r), env, ctx)
         end
     end
   end
 
   defp eval_binop(op, {:pandas_series, _} = l, r, env, ctx) do
-    binop_result(series_binop(op, l, r), env, ctx)
+    BinaryOps.binop_result(BinaryOps.series_binop(op, l, r), env, ctx)
   end
 
   defp eval_binop(op, l, {:pandas_series, _} = r, env, ctx) do
-    binop_result(series_binop(op, l, r), env, ctx)
+    BinaryOps.binop_result(BinaryOps.series_binop(op, l, r), env, ctx)
   end
 
   defp eval_binop(op, l, r, env, ctx) do
-    binop_result(safe_binop(op, l, r), env, ctx)
+    BinaryOps.binop_result(safe_binop(op, l, r), env, ctx)
   end
 
-  @spec series_binop(atom(), pyvalue(), pyvalue()) :: pyvalue() | {:exception, String.t()}
-  defp series_binop(op, l, r) do
-    ls = series_unwrap(l)
-    rs = series_unwrap(r)
-
-    result =
-      case op do
-        :plus -> Explorer.Series.add(ls, rs)
-        :minus -> Explorer.Series.subtract(ls, rs)
-        :star -> Explorer.Series.multiply(ls, rs)
-        :slash -> Explorer.Series.divide(ls, rs)
-        :gt -> Explorer.Series.greater(ls, rs)
-        :gte -> Explorer.Series.greater_equal(ls, rs)
-        :lt -> Explorer.Series.less(ls, rs)
-        :lte -> Explorer.Series.less_equal(ls, rs)
-        :eq -> Explorer.Series.equal(ls, rs)
-        :neq -> Explorer.Series.not_equal(ls, rs)
-        :amp -> series_bool_and(ls, rs)
-        :pipe -> series_bool_or(ls, rs)
-        _ -> {:exception, "TypeError: unsupported operand for Series"}
-      end
-
-    case result do
-      {:exception, _} = err -> err
-      %Explorer.Series{} = s -> {:pandas_series, s}
-    end
-  end
-
-  @spec series_unwrap(pyvalue()) :: Explorer.Series.t() | number()
-  defp series_unwrap({:pandas_series, s}), do: s
-  defp series_unwrap(v) when is_number(v), do: v
-  defp series_unwrap(true), do: 1
-  defp series_unwrap(false), do: 0
-
-  @spec series_bool_and(Explorer.Series.t() | number(), Explorer.Series.t() | number()) ::
-          Explorer.Series.t()
-  defp series_bool_and(%Explorer.Series{} = l, %Explorer.Series{} = r) do
-    Explorer.Series.and(l, r)
-  end
-
-  @spec series_bool_or(Explorer.Series.t() | number(), Explorer.Series.t() | number()) ::
-          Explorer.Series.t()
-  defp series_bool_or(%Explorer.Series{} = l, %Explorer.Series{} = r) do
-    Explorer.Series.or(l, r)
-  end
-
-  @spec binop_result(pyvalue() | {:exception, String.t()}, Env.t(), Ctx.t()) :: eval_result()
-  defp binop_result({:exception, msg}, env, ctx), do: {{:exception, msg}, env, ctx}
-  defp binop_result(value, env, ctx), do: {value, env, ctx}
-
-  @spec dunder_for_op(atom()) :: String.t() | nil
-  defp dunder_for_op(:plus), do: "__add__"
-  defp dunder_for_op(:minus), do: "__sub__"
-  defp dunder_for_op(:star), do: "__mul__"
-  defp dunder_for_op(:slash), do: "__truediv__"
-  defp dunder_for_op(:floor_div), do: "__floordiv__"
-  defp dunder_for_op(:percent), do: "__mod__"
-  defp dunder_for_op(:double_star), do: "__pow__"
-  defp dunder_for_op(:eq), do: "__eq__"
-  defp dunder_for_op(:neq), do: "__ne__"
-  defp dunder_for_op(:lt), do: "__lt__"
-  defp dunder_for_op(:gt), do: "__gt__"
-  defp dunder_for_op(:lte), do: "__le__"
-  defp dunder_for_op(:gte), do: "__ge__"
-  defp dunder_for_op(:amp), do: "__and__"
-  defp dunder_for_op(:pipe), do: "__or__"
-  defp dunder_for_op(:caret), do: "__xor__"
-  defp dunder_for_op(:lshift), do: "__lshift__"
-  defp dunder_for_op(:rshift), do: "__rshift__"
-  defp dunder_for_op(:in), do: nil
-  defp dunder_for_op(:not_in), do: nil
-  defp dunder_for_op(:is), do: nil
-  defp dunder_for_op(:is_not), do: nil
-  defp dunder_for_op(:and), do: nil
-  defp dunder_for_op(:or), do: nil
-  defp dunder_for_op(_), do: nil
-
-  @spec rdunder_for_op(atom()) :: String.t() | nil
-  defp rdunder_for_op(:plus), do: "__radd__"
-  defp rdunder_for_op(:minus), do: "__rsub__"
-  defp rdunder_for_op(:star), do: "__rmul__"
-  defp rdunder_for_op(:slash), do: "__rtruediv__"
-  defp rdunder_for_op(:floor_div), do: "__rfloordiv__"
-  defp rdunder_for_op(:percent), do: "__rmod__"
-  defp rdunder_for_op(:double_star), do: "__rpow__"
-  defp rdunder_for_op(:eq), do: "__eq__"
-  defp rdunder_for_op(:neq), do: "__ne__"
-  defp rdunder_for_op(:lt), do: "__gt__"
-  defp rdunder_for_op(:gt), do: "__lt__"
-  defp rdunder_for_op(:lte), do: "__ge__"
-  defp rdunder_for_op(:gte), do: "__le__"
-  defp rdunder_for_op(_), do: nil
-
+  @doc false
   @spec safe_binop(atom(), pyvalue(), pyvalue()) :: pyvalue() | {:exception, String.t()}
-  defp safe_binop(op, l, r) when is_boolean(l) or is_boolean(r) do
-    case op do
-      op
-      when op in [
-             :plus,
-             :minus,
-             :star,
-             :slash,
-             :floor_div,
-             :percent,
-             :double_star,
-             :amp,
-             :pipe,
-             :caret,
-             :lshift,
-             :rshift,
-             :eq,
-             :neq,
-             :lt,
-             :gt,
-             :lte,
-             :gte
-           ] ->
-        safe_binop(op, Helpers.bool_to_int(l), Helpers.bool_to_int(r))
-
-      _ ->
-        safe_binop_dispatch(op, l, r)
-    end
-  end
-
-  defp safe_binop(op, l, r), do: safe_binop_dispatch(op, l, r)
-
-  defp safe_binop_dispatch(:plus, l, r) when is_binary(l) and is_binary(r), do: l <> r
-
-  defp safe_binop_dispatch(:plus, {:py_list, lr, ll}, {:py_list, rr, rl}) do
-    items = Enum.reverse(lr) ++ Enum.reverse(rr)
-    {:py_list, Enum.reverse(items), ll + rl}
-  end
-
-  defp safe_binop_dispatch(:plus, {:py_list, lr, ll}, r) when is_list(r) do
-    items = Enum.reverse(lr) ++ r
-    {:py_list, Enum.reverse(items), ll + length(r)}
-  end
-
-  defp safe_binop_dispatch(:plus, l, {:py_list, rr, rl}) when is_list(l) do
-    items = l ++ Enum.reverse(rr)
-    {:py_list, Enum.reverse(items), length(l) + rl}
-  end
-
-  defp safe_binop_dispatch(:plus, l, r) when is_list(l) and is_list(r), do: l ++ r
-  defp safe_binop_dispatch(:plus, {:tuple, l}, {:tuple, r}), do: {:tuple, l ++ r}
-
-  defp safe_binop_dispatch(:plus, %{"__counter__" => true} = l, %{"__counter__" => true} = r) do
-    Pyex.Stdlib.Collections.counter_add(l, r)
-  end
-
-  defp safe_binop_dispatch(:plus, l, r) when is_number(l) and is_number(r), do: l + r
-
-  defp safe_binop_dispatch(:plus, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for +: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:minus, l, r) when is_number(l) and is_number(r), do: l - r
-
-  defp safe_binop_dispatch(:minus, {:set, a}, {:set, b}),
-    do: {:set, MapSet.difference(a, b)}
-
-  defp safe_binop_dispatch(:minus, {:frozenset, a}, {:set, b}),
-    do: {:frozenset, MapSet.difference(a, b)}
-
-  defp safe_binop_dispatch(:minus, {:frozenset, a}, {:frozenset, b}),
-    do: {:frozenset, MapSet.difference(a, b)}
-
-  defp safe_binop_dispatch(:minus, {:set, a}, {:frozenset, b}),
-    do: {:set, MapSet.difference(a, b)}
-
-  defp safe_binop_dispatch(:minus, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for -: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:star, l, r) when is_binary(l) and is_integer(r) do
-    len = String.length(l) * max(r, 0)
-
-    if len > 10_000_000 do
-      {:exception, "MemoryError: string repetition would create #{len} characters (max 10000000)"}
-    else
-      String.duplicate(l, max(r, 0))
-    end
-  end
-
-  defp safe_binop_dispatch(:star, l, r) when is_integer(l) and is_binary(r),
-    do: safe_binop_dispatch(:star, r, l)
-
-  defp safe_binop_dispatch(:star, l, r) when is_integer(l) and is_list(r),
-    do: Helpers.repeat_list(r, l)
-
-  defp safe_binop_dispatch(:star, l, r) when is_list(l) and is_integer(r),
-    do: Helpers.repeat_list(l, r)
-
-  defp safe_binop_dispatch(:star, {:py_list, reversed, len}, r) when is_integer(r) do
-    case Helpers.repeat_list(Enum.reverse(reversed), r) do
-      {:exception, _} = err -> err
-      items -> {:py_list, Enum.reverse(items), len * max(r, 0)}
-    end
-  end
-
-  defp safe_binop_dispatch(:star, l, {:py_list, reversed, len}) when is_integer(l) do
-    case Helpers.repeat_list(Enum.reverse(reversed), l) do
-      {:exception, _} = err -> err
-      items -> {:py_list, Enum.reverse(items), len * max(l, 0)}
-    end
-  end
-
-  defp safe_binop_dispatch(:star, {:tuple, items}, r) when is_integer(r) do
-    case Helpers.repeat_list(items, r) do
-      {:exception, _} = err -> err
-      list -> {:tuple, list}
-    end
-  end
-
-  defp safe_binop_dispatch(:star, l, {:tuple, items}) when is_integer(l) do
-    case Helpers.repeat_list(items, l) do
-      {:exception, _} = err -> err
-      list -> {:tuple, list}
-    end
-  end
-
-  defp safe_binop_dispatch(:star, l, r) when is_number(l) and is_number(r), do: l * r
-
-  defp safe_binop_dispatch(:star, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for *: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:slash, _l, r) when r == 0 or r == 0.0,
-    do: {:exception, "ZeroDivisionError: division by zero"}
-
-  defp safe_binop_dispatch(:slash, l, r) when is_number(l) and is_number(r), do: l / r
-
-  defp safe_binop_dispatch(:slash, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for /: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:floor_div, _l, r) when r == 0 or r == 0.0,
-    do: {:exception, "ZeroDivisionError: integer division or modulo by zero"}
-
-  defp safe_binop_dispatch(:floor_div, l, r) when is_integer(l) and is_integer(r),
-    do: Integer.floor_div(l, r)
-
-  defp safe_binop_dispatch(:floor_div, l, r) when is_number(l) and is_number(r),
-    do: Float.floor(l / r)
-
-  defp safe_binop_dispatch(:floor_div, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for //: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:percent, l, r) when is_binary(l), do: Format.string_format(l, r)
-
-  defp safe_binop_dispatch(:percent, _l, r) when r == 0 or r == 0.0,
-    do: {:exception, "ZeroDivisionError: integer division or modulo by zero"}
-
-  defp safe_binop_dispatch(:percent, l, r) when is_integer(l) and is_integer(r),
-    do: Integer.mod(l, r)
-
-  defp safe_binop_dispatch(:percent, l, r) when is_number(l) and is_number(r),
-    do: l - Float.floor(l / r) * r
-
-  defp safe_binop_dispatch(:percent, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for %: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:double_star, l, r) when is_number(l) and is_number(r) do
-    cond do
-      l == 0 and r < 0 ->
-        {:exception, "ZeroDivisionError: 0 cannot be raised to a negative power"}
-
-      is_integer(l) and is_integer(r) and r >= 0 ->
-        Helpers.int_pow(l, r)
-
-      is_float(l) or is_float(r) ->
-        try do
-          :math.pow(l, r)
-        rescue
-          ArithmeticError ->
-            {:exception, "ValueError: math domain error"}
-        end
-
-      true ->
-        try do
-          :math.pow(l, r) |> Helpers.maybe_intify()
-        rescue
-          ArithmeticError ->
-            {:exception, "ValueError: math domain error"}
-        end
-    end
-  end
-
-  defp safe_binop_dispatch(:double_star, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for **: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:eq, {:py_list, lr, _}, {:py_list, rr, _}),
-    do: Enum.reverse(lr) == Enum.reverse(rr)
-
-  defp safe_binop_dispatch(:eq, {:py_list, reversed, _}, r) when is_list(r),
-    do: Enum.reverse(reversed) == r
-
-  defp safe_binop_dispatch(:eq, l, {:py_list, reversed, _}) when is_list(l),
-    do: l == Enum.reverse(reversed)
-
-  defp safe_binop_dispatch(:eq, l, r), do: l == r
-
-  defp safe_binop_dispatch(:neq, {:py_list, lr, _}, {:py_list, rr, _}),
-    do: Enum.reverse(lr) != Enum.reverse(rr)
-
-  defp safe_binop_dispatch(:neq, {:py_list, reversed, _}, r) when is_list(r),
-    do: Enum.reverse(reversed) != r
-
-  defp safe_binop_dispatch(:neq, l, {:py_list, reversed, _}) when is_list(l),
-    do: l != Enum.reverse(reversed)
-
-  defp safe_binop_dispatch(:neq, l, r), do: l != r
-  defp safe_binop_dispatch(:lt, l, r), do: ordering_compare(:lt, l, r)
-  defp safe_binop_dispatch(:gt, l, r), do: ordering_compare(:gt, l, r)
-  defp safe_binop_dispatch(:lte, l, r), do: ordering_compare(:lte, l, r)
-  defp safe_binop_dispatch(:gte, l, r), do: ordering_compare(:gte, l, r)
-  defp safe_binop_dispatch(:in, l, {:tuple, items}), do: l in items
-  defp safe_binop_dispatch(:in, l, {:py_list, reversed, _}), do: l in reversed
-  defp safe_binop_dispatch(:in, l, r) when is_list(r), do: l in r
-
-  defp safe_binop_dispatch(:in, l, r) when is_binary(l) and is_binary(r),
-    do: String.contains?(r, l)
-
-  defp safe_binop_dispatch(:in, l, r) when is_map(r),
-    do: Map.has_key?(Builtins.visible_dict(r), l)
-
-  defp safe_binop_dispatch(:in, l, {:set, s}), do: MapSet.member?(s, l)
-  defp safe_binop_dispatch(:in, l, {:frozenset, s}), do: MapSet.member?(s, l)
-
-  defp safe_binop_dispatch(:in, l, {:range, start, stop, step}) when is_integer(l) do
-    cond do
-      step > 0 and l >= start and l < stop -> rem(l - start, step) == 0
-      step < 0 and l <= start and l > stop -> rem(start - l, -step) == 0
-      true -> false
-    end
-  end
-
-  defp safe_binop_dispatch(:in, _l, {:range, _, _, _}), do: false
-
-  defp safe_binop_dispatch(:in, _l, r),
-    do: {:exception, "TypeError: argument of type '#{Helpers.py_type(r)}' is not iterable"}
-
-  defp safe_binop_dispatch(:is, l, r), do: l === r
-  defp safe_binop_dispatch(:is_not, l, r), do: l !== r
-
-  defp safe_binop_dispatch(:not_in, l, r) do
-    case safe_binop(:in, l, r) do
-      {:exception, _} = exc -> exc
-      val -> not val
-    end
-  end
-
-  defp safe_binop_dispatch(:amp, {:set, a}, {:set, b}), do: {:set, MapSet.intersection(a, b)}
-
-  defp safe_binop_dispatch(:amp, {:frozenset, a}, {:set, b}),
-    do: {:frozenset, MapSet.intersection(a, b)}
-
-  defp safe_binop_dispatch(:amp, {:frozenset, a}, {:frozenset, b}),
-    do: {:frozenset, MapSet.intersection(a, b)}
-
-  defp safe_binop_dispatch(:amp, {:set, a}, {:frozenset, b}),
-    do: {:set, MapSet.intersection(a, b)}
-
-  defp safe_binop_dispatch(:amp, l, r) when is_integer(l) and is_integer(r), do: band(l, r)
-
-  defp safe_binop_dispatch(:amp, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for &: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:pipe, {:set, a}, {:set, b}), do: {:set, MapSet.union(a, b)}
-
-  defp safe_binop_dispatch(:pipe, {:frozenset, a}, {:set, b}),
-    do: {:frozenset, MapSet.union(a, b)}
-
-  defp safe_binop_dispatch(:pipe, {:frozenset, a}, {:frozenset, b}),
-    do: {:frozenset, MapSet.union(a, b)}
-
-  defp safe_binop_dispatch(:pipe, {:set, a}, {:frozenset, b}), do: {:set, MapSet.union(a, b)}
-
-  defp safe_binop_dispatch(:pipe, l, r) when is_integer(l) and is_integer(r), do: bor(l, r)
-
-  defp safe_binop_dispatch(:pipe, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for |: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:caret, {:set, a}, {:set, b}),
-    do: {:set, MapSet.symmetric_difference(a, b)}
-
-  defp safe_binop_dispatch(:caret, {:frozenset, a}, {:set, b}),
-    do: {:frozenset, MapSet.symmetric_difference(a, b)}
-
-  defp safe_binop_dispatch(:caret, {:frozenset, a}, {:frozenset, b}),
-    do: {:frozenset, MapSet.symmetric_difference(a, b)}
-
-  defp safe_binop_dispatch(:caret, {:set, a}, {:frozenset, b}),
-    do: {:set, MapSet.symmetric_difference(a, b)}
-
-  defp safe_binop_dispatch(:caret, l, r) when is_integer(l) and is_integer(r), do: bxor(l, r)
-
-  defp safe_binop_dispatch(:caret, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for ^: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:lshift, l, r) when is_integer(l) and is_integer(r) do
-    if r > 100_000 do
-      {:exception, "OverflowError: left shift by #{r} exceeds maximum allowed (100000)"}
-    else
-      bsl(l, r)
-    end
-  end
-
-  defp safe_binop_dispatch(:lshift, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for <<: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  defp safe_binop_dispatch(:rshift, l, r) when is_integer(l) and is_integer(r), do: bsr(l, r)
-
-  defp safe_binop_dispatch(:rshift, l, r),
-    do:
-      {:exception,
-       "TypeError: unsupported operand type(s) for >>: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-
-  @spec ordering_compare(atom(), pyvalue(), pyvalue()) :: boolean() | {:exception, String.t()}
-  defp ordering_compare(op, l, r) when is_number(l) and is_number(r), do: ord_cmp(op, l, r)
-  defp ordering_compare(op, l, r) when is_binary(l) and is_binary(r), do: ord_cmp(op, l, r)
-  defp ordering_compare(op, l, r) when is_list(l) and is_list(r), do: ord_cmp(op, l, r)
-
-  defp ordering_compare(op, {:py_list, lr, _}, {:py_list, rr, _}),
-    do: ord_cmp(op, Enum.reverse(lr), Enum.reverse(rr))
-
-  defp ordering_compare(op, {:py_list, lr, _}, r) when is_list(r),
-    do: ord_cmp(op, Enum.reverse(lr), r)
-
-  defp ordering_compare(op, l, {:py_list, rr, _}) when is_list(l),
-    do: ord_cmp(op, l, Enum.reverse(rr))
-
-  defp ordering_compare(op, {:tuple, a}, {:tuple, b}), do: ord_cmp(op, a, b)
-
-  defp ordering_compare(op, l, r) when is_boolean(l) and is_number(r),
-    do: ordering_compare(op, bool_to_int(l), r)
-
-  defp ordering_compare(op, l, r) when is_number(l) and is_boolean(r),
-    do: ordering_compare(op, l, bool_to_int(r))
-
-  defp ordering_compare(_op, l, r) do
-    {:exception,
-     "TypeError: '<' not supported between instances of '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
-  end
-
-  @spec ord_cmp(atom(), term(), term()) :: boolean()
-  defp ord_cmp(:lt, l, r), do: l < r
-  defp ord_cmp(:gt, l, r), do: l > r
-  defp ord_cmp(:lte, l, r), do: l <= r
-  defp ord_cmp(:gte, l, r), do: l >= r
-
-  @spec bool_to_int(boolean()) :: 0 | 1
-  defp bool_to_int(true), do: 1
-  defp bool_to_int(false), do: 0
+  defdelegate safe_binop(op, l, r), to: BinaryOps
 
   @spec eval_chained_compare([atom()], [Parser.ast_node()], pyvalue() | nil, Env.t(), Ctx.t()) ::
           {pyvalue(), Env.t(), Ctx.t()}
@@ -3821,51 +1642,9 @@ defmodule Pyex.Interpreter do
     {start, stop}
   end
 
-  @spec setattr(Parser.ast_node(), pyvalue(), Env.t(), Ctx.t()) :: eval_result()
-  defp setattr({:getattr, _, [{:var, _, [var_name]}, attr]}, value, env, ctx) do
-    case Env.get(env, var_name) do
-      {:ok, {:instance, class, attrs}} ->
-        updated = {:instance, class, Map.put(attrs, attr, value)}
-        {nil, Env.put_at_source(env, var_name, updated), ctx}
-
-      {:ok, {:class, name, bases, class_attrs}} ->
-        updated = {:class, name, bases, Map.put(class_attrs, attr, value)}
-        {nil, Env.put_at_source(env, var_name, updated), ctx}
-
-      {:ok, other} when is_map(other) ->
-        updated = Map.put(other, attr, value)
-        {nil, Env.put_at_source(env, var_name, updated), ctx}
-
-      _ ->
-        {{:exception, "AttributeError: cannot set attribute '#{attr}'"}, env, ctx}
-    end
-  end
-
-  defp setattr({:getattr, _, [inner_target, attr]}, value, env, ctx) do
-    case eval(inner_target, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {{:instance, class, attrs}, env, ctx} ->
-        updated = {:instance, class, Map.put(attrs, attr, value)}
-        write_back_target(inner_target, updated, env, ctx)
-
-      _ ->
-        {{:exception, "AttributeError: cannot set attribute '#{attr}'"}, env, ctx}
-    end
-  end
-
-  defp setattr(_target, _value, env, ctx) do
-    {{:exception, "SyntaxError: cannot assign to attribute"}, env, ctx}
-  end
-
-  @spec setattr_nested(Parser.ast_node(), pyvalue(), Env.t(), Ctx.t()) :: eval_result()
-  defp setattr_nested({:getattr, meta, [obj_expr, attr]}, value, env, ctx) do
-    setattr({:getattr, meta, [obj_expr, attr]}, value, env, ctx)
-  end
-
+  @doc false
   @spec eval_sort([pyvalue()], pyvalue() | nil, boolean(), Env.t(), Ctx.t()) :: call_result()
-  defp eval_sort(items, key_fn, reverse, env, ctx) do
+  def eval_sort(items, key_fn, reverse, env, ctx) do
     has_instances? = Enum.any?(items, &match?({:instance, _, _}, &1))
 
     sorted =
@@ -3890,9 +1669,10 @@ defmodule Pyex.Interpreter do
     end
   end
 
+  @doc false
   @spec eval_minmax([pyvalue()], pyvalue(), :min | :max, Env.t(), Ctx.t()) ::
           {pyvalue(), Env.t(), Ctx.t()}
-  defp eval_minmax(items, key_fn, op, env, ctx) do
+  def eval_minmax(items, key_fn, op, env, ctx) do
     keys_result =
       Enum.reduce_while(items, {:ok, [], env, ctx}, fn item, {:ok, acc, env, ctx} ->
         case call_function(key_fn, [item], %{}, env, ctx) do
@@ -3993,137 +1773,7 @@ defmodule Pyex.Interpreter do
 
   defp pyvalue_lte(a, b), do: a <= b
 
-  # For setattr(obj, attr, val), the first arg_expr is the mutation target.
-  # For everything else (method calls, callable instances), func_expr is the target.
-  defp mutate_target_expr({:var, _, ["setattr"]}, [first_arg | _]) do
-    first_arg
-  end
-
-  defp mutate_target_expr(func_expr, _arg_exprs), do: func_expr
-
-  @spec mutate_target(Parser.ast_node(), pyvalue(), Env.t(), Ctx.t()) :: Env.t()
-  defp mutate_target({:getattr, _, [{:var, _, [var_name]}, _method]}, new_object, env, _ctx) do
-    Env.smart_put(env, var_name, new_object)
-  end
-
-  defp mutate_target(
-         {:getattr, _, [{:getattr, _, _} = inner_target, _method]},
-         new_object,
-         env,
-         ctx
-       ) do
-    case setattr(inner_target, new_object, env, ctx) do
-      {_, env, _} -> env
-    end
-  end
-
-  defp mutate_target({:getattr, _, [{:call, _, _}, _method]}, new_object, env, _ctx) do
-    Env.smart_put(env, "self", new_object)
-  end
-
-  defp mutate_target(
-         {:getattr, _, [{:subscript, _, [container_expr, key_expr]}, _method]},
-         new_object,
-         env,
-         ctx
-       ) do
-    {container, env, ctx} = eval(container_expr, env, ctx)
-    {key, env, _ctx} = eval(key_expr, env, ctx)
-    new_container = set_subscript_value(container, key, new_object)
-    mutate_target(container_expr, new_container, env, ctx)
-  end
-
-  defp mutate_target({:var, _, [var_name]}, new_object, env, _ctx) do
-    Env.smart_put(env, var_name, new_object)
-  end
-
-  defp mutate_target({:subscript, _, [expr, _index]}, new_object, env, ctx) do
-    mutate_target(expr, new_object, env, ctx)
-  end
-
-  defp mutate_target(_, _new_object, env, _ctx), do: env
-
-  @spec write_back_target(Parser.ast_node(), pyvalue(), Env.t(), Ctx.t()) :: eval_result()
-  defp write_back_target({:var, _, [name]}, value, env, ctx) do
-    {nil, Env.smart_put(env, name, value), ctx}
-  end
-
-  defp write_back_target({:getattr, _, [{:var, _, [var_name]}, attr]}, value, env, ctx) do
-    case Env.get(env, var_name) do
-      {:ok, {:instance, class, attrs}} ->
-        updated = {:instance, class, Map.put(attrs, attr, value)}
-        {nil, Env.smart_put(env, var_name, updated), ctx}
-
-      _ ->
-        {{:exception, "AttributeError: cannot write back to nested attribute"}, env, ctx}
-    end
-  end
-
-  defp write_back_target(_, _, env, ctx) do
-    {{:exception, "SyntaxError: cannot assign to nested attribute"}, env, ctx}
-  end
-
-  @spec get_mutated_instance(Env.t(), pyvalue()) :: pyvalue()
-  defp get_mutated_instance(env, {:instance, _, _} = original) do
-    case Env.get(env, "self") do
-      {:ok, {:instance, _, _} = updated} -> updated
-      _ -> original
-    end
-  end
-
-  @spec call_method(
-          pyvalue(),
-          pyvalue(),
-          [pyvalue()],
-          %{optional(String.t()) => pyvalue()},
-          Env.t(),
-          Ctx.t()
-        ) ::
-          call_result()
-  defp call_method(instance, {:function, _, _, _, _} = func, args, kwargs, env, ctx) do
-    method_args = [instance | args]
-
-    case call_function(func, method_args, kwargs, env, ctx) do
-      {{:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {result, env, ctx, _updated} ->
-        updated_instance = get_mutated_instance(env, instance)
-        env = rebind_instance(env, instance, updated_instance)
-        {result, env, ctx}
-
-      {result, env, ctx} ->
-        updated_instance = get_mutated_instance(env, instance)
-        env = rebind_instance(env, instance, updated_instance)
-        {result, env, ctx}
-    end
-  end
-
-  @spec rebind_instance(Env.t(), pyvalue(), pyvalue()) :: Env.t()
-  defp rebind_instance(env, _old, new) do
-    case Env.get(env, "self") do
-      {:ok, {:instance, _, _}} -> Env.smart_put(env, "self", new)
-      _ -> env
-    end
-  end
-
-  @spec maybe_update_instance_var(Env.t(), String.t()) :: Env.t()
-  defp maybe_update_instance_var(env, var_name) do
-    case Env.get(env, var_name) do
-      {:ok, {:instance, _, _}} ->
-        case Env.get(env, "self") do
-          {:ok, {:instance, _, _} = updated_self} ->
-            Env.smart_put(env, var_name, updated_self)
-
-          _ ->
-            env
-        end
-
-      _ ->
-        env
-    end
-  end
-
+  @doc false
   @spec eval_instance_next(
           pyvalue(),
           non_neg_integer(),
@@ -4132,30 +1782,12 @@ defmodule Pyex.Interpreter do
           Ctx.t()
         ) ::
           eval_result()
-  defp eval_instance_next(inst, id, default_opt, env, ctx) do
-    case call_dunder_mut(inst, "__next__", [], env, ctx) do
-      {:ok, _new_inst, {:exception, "StopIteration" <> _}, env, ctx} ->
-        ctx = Ctx.delete_iterator(ctx, id)
+  def eval_instance_next(inst, id, default_opt, env, ctx),
+    do: Iterables.eval_instance_next(inst, id, default_opt, env, ctx)
 
-        case default_opt do
-          {:default, default} -> {default, env, ctx}
-          :no_default -> {{:exception, "StopIteration"}, env, ctx}
-        end
-
-      {:ok, _new_inst, {:exception, _} = signal, env, ctx} ->
-        {signal, env, ctx}
-
-      {:ok, new_inst, value, env, ctx} ->
-        ctx = Ctx.update_instance_iterator(ctx, id, new_inst)
-        {value, env, ctx}
-
-      :not_found ->
-        {{:exception, "TypeError: object has no __next__"}, env, ctx}
-    end
-  end
-
+  @doc false
   @spec eval_print_call([pyvalue()], String.t(), String.t(), Env.t(), Ctx.t()) :: eval_result()
-  defp eval_print_call(args, sep, end_str, env, ctx) do
+  def eval_print_call(args, sep, end_str, env, ctx) do
     {strs, env, ctx} =
       Enum.reduce(args, {[], env, ctx}, fn arg, {acc, env, ctx} ->
         {str, env, ctx} = eval_py_str(arg, env, ctx)
@@ -4168,8 +1800,9 @@ defmodule Pyex.Interpreter do
     {nil, env, ctx}
   end
 
+  @doc false
   @spec eval_super(Env.t(), Ctx.t()) :: eval_result()
-  defp eval_super(env, ctx) do
+  def eval_super(env, ctx) do
     case Env.get(env, "self") do
       {:ok, {:instance, _, _} = instance} ->
         case Env.get(env, "__class__") do
@@ -4187,151 +1820,6 @@ defmodule Pyex.Interpreter do
         {{:exception, "RuntimeError: super(): self is not bound"}, env, ctx}
     end
   end
-
-  @spec call_dunder(pyvalue(), String.t(), [pyvalue()], Env.t(), Ctx.t()) ::
-          {:ok, pyvalue(), Env.t(), Ctx.t()} | :not_found
-  defp call_dunder(instance, method, args, env, ctx) do
-    case call_dunder_mut(instance, method, args, env, ctx) do
-      {:ok, _new_obj, return_val, env, ctx} -> {:ok, return_val, env, ctx}
-      :not_found -> :not_found
-    end
-  end
-
-  @spec call_dunder_mut(pyvalue(), String.t(), [pyvalue()], Env.t(), Ctx.t()) ::
-          {:ok, pyvalue(), pyvalue(), Env.t(), Ctx.t()} | :not_found
-  defp call_dunder_mut(
-         {:instance, {:class, _, _, _} = class, _} = instance,
-         method,
-         args,
-         env,
-         ctx
-       ) do
-    case resolve_class_attr(class, method) do
-      {:ok, {:function, _, _, _, _} = func} ->
-        case call_function({:bound_method, instance, func}, args, %{}, env, ctx) do
-          {:mutate, new_obj, return_val, new_env, ctx} ->
-            {:ok, new_obj, return_val, new_env, ctx}
-
-          {:mutate, new_obj, return_val, ctx} ->
-            {:ok, new_obj, return_val, env, ctx}
-
-          {{:exception, _} = signal, env, ctx} ->
-            {:ok, instance, signal, env, ctx}
-
-          {return_val, env, ctx} ->
-            {:ok, instance, return_val, env, ctx}
-
-          {return_val, env, ctx, _} ->
-            {:ok, instance, return_val, env, ctx}
-        end
-
-      {:ok, {:builtin, fun}} ->
-        case call_function({:builtin, fun}, [instance | args], %{}, env, ctx) do
-          {:mutate, new_obj, return_val, ctx} ->
-            {:ok, new_obj, return_val, env, ctx}
-
-          {{:exception, _} = signal, env, ctx} ->
-            {:ok, instance, signal, env, ctx}
-
-          {return_val, env, ctx} ->
-            {:ok, instance, return_val, env, ctx}
-        end
-
-      _ ->
-        :not_found
-    end
-  end
-
-  defp call_dunder_mut({:file_handle, _id} = handle, "__enter__", [], env, ctx) do
-    {:ok, handle, handle, env, ctx}
-  end
-
-  defp call_dunder_mut({:file_handle, id} = handle, "__exit__", _args, env, ctx) do
-    case Ctx.close_handle(ctx, id) do
-      {:ok, ctx} -> {:ok, handle, nil, env, ctx}
-      {:error, _} -> {:ok, handle, nil, env, ctx}
-    end
-  end
-
-  defp call_dunder_mut(_, _, _, _, _), do: :not_found
-
-  @spec resolve_class_attr(pyvalue(), String.t()) :: {:ok, pyvalue()} | :error
-  defp resolve_class_attr(class, attr) do
-    mro = c3_linearize(class)
-
-    Enum.find_value(mro, :error, fn {:class, _, _, class_attrs} ->
-      case Map.get(class_attrs, attr) do
-        nil -> nil
-        value -> {:ok, value}
-      end
-    end)
-  end
-
-  @spec resolve_class_attr_with_owner(pyvalue(), String.t()) ::
-          {:ok, pyvalue(), pyvalue()} | :error
-  defp resolve_class_attr_with_owner(class, attr) do
-    mro = c3_linearize(class)
-
-    Enum.find_value(mro, :error, fn {:class, _, _, class_attrs} = c ->
-      case Map.get(class_attrs, attr) do
-        nil -> nil
-        value -> {:ok, value, c}
-      end
-    end)
-  end
-
-  @spec c3_linearize(pyvalue()) :: [pyvalue()]
-  defp c3_linearize({:class, _, [], _} = class), do: [class]
-
-  defp c3_linearize({:class, _, bases, _} = class) do
-    parent_mros = Enum.map(bases, &c3_linearize/1)
-    [class | c3_merge(parent_mros ++ [bases])]
-  end
-
-  @spec c3_merge([[pyvalue()]]) :: [pyvalue()]
-  defp c3_merge(lists) do
-    lists = Enum.reject(lists, &(&1 == []))
-
-    case lists do
-      [] ->
-        []
-
-      _ ->
-        case find_c3_head(lists) do
-          {:ok, head} ->
-            remaining =
-              lists
-              |> Enum.map(fn list ->
-                case list do
-                  [^head | rest] -> rest
-                  _ -> Enum.reject(list, &(&1 == head))
-                end
-              end)
-
-            [head | c3_merge(remaining)]
-
-          :error ->
-            Enum.flat_map(lists, & &1) |> Enum.uniq()
-        end
-    end
-  end
-
-  @spec find_c3_head([[pyvalue()]]) :: {:ok, pyvalue()} | :error
-  defp find_c3_head(lists) do
-    tails = lists |> Enum.flat_map(&tl_safe/1) |> MapSet.new()
-
-    Enum.find_value(lists, :error, fn
-      [head | _] ->
-        if MapSet.member?(tails, head), do: nil, else: {:ok, head}
-
-      [] ->
-        nil
-    end)
-  end
-
-  @spec tl_safe([pyvalue()]) :: [pyvalue()]
-  defp tl_safe([]), do: []
-  defp tl_safe([_ | rest]), do: rest
 
   @spec yield_from_deferred([pyvalue()], Env.t(), Ctx.t()) :: eval_result()
   defp yield_from_deferred([], env, ctx), do: {nil, env, ctx}
@@ -4379,7 +1867,7 @@ defmodule Pyex.Interpreter do
   end
 
   def resume_generator([{:cont_for, var, items, body, else_body} | rest], env, ctx) do
-    case eval_for(var, items, body, else_body, env, ctx) do
+    case ControlFlow.eval_for_items(var, items, body, else_body, env, ctx) do
       {{:yielded, val, inner_cont}, env, ctx} ->
         {{:yielded, val, inner_cont ++ rest}, env, ctx}
 
@@ -4395,7 +1883,7 @@ defmodule Pyex.Interpreter do
   end
 
   def resume_generator([{:cont_while, condition, body, else_body} | rest], env, ctx) do
-    case eval_while(condition, body, else_body, env, ctx) do
+    case ControlFlow.eval_while(condition, body, else_body, env, ctx) do
       {{:yielded, val, inner_cont}, env, ctx} ->
         {{:yielded, val, inner_cont ++ rest}, env, ctx}
 
@@ -4420,25 +1908,26 @@ defmodule Pyex.Interpreter do
     end
   end
 
+  @doc false
   @spec contains_yield?([Parser.ast_node()]) :: boolean()
-  defp contains_yield?([]), do: false
+  def contains_yield?([]), do: false
 
-  defp contains_yield?([{:yield, _, _} | _]), do: true
-  defp contains_yield?([{:yield_from, _, _} | _]), do: true
+  def contains_yield?([{:yield, _, _} | _]), do: true
+  def contains_yield?([{:yield_from, _, _} | _]), do: true
 
-  defp contains_yield?([{:def, _, _} | rest]) do
+  def contains_yield?([{:def, _, _} | rest]) do
     contains_yield?(rest)
   end
 
-  defp contains_yield?([{:class, _, _} | rest]) do
+  def contains_yield?([{:class, _, _} | rest]) do
     contains_yield?(rest)
   end
 
-  defp contains_yield?([{:lambda, _, _} | rest]) do
+  def contains_yield?([{:lambda, _, _} | rest]) do
     contains_yield?(rest)
   end
 
-  defp contains_yield?([{_, _, children} | rest]) when is_list(children) do
+  def contains_yield?([{_, _, children} | rest]) when is_list(children) do
     Enum.any?(children, fn
       child when is_list(child) ->
         contains_yield?(child)
@@ -4454,37 +1943,7 @@ defmodule Pyex.Interpreter do
     end) or contains_yield?(rest)
   end
 
-  defp contains_yield?([_ | rest]), do: contains_yield?(rest)
-
-  @spec write_back_subscript(Parser.ast_node(), pyvalue(), Env.t(), Ctx.t()) :: eval_result()
-  defp write_back_subscript({:var, _, [name]}, updated, env, ctx) do
-    {updated, Env.put_at_source(env, name, updated), ctx}
-  end
-
-  defp write_back_subscript({:subscript, _, [parent_expr, key_expr]}, updated, env, ctx) do
-    {parent, env, ctx} = eval(parent_expr, env, ctx)
-    {key, env, ctx} = eval(key_expr, env, ctx)
-    updated_parent = set_subscript_value(parent, key, updated)
-    write_back_subscript(parent_expr, updated_parent, env, ctx)
-  end
-
-  defp write_back_subscript({:getattr, _, _} = target, updated, env, ctx) do
-    setattr_nested(target, updated, env, ctx)
-  end
-
-  defp write_back_subscript(_, updated, env, ctx) do
-    {updated, env, ctx}
-  end
-
-  @spec decrement_depth(call_result()) :: call_result()
-  defp decrement_depth({{:exception, _} = signal, env, ctx}),
-    do: {signal, env, %{ctx | call_depth: ctx.call_depth - 1}}
-
-  defp decrement_depth({val, env, ctx, updated_func}),
-    do: {val, env, %{ctx | call_depth: ctx.call_depth - 1}, updated_func}
-
-  defp decrement_depth({val, env, ctx}),
-    do: {val, env, %{ctx | call_depth: ctx.call_depth - 1}}
+  def contains_yield?([_ | rest]), do: contains_yield?(rest)
 
   @spec extract_exception_type_name(String.t()) :: String.t() | nil
   defp extract_exception_type_name(msg) do

--- a/lib/pyex/interpreter/assignments.ex
+++ b/lib/pyex/interpreter/assignments.ex
@@ -1,0 +1,539 @@
+defmodule Pyex.Interpreter.Assignments do
+  @moduledoc """
+  Attribute and subscript assignment helpers for `Pyex.Interpreter`.
+
+  Keeps write-back semantics together so mutation-heavy evaluation paths
+  stay isolated from the main interpreter dispatch.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+  alias Pyex.Interpreter.{Dunder, Helpers}
+
+  @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+
+  defguardp is_py_exception(value) when is_tuple(value) and elem(value, 0) == :exception
+
+  @doc """
+  Evaluates direct attribute assignment.
+  """
+  @spec eval_attr_assign(Parser.ast_node(), Parser.ast_node(), Env.t(), Ctx.t()) :: eval_result()
+  def eval_attr_assign(target, expr, env, ctx) do
+    case Interpreter.eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {value, env, ctx} ->
+        setattr(target, value, env, ctx)
+    end
+  end
+
+  @doc """
+  Evaluates augmented attribute assignment.
+  """
+  @spec eval_aug_attr_assign(Parser.ast_node(), atom(), Parser.ast_node(), Env.t(), Ctx.t()) ::
+          eval_result()
+  def eval_aug_attr_assign(target, op, expr, env, ctx) do
+    case Interpreter.eval(target, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {old_value, env, ctx} ->
+        case Interpreter.eval(expr, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {rhs, env, ctx} ->
+            case Interpreter.safe_binop(op, old_value, rhs) do
+              {:exception, _} = signal -> {signal, env, ctx}
+              new_value -> setattr(target, new_value, env, ctx)
+            end
+        end
+    end
+  end
+
+  @doc """
+  Evaluates nested subscript assignment.
+  """
+  @spec eval_nested_subscript_assign(
+          Parser.ast_node(),
+          Parser.ast_node(),
+          Parser.ast_node(),
+          Parser.ast_node(),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def eval_nested_subscript_assign(
+        container_expr,
+        outer_key_expr,
+        inner_key_expr,
+        val_expr,
+        env,
+        ctx
+      ) do
+    with {container, env, ctx} when not is_py_exception(container) <-
+           Interpreter.eval(container_expr, env, ctx),
+         {outer_key, env, ctx} when not is_py_exception(outer_key) <-
+           Interpreter.eval(outer_key_expr, env, ctx),
+         {inner_key, env, ctx} when not is_py_exception(inner_key) <-
+           Interpreter.eval(inner_key_expr, env, ctx),
+         {val, env, ctx} when not is_py_exception(val) <- Interpreter.eval(val_expr, env, ctx) do
+      case get_subscript_value(container, outer_key) do
+        {:exception, msg} ->
+          {{:exception, msg}, env, ctx}
+
+        {:defaultdict_call_needed, factory} ->
+          case Interpreter.call_function(factory, [], %{}, env, ctx) do
+            {{:exception, _} = signal, env, ctx} ->
+              {signal, env, ctx}
+
+            {default_val, env, ctx, _updated_func} ->
+              container = set_subscript_value(container, outer_key, default_val)
+              updated_inner = set_subscript_value(default_val, inner_key, val)
+              updated_outer = set_subscript_value(container, outer_key, updated_inner)
+              write_back_subscript(container_expr, updated_outer, env, ctx)
+
+            {default_val, env, ctx} ->
+              container = set_subscript_value(container, outer_key, default_val)
+              updated_inner = set_subscript_value(default_val, inner_key, val)
+              updated_outer = set_subscript_value(container, outer_key, updated_inner)
+              write_back_subscript(container_expr, updated_outer, env, ctx)
+          end
+
+        inner_container ->
+          updated_inner = set_subscript_value(inner_container, inner_key, val)
+          updated_outer = set_subscript_value(container, outer_key, updated_inner)
+          write_back_subscript(container_expr, updated_outer, env, ctx)
+      end
+    else
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates attribute-backed subscript assignment.
+  """
+  @spec eval_attr_subscript_assign(
+          Parser.ast_node(),
+          Parser.ast_node(),
+          Parser.ast_node(),
+          Env.t(),
+          Ctx.t()
+        ) ::
+          eval_result()
+  def eval_attr_subscript_assign(target_expr, key_expr, val_expr, env, ctx) do
+    with {container, env, ctx} when not is_py_exception(container) <-
+           Interpreter.eval(target_expr, env, ctx),
+         {key, env, ctx} when not is_py_exception(key) <- Interpreter.eval(key_expr, env, ctx),
+         {val, env, ctx} when not is_py_exception(val) <- Interpreter.eval(val_expr, env, ctx) do
+      case container do
+        %{} = map ->
+          setattr_nested(target_expr, Map.put(map, key, val), env, ctx)
+
+        {:py_list, reversed, len} when is_integer(key) ->
+          real_idx = if key < 0, do: len + key, else: key
+          updated = {:py_list, List.replace_at(reversed, len - 1 - real_idx, val), len}
+          setattr_nested(target_expr, updated, env, ctx)
+
+        list when is_list(list) and is_integer(key) ->
+          setattr_nested(target_expr, List.replace_at(list, key, val), env, ctx)
+
+        _ ->
+          {{:exception, "TypeError: object does not support item assignment"}, env, ctx}
+      end
+    else
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates name-backed subscript assignment.
+  """
+  @spec eval_name_subscript_assign(
+          String.t(),
+          Parser.ast_node(),
+          Parser.ast_node(),
+          Env.t(),
+          Ctx.t()
+        ) ::
+          eval_result()
+  def eval_name_subscript_assign(name, key_expr, val_expr, env, ctx) do
+    with {container, env, ctx} when not is_py_exception(container) <-
+           Interpreter.eval({:var, [line: 1], [name]}, env, ctx),
+         {key, env, ctx} when not is_py_exception(key) <- Interpreter.eval(key_expr, env, ctx),
+         {val, env, ctx} when not is_py_exception(val) <- Interpreter.eval(val_expr, env, ctx) do
+      case container do
+        %{} = map ->
+          {val, Env.put_at_source(env, name, Map.put(map, key, val)), ctx}
+
+        {:py_list, reversed, len} when is_integer(key) ->
+          real_idx = if key < 0, do: len + key, else: key
+          updated = {:py_list, List.replace_at(reversed, len - 1 - real_idx, val), len}
+          {val, Env.put_at_source(env, name, updated), ctx}
+
+        list when is_list(list) and is_integer(key) ->
+          {val, Env.put_at_source(env, name, List.replace_at(list, key, val)), ctx}
+
+        {:instance, _, _} = inst ->
+          case Dunder.call_dunder_mut(inst, "__setitem__", [key, val], env, ctx) do
+            {:ok, updated_inst, _return_val, env, ctx} ->
+              {val, Env.put_at_source(env, name, updated_inst), ctx}
+
+            :not_found ->
+              {{:exception,
+                "TypeError: '#{Helpers.py_type(inst)}' object does not support item assignment"},
+               env, ctx}
+          end
+
+        _ ->
+          {{:exception, "TypeError: object does not support item assignment"}, env, ctx}
+      end
+    else
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates nested augmented subscript assignment.
+  """
+  @spec eval_nested_aug_subscript_assign(
+          Parser.ast_node(),
+          Parser.ast_node(),
+          Parser.ast_node(),
+          atom(),
+          Parser.ast_node(),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def eval_nested_aug_subscript_assign(
+        container_expr,
+        outer_key_expr,
+        inner_key_expr,
+        op,
+        val_expr,
+        env,
+        ctx
+      ) do
+    with {container, env, ctx} when not is_py_exception(container) <-
+           Interpreter.eval(container_expr, env, ctx),
+         {outer_key, env, ctx} when not is_py_exception(outer_key) <-
+           Interpreter.eval(outer_key_expr, env, ctx),
+         {inner_key, env, ctx} when not is_py_exception(inner_key) <-
+           Interpreter.eval(inner_key_expr, env, ctx),
+         {val, env, ctx} when not is_py_exception(val) <- Interpreter.eval(val_expr, env, ctx) do
+      case get_subscript_value(container, outer_key) do
+        {:exception, msg} ->
+          {{:exception, msg}, env, ctx}
+
+        {:defaultdict_call_needed, factory} ->
+          case Interpreter.call_function(factory, [], %{}, env, ctx) do
+            {{:exception, _} = signal, env, ctx} ->
+              {signal, env, ctx}
+
+            {default_val, env, ctx, _updated_func} ->
+              # Auto-insert the default, then proceed with inner aug assign
+              container = set_subscript_value(container, outer_key, default_val)
+
+              do_nested_aug_inner(
+                container,
+                container_expr,
+                outer_key,
+                default_val,
+                inner_key,
+                op,
+                val,
+                env,
+                ctx
+              )
+
+            {default_val, env, ctx} ->
+              container = set_subscript_value(container, outer_key, default_val)
+
+              do_nested_aug_inner(
+                container,
+                container_expr,
+                outer_key,
+                default_val,
+                inner_key,
+                op,
+                val,
+                env,
+                ctx
+              )
+          end
+
+        inner_container ->
+          do_nested_aug_inner(
+            container,
+            container_expr,
+            outer_key,
+            inner_container,
+            inner_key,
+            op,
+            val,
+            env,
+            ctx
+          )
+      end
+    else
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+    end
+  end
+
+  defp do_nested_aug_inner(
+         container,
+         container_expr,
+         outer_key,
+         inner_container,
+         inner_key,
+         op,
+         val,
+         env,
+         ctx
+       ) do
+    case get_subscript_value(inner_container, inner_key) do
+      {:exception, msg} ->
+        {{:exception, msg}, env, ctx}
+
+      old_val ->
+        case Interpreter.safe_binop(op, old_val, val) do
+          {:exception, msg} ->
+            {{:exception, msg}, env, ctx}
+
+          new_val ->
+            updated_inner = set_subscript_value(inner_container, inner_key, new_val)
+            updated_outer = set_subscript_value(container, outer_key, updated_inner)
+            write_back_subscript(container_expr, updated_outer, env, ctx)
+        end
+    end
+  end
+
+  @doc """
+  Evaluates attribute-backed augmented subscript assignment.
+  """
+  @spec eval_attr_aug_subscript_assign(
+          Parser.ast_node(),
+          Parser.ast_node(),
+          atom(),
+          Parser.ast_node(),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def eval_attr_aug_subscript_assign(target_expr, key_expr, op, val_expr, env, ctx) do
+    with {container, env, ctx} when not is_py_exception(container) <-
+           Interpreter.eval(target_expr, env, ctx),
+         {key, env, ctx} when not is_py_exception(key) <- Interpreter.eval(key_expr, env, ctx),
+         {val, env, ctx} when not is_py_exception(val) <- Interpreter.eval(val_expr, env, ctx) do
+      case container do
+        %{} = map ->
+          old_val = Map.get(map, key, 0)
+          new_val = Interpreter.safe_binop(op, old_val, val)
+          setattr_nested(target_expr, Map.put(map, key, new_val), env, ctx)
+
+        _ ->
+          {{:exception, "TypeError: object does not support item assignment"}, env, ctx}
+      end
+    else
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates name-backed augmented subscript assignment.
+  """
+  @spec eval_name_aug_subscript_assign(
+          String.t(),
+          Parser.ast_node(),
+          atom(),
+          Parser.ast_node(),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def eval_name_aug_subscript_assign(var_name, key_expr, op, val_expr, env, ctx) do
+    case Env.get(env, var_name) do
+      {:ok, obj} ->
+        with {key, env, ctx} when not is_py_exception(key) <- Interpreter.eval(key_expr, env, ctx),
+             {val, env, ctx} when not is_py_exception(val) <- Interpreter.eval(val_expr, env, ctx) do
+          case get_subscript_value(obj, key) do
+            {:exception, msg} ->
+              {{:exception, msg}, env, ctx}
+
+            {:defaultdict_call_needed, factory} ->
+              case Interpreter.call_function(factory, [], %{}, env, ctx) do
+                {{:exception, _} = signal, env, ctx} ->
+                  {signal, env, ctx}
+
+                {default_val, env, ctx, _updated_func} ->
+                  do_aug_subscript(obj, key, op, val, default_val, var_name, env, ctx)
+
+                {default_val, env, ctx} ->
+                  do_aug_subscript(obj, key, op, val, default_val, var_name, env, ctx)
+              end
+
+            current_val ->
+              case Interpreter.safe_binop(op, current_val, val) do
+                {:exception, msg} ->
+                  {{:exception, msg}, env, ctx}
+
+                new_val ->
+                  new_obj = set_subscript_value(obj, key, new_val)
+                  {new_val, Env.put_at_source(env, var_name, new_obj), ctx}
+              end
+          end
+        else
+          {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+        end
+
+      :undefined ->
+        {{:exception, "NameError: name '#{var_name}' is not defined"}, env, ctx}
+    end
+  end
+
+  defp do_aug_subscript(obj, key, op, val, default_val, var_name, env, ctx) do
+    # Insert default into dict first (auto-insert), then apply aug op
+    obj = set_subscript_value(obj, key, default_val)
+
+    case Interpreter.safe_binop(op, default_val, val) do
+      {:exception, msg} ->
+        {{:exception, msg}, env, ctx}
+
+      new_val ->
+        new_obj = set_subscript_value(obj, key, new_val)
+        {new_val, Env.put_at_source(env, var_name, new_obj), ctx}
+    end
+  end
+
+  @doc false
+  @spec setattr(Parser.ast_node(), Interpreter.pyvalue(), Env.t(), Ctx.t()) :: eval_result()
+  def setattr({:getattr, _, [{:var, _, [var_name]}, attr]}, value, env, ctx) do
+    case Env.get(env, var_name) do
+      {:ok, {:instance, class, attrs}} ->
+        updated = {:instance, class, Map.put(attrs, attr, value)}
+        {nil, Env.put_at_source(env, var_name, updated), ctx}
+
+      {:ok, {:class, name, bases, class_attrs}} ->
+        updated = {:class, name, bases, Map.put(class_attrs, attr, value)}
+        {nil, Env.put_at_source(env, var_name, updated), ctx}
+
+      {:ok, other} when is_map(other) ->
+        {nil, Env.put_at_source(env, var_name, Map.put(other, attr, value)), ctx}
+
+      _ ->
+        {{:exception, "AttributeError: cannot set attribute '#{attr}'"}, env, ctx}
+    end
+  end
+
+  def setattr({:getattr, _, [inner_target, attr]}, value, env, ctx) do
+    case Interpreter.eval(inner_target, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {{:instance, class, attrs}, env, ctx} ->
+        updated = {:instance, class, Map.put(attrs, attr, value)}
+        write_back_target(inner_target, updated, env, ctx)
+
+      _ ->
+        {{:exception, "AttributeError: cannot set attribute '#{attr}'"}, env, ctx}
+    end
+  end
+
+  def setattr(_target, _value, env, ctx) do
+    {{:exception, "SyntaxError: cannot assign to attribute"}, env, ctx}
+  end
+
+  @doc false
+  @spec setattr_nested(Parser.ast_node(), Interpreter.pyvalue(), Env.t(), Ctx.t()) ::
+          eval_result()
+  def setattr_nested({:getattr, meta, [obj_expr, attr]}, value, env, ctx) do
+    setattr({:getattr, meta, [obj_expr, attr]}, value, env, ctx)
+  end
+
+  @doc false
+  @spec get_subscript_value(Interpreter.pyvalue(), Interpreter.pyvalue()) ::
+          Interpreter.pyvalue() | {:exception, String.t()}
+  def get_subscript_value(obj, key) when is_map(obj) do
+    case Map.fetch(obj, key) do
+      {:ok, val} ->
+        val
+
+      :error ->
+        case Map.fetch(obj, "__defaultdict_factory__") do
+          {:ok, {:builtin_type, _, func}} -> func.([])
+          {:ok, {:builtin, func}} -> func.([])
+          {:ok, {:function, _, _, _, _} = func} -> {:defaultdict_call_needed, func}
+          _ -> {:exception, "KeyError: #{inspect(key)}"}
+        end
+    end
+  end
+
+  def get_subscript_value({:py_list, reversed, len}, key) when is_integer(key) do
+    idx = if key < 0, do: len + key, else: key
+
+    if idx < 0 or idx >= len do
+      {:exception, "IndexError: list index out of range"}
+    else
+      Enum.at(reversed, len - 1 - idx)
+    end
+  end
+
+  def get_subscript_value(obj, key) when is_list(obj) and is_integer(key) do
+    len = length(obj)
+    idx = if key < 0, do: len + key, else: key
+
+    if idx < 0 or idx >= len do
+      {:exception, "IndexError: list index out of range"}
+    else
+      Enum.at(obj, idx)
+    end
+  end
+
+  def get_subscript_value(_, _), do: {:exception, "TypeError: object is not subscriptable"}
+
+  @doc false
+  @spec set_subscript_value(Interpreter.pyvalue(), Interpreter.pyvalue(), Interpreter.pyvalue()) ::
+          Interpreter.pyvalue()
+  def set_subscript_value(obj, key, val) when is_map(obj), do: Map.put(obj, key, val)
+
+  def set_subscript_value({:py_list, reversed, len}, key, val) when is_integer(key) do
+    idx = if key < 0, do: len + key, else: key
+    {:py_list, List.replace_at(reversed, len - 1 - idx, val), len}
+  end
+
+  def set_subscript_value(obj, key, val) when is_list(obj) and is_integer(key) do
+    List.replace_at(obj, key, val)
+  end
+
+  @spec write_back_target(Parser.ast_node(), Interpreter.pyvalue(), Env.t(), Ctx.t()) ::
+          eval_result()
+  defp write_back_target({:var, _, [name]}, updated, env, ctx) do
+    {updated, Env.put_at_source(env, name, updated), ctx}
+  end
+
+  defp write_back_target({:getattr, _, _} = target, updated, env, ctx) do
+    setattr_nested(target, updated, env, ctx)
+  end
+
+  defp write_back_target(_, updated, env, ctx) do
+    {updated, env, ctx}
+  end
+
+  @spec write_back_subscript(Parser.ast_node(), Interpreter.pyvalue(), Env.t(), Ctx.t()) ::
+          eval_result()
+  defp write_back_subscript({:var, _, [name]}, updated, env, ctx) do
+    {updated, Env.put_at_source(env, name, updated), ctx}
+  end
+
+  defp write_back_subscript({:subscript, _, [parent_expr, key_expr]}, updated, env, ctx) do
+    {parent, env, ctx} = Interpreter.eval(parent_expr, env, ctx)
+    {key, env, ctx} = Interpreter.eval(key_expr, env, ctx)
+    updated_parent = set_subscript_value(parent, key, updated)
+    write_back_subscript(parent_expr, updated_parent, env, ctx)
+  end
+
+  defp write_back_subscript({:getattr, _, _} = target, updated, env, ctx) do
+    setattr_nested(target, updated, env, ctx)
+  end
+
+  defp write_back_subscript(_, updated, env, ctx) do
+    {updated, env, ctx}
+  end
+end

--- a/lib/pyex/interpreter/binary_ops.ex
+++ b/lib/pyex/interpreter/binary_ops.ex
@@ -1,0 +1,564 @@
+defmodule Pyex.Interpreter.BinaryOps do
+  @moduledoc """
+  Pure binary-operation evaluation for `Pyex.Interpreter`.
+
+  Every function here is side-effect-free: no `Env` or `Ctx` threading.
+  The main interpreter calls into this module after evaluating operands
+  and resolving dunder methods, so all values arriving here are plain
+  Pyex values.
+  """
+
+  import Bitwise, only: [band: 2, bor: 2, bxor: 2, bsl: 2, bsr: 2]
+
+  alias Pyex.Interpreter.{Format, Helpers}
+  alias Pyex.Stdlib.Collections
+
+  # -------------------------------------------------------------------
+  # Public API
+  # -------------------------------------------------------------------
+
+  @doc false
+  @spec safe_binop(atom(), term(), term()) :: term()
+  def safe_binop(op, l, r) when is_boolean(l) or is_boolean(r) do
+    case op do
+      op
+      when op in [
+             :plus,
+             :minus,
+             :star,
+             :slash,
+             :floor_div,
+             :percent,
+             :double_star,
+             :amp,
+             :pipe,
+             :caret,
+             :lshift,
+             :rshift,
+             :eq,
+             :neq,
+             :lt,
+             :gt,
+             :lte,
+             :gte
+           ] ->
+        safe_binop(op, Helpers.bool_to_int(l), Helpers.bool_to_int(r))
+
+      _ ->
+        dispatch(op, l, r)
+    end
+  end
+
+  def safe_binop(op, {:pyex_decimal, _} = l, r), do: decimal_dispatch(op, l, r)
+  def safe_binop(op, l, {:pyex_decimal, _} = r), do: decimal_dispatch(op, l, r)
+  def safe_binop(op, l, r), do: dispatch(op, l, r)
+
+  @doc false
+  @spec dunder_for_op(atom()) :: String.t() | nil
+  def dunder_for_op(:plus), do: "__add__"
+  def dunder_for_op(:minus), do: "__sub__"
+  def dunder_for_op(:star), do: "__mul__"
+  def dunder_for_op(:slash), do: "__truediv__"
+  def dunder_for_op(:floor_div), do: "__floordiv__"
+  def dunder_for_op(:percent), do: "__mod__"
+  def dunder_for_op(:double_star), do: "__pow__"
+  def dunder_for_op(:eq), do: "__eq__"
+  def dunder_for_op(:neq), do: "__ne__"
+  def dunder_for_op(:lt), do: "__lt__"
+  def dunder_for_op(:gt), do: "__gt__"
+  def dunder_for_op(:lte), do: "__le__"
+  def dunder_for_op(:gte), do: "__ge__"
+  def dunder_for_op(:amp), do: "__and__"
+  def dunder_for_op(:pipe), do: "__or__"
+  def dunder_for_op(:caret), do: "__xor__"
+  def dunder_for_op(:lshift), do: "__lshift__"
+  def dunder_for_op(:rshift), do: "__rshift__"
+  def dunder_for_op(:in), do: nil
+  def dunder_for_op(:not_in), do: nil
+  def dunder_for_op(:is), do: nil
+  def dunder_for_op(:is_not), do: nil
+  def dunder_for_op(:and), do: nil
+  def dunder_for_op(:or), do: nil
+  def dunder_for_op(_), do: nil
+
+  @doc false
+  @spec rdunder_for_op(atom()) :: String.t() | nil
+  def rdunder_for_op(:plus), do: "__radd__"
+  def rdunder_for_op(:minus), do: "__rsub__"
+  def rdunder_for_op(:star), do: "__rmul__"
+  def rdunder_for_op(:slash), do: "__rtruediv__"
+  def rdunder_for_op(:floor_div), do: "__rfloordiv__"
+  def rdunder_for_op(:percent), do: "__rmod__"
+  def rdunder_for_op(:double_star), do: "__rpow__"
+  def rdunder_for_op(:eq), do: "__eq__"
+  def rdunder_for_op(:neq), do: "__ne__"
+  def rdunder_for_op(:lt), do: "__gt__"
+  def rdunder_for_op(:gt), do: "__lt__"
+  def rdunder_for_op(:lte), do: "__ge__"
+  def rdunder_for_op(:gte), do: "__le__"
+  def rdunder_for_op(_), do: nil
+
+  @doc false
+  @spec ordering_compare(atom(), term(), term()) :: boolean() | {:exception, String.t()}
+  def ordering_compare(op, l, r) when is_number(l) and is_number(r), do: ord_cmp(op, l, r)
+  def ordering_compare(op, l, r) when is_binary(l) and is_binary(r), do: ord_cmp(op, l, r)
+  def ordering_compare(op, l, r) when is_list(l) and is_list(r), do: ord_cmp(op, l, r)
+
+  def ordering_compare(op, {:py_list, lr, _}, {:py_list, rr, _}),
+    do: ord_cmp(op, Enum.reverse(lr), Enum.reverse(rr))
+
+  def ordering_compare(op, {:py_list, lr, _}, r) when is_list(r),
+    do: ord_cmp(op, Enum.reverse(lr), r)
+
+  def ordering_compare(op, l, {:py_list, rr, _}) when is_list(l),
+    do: ord_cmp(op, l, Enum.reverse(rr))
+
+  def ordering_compare(op, {:tuple, a}, {:tuple, b}), do: ord_cmp(op, a, b)
+
+  def ordering_compare(op, l, r) when is_boolean(l) and is_number(r),
+    do: ordering_compare(op, bool_to_int(l), r)
+
+  def ordering_compare(op, l, r) when is_number(l) and is_boolean(r),
+    do: ordering_compare(op, l, bool_to_int(r))
+
+  def ordering_compare(_op, l, r) do
+    {:exception,
+     "TypeError: '<' not supported between instances of '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
+  end
+
+  @doc false
+  @spec binop_result(term(), term(), term()) :: {term(), term(), term()}
+  def binop_result({:exception, msg}, env, ctx), do: {{:exception, msg}, env, ctx}
+  def binop_result(value, env, ctx), do: {value, env, ctx}
+
+  @doc false
+  @spec series_binop(atom(), term(), term()) :: term()
+  def series_binop(op, l, r) do
+    ls = series_unwrap(l)
+    rs = series_unwrap(r)
+
+    result =
+      case op do
+        :plus -> Explorer.Series.add(ls, rs)
+        :minus -> Explorer.Series.subtract(ls, rs)
+        :star -> Explorer.Series.multiply(ls, rs)
+        :slash -> Explorer.Series.divide(ls, rs)
+        :gt -> Explorer.Series.greater(ls, rs)
+        :gte -> Explorer.Series.greater_equal(ls, rs)
+        :lt -> Explorer.Series.less(ls, rs)
+        :lte -> Explorer.Series.less_equal(ls, rs)
+        :eq -> Explorer.Series.equal(ls, rs)
+        :neq -> Explorer.Series.not_equal(ls, rs)
+        :amp -> series_bool_and(ls, rs)
+        :pipe -> series_bool_or(ls, rs)
+        _ -> {:exception, "TypeError: unsupported operand for Series"}
+      end
+
+    case result do
+      {:exception, _} = err -> err
+      %Explorer.Series{} = s -> {:pandas_series, s}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # Dispatch (all private)
+  # -------------------------------------------------------------------
+
+  # -- plus -----------------------------------------------------------
+
+  defp dispatch(:plus, l, r) when is_binary(l) and is_binary(r), do: l <> r
+
+  defp dispatch(:plus, {:py_list, lr, ll}, {:py_list, rr, rl}) do
+    items = Enum.reverse(lr) ++ Enum.reverse(rr)
+    {:py_list, Enum.reverse(items), ll + rl}
+  end
+
+  defp dispatch(:plus, {:py_list, lr, ll}, r) when is_list(r) do
+    items = Enum.reverse(lr) ++ r
+    {:py_list, Enum.reverse(items), ll + length(r)}
+  end
+
+  defp dispatch(:plus, l, {:py_list, rr, rl}) when is_list(l) do
+    items = l ++ Enum.reverse(rr)
+    {:py_list, Enum.reverse(items), length(l) + rl}
+  end
+
+  defp dispatch(:plus, l, r) when is_list(l) and is_list(r), do: l ++ r
+  defp dispatch(:plus, {:tuple, l}, {:tuple, r}), do: {:tuple, l ++ r}
+
+  defp dispatch(:plus, %{"__counter__" => true} = l, %{"__counter__" => true} = r) do
+    Collections.counter_add(l, r)
+  end
+
+  defp dispatch(:plus, l, r) when is_number(l) and is_number(r), do: l + r
+
+  defp dispatch(:plus, l, r),
+    do: type_error("+", l, r)
+
+  # -- minus ----------------------------------------------------------
+
+  defp dispatch(:minus, l, r) when is_number(l) and is_number(r), do: l - r
+
+  defp dispatch(:minus, {:set, a}, {:set, b}),
+    do: {:set, MapSet.difference(a, b)}
+
+  defp dispatch(:minus, {:frozenset, a}, {:set, b}),
+    do: {:frozenset, MapSet.difference(a, b)}
+
+  defp dispatch(:minus, {:frozenset, a}, {:frozenset, b}),
+    do: {:frozenset, MapSet.difference(a, b)}
+
+  defp dispatch(:minus, {:set, a}, {:frozenset, b}),
+    do: {:set, MapSet.difference(a, b)}
+
+  defp dispatch(:minus, l, r),
+    do: type_error("-", l, r)
+
+  # -- star -----------------------------------------------------------
+
+  defp dispatch(:star, l, r) when is_binary(l) and is_integer(r) do
+    len = String.length(l) * max(r, 0)
+
+    if len > 10_000_000 do
+      {:exception, "MemoryError: string repetition would create #{len} characters (max 10000000)"}
+    else
+      String.duplicate(l, max(r, 0))
+    end
+  end
+
+  defp dispatch(:star, l, r) when is_integer(l) and is_binary(r),
+    do: dispatch(:star, r, l)
+
+  defp dispatch(:star, l, r) when is_integer(l) and is_list(r),
+    do: Helpers.repeat_list(r, l)
+
+  defp dispatch(:star, l, r) when is_list(l) and is_integer(r),
+    do: Helpers.repeat_list(l, r)
+
+  defp dispatch(:star, {:py_list, reversed, len}, r) when is_integer(r) do
+    case Helpers.repeat_list(Enum.reverse(reversed), r) do
+      {:exception, _} = err -> err
+      items -> {:py_list, Enum.reverse(items), len * max(r, 0)}
+    end
+  end
+
+  defp dispatch(:star, l, {:py_list, reversed, len}) when is_integer(l) do
+    case Helpers.repeat_list(Enum.reverse(reversed), l) do
+      {:exception, _} = err -> err
+      items -> {:py_list, Enum.reverse(items), len * max(l, 0)}
+    end
+  end
+
+  defp dispatch(:star, {:tuple, items}, r) when is_integer(r) do
+    case Helpers.repeat_list(items, r) do
+      {:exception, _} = err -> err
+      list -> {:tuple, list}
+    end
+  end
+
+  defp dispatch(:star, l, {:tuple, items}) when is_integer(l) do
+    case Helpers.repeat_list(items, l) do
+      {:exception, _} = err -> err
+      list -> {:tuple, list}
+    end
+  end
+
+  defp dispatch(:star, l, r) when is_number(l) and is_number(r), do: l * r
+
+  defp dispatch(:star, l, r),
+    do: type_error("*", l, r)
+
+  # -- slash ----------------------------------------------------------
+
+  defp dispatch(:slash, _l, r) when r == 0 or r == 0.0,
+    do: {:exception, "ZeroDivisionError: division by zero"}
+
+  defp dispatch(:slash, l, r) when is_number(l) and is_number(r), do: l / r
+
+  defp dispatch(:slash, l, r),
+    do: type_error("/", l, r)
+
+  # -- floor_div ------------------------------------------------------
+
+  defp dispatch(:floor_div, _l, r) when r == 0 or r == 0.0,
+    do: {:exception, "ZeroDivisionError: integer division or modulo by zero"}
+
+  defp dispatch(:floor_div, l, r) when is_integer(l) and is_integer(r),
+    do: Integer.floor_div(l, r)
+
+  defp dispatch(:floor_div, l, r) when is_number(l) and is_number(r),
+    do: Float.floor(l / r)
+
+  defp dispatch(:floor_div, l, r),
+    do: type_error("//", l, r)
+
+  # -- percent --------------------------------------------------------
+
+  defp dispatch(:percent, l, r) when is_binary(l), do: Format.string_format(l, r)
+
+  defp dispatch(:percent, _l, r) when r == 0 or r == 0.0,
+    do: {:exception, "ZeroDivisionError: integer division or modulo by zero"}
+
+  defp dispatch(:percent, l, r) when is_integer(l) and is_integer(r),
+    do: Integer.mod(l, r)
+
+  defp dispatch(:percent, l, r) when is_number(l) and is_number(r),
+    do: l - Float.floor(l / r) * r
+
+  defp dispatch(:percent, l, r),
+    do: type_error("%", l, r)
+
+  # -- double_star ----------------------------------------------------
+
+  defp dispatch(:double_star, l, r) when is_number(l) and is_number(r) do
+    cond do
+      l == 0 and r < 0 ->
+        {:exception, "ZeroDivisionError: 0 cannot be raised to a negative power"}
+
+      is_integer(l) and is_integer(r) and r >= 0 ->
+        Helpers.int_pow(l, r)
+
+      is_float(l) or is_float(r) ->
+        try do
+          :math.pow(l, r)
+        rescue
+          ArithmeticError ->
+            {:exception, "ValueError: math domain error"}
+        end
+
+      true ->
+        try do
+          :math.pow(l, r) |> Helpers.maybe_intify()
+        rescue
+          ArithmeticError ->
+            {:exception, "ValueError: math domain error"}
+        end
+    end
+  end
+
+  defp dispatch(:double_star, l, r),
+    do: type_error("**", l, r)
+
+  # -- equality -------------------------------------------------------
+
+  defp dispatch(:eq, {:py_list, lr, _}, {:py_list, rr, _}),
+    do: Enum.reverse(lr) == Enum.reverse(rr)
+
+  defp dispatch(:eq, {:py_list, reversed, _}, r) when is_list(r),
+    do: Enum.reverse(reversed) == r
+
+  defp dispatch(:eq, l, {:py_list, reversed, _}) when is_list(l),
+    do: l == Enum.reverse(reversed)
+
+  defp dispatch(:eq, l, r), do: l == r
+
+  defp dispatch(:neq, {:py_list, lr, _}, {:py_list, rr, _}),
+    do: Enum.reverse(lr) != Enum.reverse(rr)
+
+  defp dispatch(:neq, {:py_list, reversed, _}, r) when is_list(r),
+    do: Enum.reverse(reversed) != r
+
+  defp dispatch(:neq, l, {:py_list, reversed, _}) when is_list(l),
+    do: l != Enum.reverse(reversed)
+
+  defp dispatch(:neq, l, r), do: l != r
+
+  # -- ordering -------------------------------------------------------
+
+  defp dispatch(:lt, l, r), do: ordering_compare(:lt, l, r)
+  defp dispatch(:gt, l, r), do: ordering_compare(:gt, l, r)
+  defp dispatch(:lte, l, r), do: ordering_compare(:lte, l, r)
+  defp dispatch(:gte, l, r), do: ordering_compare(:gte, l, r)
+
+  # -- membership -----------------------------------------------------
+
+  defp dispatch(:in, l, {:tuple, items}), do: l in items
+  defp dispatch(:in, l, {:py_list, reversed, _}), do: l in reversed
+  defp dispatch(:in, l, r) when is_list(r), do: l in r
+
+  defp dispatch(:in, l, r) when is_binary(l) and is_binary(r),
+    do: String.contains?(r, l)
+
+  defp dispatch(:in, l, r) when is_map(r),
+    do: Map.has_key?(Pyex.Builtins.visible_dict(r), l)
+
+  defp dispatch(:in, l, {:set, s}), do: MapSet.member?(s, l)
+  defp dispatch(:in, l, {:frozenset, s}), do: MapSet.member?(s, l)
+
+  defp dispatch(:in, l, {:range, start, stop, step}) when is_integer(l) do
+    cond do
+      step > 0 and l >= start and l < stop -> rem(l - start, step) == 0
+      step < 0 and l <= start and l > stop -> rem(start - l, -step) == 0
+      true -> false
+    end
+  end
+
+  defp dispatch(:in, _l, {:range, _, _, _}), do: false
+
+  defp dispatch(:in, _l, r),
+    do: {:exception, "TypeError: argument of type '#{Helpers.py_type(r)}' is not iterable"}
+
+  # -- identity -------------------------------------------------------
+
+  defp dispatch(:is, l, r), do: l === r
+  defp dispatch(:is_not, l, r), do: l !== r
+
+  # -- not_in ---------------------------------------------------------
+
+  defp dispatch(:not_in, l, r) do
+    case safe_binop(:in, l, r) do
+      {:exception, _} = exc -> exc
+      val -> not val
+    end
+  end
+
+  # -- bitwise --------------------------------------------------------
+
+  defp dispatch(:amp, {:set, a}, {:set, b}), do: {:set, MapSet.intersection(a, b)}
+
+  defp dispatch(:amp, {:frozenset, a}, {:set, b}),
+    do: {:frozenset, MapSet.intersection(a, b)}
+
+  defp dispatch(:amp, {:frozenset, a}, {:frozenset, b}),
+    do: {:frozenset, MapSet.intersection(a, b)}
+
+  defp dispatch(:amp, {:set, a}, {:frozenset, b}),
+    do: {:set, MapSet.intersection(a, b)}
+
+  defp dispatch(:amp, l, r) when is_integer(l) and is_integer(r), do: band(l, r)
+
+  defp dispatch(:amp, l, r),
+    do: type_error("&", l, r)
+
+  defp dispatch(:pipe, {:set, a}, {:set, b}), do: {:set, MapSet.union(a, b)}
+
+  defp dispatch(:pipe, {:frozenset, a}, {:set, b}),
+    do: {:frozenset, MapSet.union(a, b)}
+
+  defp dispatch(:pipe, {:frozenset, a}, {:frozenset, b}),
+    do: {:frozenset, MapSet.union(a, b)}
+
+  defp dispatch(:pipe, {:set, a}, {:frozenset, b}), do: {:set, MapSet.union(a, b)}
+
+  defp dispatch(:pipe, l, r) when is_integer(l) and is_integer(r), do: bor(l, r)
+
+  defp dispatch(:pipe, l, r),
+    do: type_error("|", l, r)
+
+  defp dispatch(:caret, {:set, a}, {:set, b}),
+    do: {:set, MapSet.symmetric_difference(a, b)}
+
+  defp dispatch(:caret, {:frozenset, a}, {:set, b}),
+    do: {:frozenset, MapSet.symmetric_difference(a, b)}
+
+  defp dispatch(:caret, {:frozenset, a}, {:frozenset, b}),
+    do: {:frozenset, MapSet.symmetric_difference(a, b)}
+
+  defp dispatch(:caret, {:set, a}, {:frozenset, b}),
+    do: {:set, MapSet.symmetric_difference(a, b)}
+
+  defp dispatch(:caret, l, r) when is_integer(l) and is_integer(r), do: bxor(l, r)
+
+  defp dispatch(:caret, l, r),
+    do: type_error("^", l, r)
+
+  # -- shifts ---------------------------------------------------------
+
+  defp dispatch(:lshift, l, r) when is_integer(l) and is_integer(r) do
+    if r > 100_000 do
+      {:exception, "OverflowError: left shift by #{r} exceeds maximum allowed (100000)"}
+    else
+      bsl(l, r)
+    end
+  end
+
+  defp dispatch(:lshift, l, r),
+    do: type_error("<<", l, r)
+
+  defp dispatch(:rshift, l, r) when is_integer(l) and is_integer(r), do: bsr(l, r)
+
+  defp dispatch(:rshift, l, r),
+    do: type_error(">>", l, r)
+
+  # -------------------------------------------------------------------
+  # Private helpers
+  # -------------------------------------------------------------------
+
+  defp type_error(op_str, l, r) do
+    {:exception,
+     "TypeError: unsupported operand type(s) for #{op_str}: '#{Helpers.py_type(l)}' and '#{Helpers.py_type(r)}'"}
+  end
+
+  defp ord_cmp(:lt, l, r), do: l < r
+  defp ord_cmp(:gt, l, r), do: l > r
+  defp ord_cmp(:lte, l, r), do: l <= r
+  defp ord_cmp(:gte, l, r), do: l >= r
+
+  defp bool_to_int(true), do: 1
+  defp bool_to_int(false), do: 0
+
+  defp series_unwrap({:pandas_series, s}), do: s
+  defp series_unwrap(v) when is_number(v), do: v
+  defp series_unwrap(true), do: 1
+  defp series_unwrap(false), do: 0
+
+  defp series_bool_and(%Explorer.Series{} = l, %Explorer.Series{} = r) do
+    Explorer.Series.and(l, r)
+  end
+
+  defp series_bool_or(%Explorer.Series{} = l, %Explorer.Series{} = r) do
+    Explorer.Series.or(l, r)
+  end
+
+  # -------------------------------------------------------------------
+  # Decimal dispatch
+  # -------------------------------------------------------------------
+
+  @spec decimal_dispatch(atom(), term(), term()) :: term()
+  defp decimal_dispatch(op, l, r) do
+    dl = to_decimal(l)
+    dr = to_decimal(r)
+
+    case {dl, dr} do
+      {{:error, _}, _} -> type_error(op_str(op), l, r)
+      {_, {:error, _}} -> type_error(op_str(op), l, r)
+      {dl, dr} -> decimal_op(op, dl, dr, l, r)
+    end
+  end
+
+  defp decimal_op(:plus, dl, dr, _l, _r), do: {:pyex_decimal, Decimal.add(dl, dr)}
+  defp decimal_op(:minus, dl, dr, _l, _r), do: {:pyex_decimal, Decimal.sub(dl, dr)}
+  defp decimal_op(:star, dl, dr, _l, _r), do: {:pyex_decimal, Decimal.mult(dl, dr)}
+
+  defp decimal_op(:slash, dl, dr, _l, _r) do
+    if Decimal.equal?(dr, Decimal.new(0)) do
+      {:exception, "ZeroDivisionError: division by zero"}
+    else
+      {:pyex_decimal, Decimal.div(dl, dr)}
+    end
+  end
+
+  defp decimal_op(:eq, dl, dr, _l, _r), do: Decimal.equal?(dl, dr)
+  defp decimal_op(:neq, dl, dr, _l, _r), do: not Decimal.equal?(dl, dr)
+  defp decimal_op(:lt, dl, dr, _l, _r), do: Decimal.lt?(dl, dr)
+  defp decimal_op(:gt, dl, dr, _l, _r), do: Decimal.gt?(dl, dr)
+  defp decimal_op(:lte, dl, dr, _l, _r), do: not Decimal.gt?(dl, dr)
+  defp decimal_op(:gte, dl, dr, _l, _r), do: not Decimal.lt?(dl, dr)
+  defp decimal_op(op, _dl, _dr, l, r), do: type_error(op_str(op), l, r)
+
+  defp to_decimal({:pyex_decimal, d}), do: d
+  defp to_decimal(n) when is_integer(n), do: Decimal.new(n)
+  defp to_decimal(_), do: {:error, :not_decimal}
+
+  defp op_str(:plus), do: "+"
+  defp op_str(:minus), do: "-"
+  defp op_str(:star), do: "*"
+  defp op_str(:slash), do: "/"
+  defp op_str(:eq), do: "=="
+  defp op_str(:neq), do: "!="
+  defp op_str(:lt), do: "<"
+  defp op_str(:gt), do: ">"
+  defp op_str(:lte), do: "<="
+  defp op_str(:gte), do: ">="
+  defp op_str(_), do: "?"
+end

--- a/lib/pyex/interpreter/bindings.ex
+++ b/lib/pyex/interpreter/bindings.ex
@@ -1,0 +1,151 @@
+defmodule Pyex.Interpreter.Bindings do
+  @moduledoc """
+  Variable binding and annotation evaluation helpers for `Pyex.Interpreter`.
+
+  Keeps plain-name assignment semantics together so the main interpreter can
+  focus on dispatch while preserving the existing public API.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+
+  @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+
+  @doc """
+  Evaluates `global` declarations.
+  """
+  @spec eval_global([String.t()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_global(names, env, ctx) do
+    env = Enum.reduce(names, env, &Env.declare_global(&2, &1))
+    {nil, env, ctx}
+  end
+
+  @doc """
+  Evaluates `nonlocal` declarations.
+  """
+  @spec eval_nonlocal([String.t()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_nonlocal(names, env, ctx) do
+    env = Enum.reduce(names, env, &Env.declare_nonlocal(&2, &1))
+    {nil, env, ctx}
+  end
+
+  @doc """
+  Evaluates a simple variable assignment.
+  """
+  @spec eval_assign(String.t(), Parser.ast_node(), Env.t(), Ctx.t()) :: eval_result()
+  def eval_assign(name, expr, env, ctx) do
+    case Interpreter.eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {value, env, ctx} ->
+        {value, Env.smart_put(env, name, value), ctx}
+    end
+  end
+
+  @doc """
+  Evaluates an annotated assignment without an initial value.
+  """
+  @spec eval_annotated_declaration(String.t(), String.t(), Env.t(), Ctx.t()) :: eval_result()
+  def eval_annotated_declaration(name, type_str, env, ctx) do
+    annotations = current_annotations(env)
+    resolved = Interpreter.resolve_annotation(type_str, env)
+    env = Env.smart_put(env, "__annotations__", Map.put(annotations, name, resolved))
+    {nil, env, ctx}
+  end
+
+  @doc """
+  Evaluates an annotated assignment with a value.
+  """
+  @spec eval_annotated_assign(String.t(), String.t(), Parser.ast_node(), Env.t(), Ctx.t()) ::
+          eval_result()
+  def eval_annotated_assign(name, type_str, expr, env, ctx) do
+    case Interpreter.eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {value, env, ctx} ->
+        annotations = current_annotations(env)
+        resolved = Interpreter.resolve_annotation(type_str, env)
+        env = Env.smart_put(env, "__annotations__", Map.put(annotations, name, resolved))
+        {value, Env.smart_put(env, name, value), ctx}
+    end
+  end
+
+  @doc """
+  Evaluates a walrus assignment.
+  """
+  @spec eval_walrus(String.t(), Parser.ast_node(), Env.t(), Ctx.t()) :: eval_result()
+  def eval_walrus(name, expr, env, ctx) do
+    case Interpreter.eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {value, env, ctx} ->
+        {value, Env.smart_put(env, name, value), ctx}
+    end
+  end
+
+  @doc """
+  Evaluates a chained assignment.
+  """
+  @spec eval_chained_assign([String.t()], Parser.ast_node(), Env.t(), Ctx.t()) :: eval_result()
+  def eval_chained_assign(names, expr, env, ctx) do
+    case Interpreter.eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {value, env, ctx} ->
+        env = Enum.reduce(names, env, &Env.smart_put(&2, &1, value))
+        {value, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates tuple or iterable unpacking assignment.
+  """
+  @spec eval_multi_assign(
+          [String.t() | {:starred, String.t()}],
+          [Parser.ast_node()],
+          Env.t(),
+          Ctx.t()
+        ) ::
+          eval_result()
+  def eval_multi_assign(names, exprs, env, ctx) do
+    case Interpreter.eval_list(exprs, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {values, env, ctx} ->
+        case Interpreter.unpack_iterable_safe(Enum.reverse(values), names) do
+          {:ok, pairs} ->
+            env =
+              Enum.reduce(pairs, env, fn {name, val}, acc -> Env.smart_put(acc, name, val) end)
+
+            {_, last_val} = List.last(pairs)
+            {last_val, env, ctx}
+
+          {:exception, msg} ->
+            {{:exception, msg}, env, ctx}
+        end
+    end
+  end
+
+  @doc """
+  Evaluates an augmented assignment by lowering it to assignment plus binop.
+  """
+  @spec eval_aug_assign(Parser.meta(), String.t(), atom(), Parser.ast_node(), Env.t(), Ctx.t()) ::
+          eval_result()
+  def eval_aug_assign(meta, name, op, expr, env, ctx) do
+    var_node = {:var, meta, [name]}
+    binop_node = {:binop, meta, [op, var_node, expr]}
+    Interpreter.eval({:assign, meta, [name, binop_node]}, env, ctx)
+  end
+
+  @spec current_annotations(Env.t()) :: map()
+  defp current_annotations(env) do
+    case Env.get(env, "__annotations__") do
+      {:ok, map} when is_map(map) -> map
+      _ -> %{}
+    end
+  end
+end

--- a/lib/pyex/interpreter/builtin_results.ex
+++ b/lib/pyex/interpreter/builtin_results.ex
@@ -1,0 +1,275 @@
+defmodule Pyex.Interpreter.BuiltinResults do
+  @moduledoc """
+  Builtin call result dispatch helpers for `Pyex.Interpreter`.
+
+  Keeps the large result-shape branching for builtin and builtin_kw calls
+  separate from callable dispatch.
+  """
+
+  alias Pyex.{Builtins, Ctx, Env, Interpreter}
+  alias Pyex.Interpreter.{Calls, Dunder, Helpers, Iteration, Unittest}
+
+  @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+
+  @doc false
+  @spec handle_builtin_result(term(), Env.t(), Ctx.t()) :: term()
+  def handle_builtin_result(result, env, ctx) do
+    case result do
+      {:ctx_call, ctx_fun} ->
+        ctx_fun.(env, ctx)
+
+      {:io_call, io_fun} ->
+        ctx = Ctx.pause_compute(ctx)
+        {result, env, ctx} = io_fun.(env, ctx)
+        ctx = Ctx.resume_compute(ctx)
+        {result, env, ctx}
+
+      {:mutate, new_object, return_value} ->
+        {:mutate, new_object, return_value, ctx}
+
+      {:method_call, instance, func, method_args} ->
+        Calls.call_method(instance, func, method_args, %{}, env, ctx)
+
+      {:dunder_call, instance, dunder_name, dunder_args} ->
+        case Dunder.call_dunder(instance, dunder_name, dunder_args, env, ctx) do
+          {:ok, value, env, ctx} ->
+            {value, env, ctx}
+
+          :not_found ->
+            case Interpreter.dunder_str_fallback(instance, dunder_name, env, ctx) do
+              {:ok, value, env, ctx} -> {value, env, ctx}
+              :error -> {{:exception, "TypeError: object has no #{dunder_name}"}, env, ctx}
+            end
+        end
+
+      {:iter_to_list, val} ->
+        iter_to_collection(val, &Function.identity/1, env, ctx)
+
+      {:iter_to_tuple, val} ->
+        iter_to_collection(val, &{:tuple, &1}, env, ctx)
+
+      {:iter_to_set, val} ->
+        iter_to_collection(val, &{:set, MapSet.new(&1)}, env, ctx)
+
+      {:iter_to_frozenset, val} ->
+        iter_to_collection(val, &{:frozenset, MapSet.new(&1)}, env, ctx)
+
+      {:iter_instance, inst} ->
+        handle_iter_instance(inst, env, ctx)
+
+      {:make_iter, items} ->
+        {token, ctx} = Ctx.new_iterator(ctx, items)
+        {token, env, ctx}
+
+      {:iter_next, id} ->
+        case Ctx.iter_next(ctx, id) do
+          {:ok, item, ctx} -> {item, env, ctx}
+          :exhausted -> {{:exception, "StopIteration"}, env, ctx}
+          {:instance, inst} -> Interpreter.eval_instance_next(inst, id, :no_default, env, ctx)
+        end
+
+      {:iter_next_default, id, default} ->
+        case Ctx.iter_next(ctx, id) do
+          {:ok, item, ctx} ->
+            {item, env, ctx}
+
+          :exhausted ->
+            {default, env, ctx}
+
+          {:instance, inst} ->
+            Interpreter.eval_instance_next(inst, id, {:default, default}, env, ctx)
+        end
+
+      {:next_instance_iter, id, default_opt} ->
+        case Ctx.iter_next(ctx, id) do
+          {:instance, inst} ->
+            Interpreter.eval_instance_next(inst, id, default_opt, env, ctx)
+
+          {:ok, item, ctx} ->
+            {item, env, ctx}
+
+          :exhausted ->
+            case default_opt do
+              {:default, default} -> {default, env, ctx}
+              :no_default -> {{:exception, "StopIteration"}, env, ctx}
+            end
+        end
+
+      {:next_with_default, inst, default} ->
+        case Dunder.call_dunder_mut(inst, "__next__", [], env, ctx) do
+          {:ok, _new_inst, {:exception, "StopIteration" <> _}, env, ctx} ->
+            {default, env, ctx}
+
+          {:ok, _new_inst, {:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {:ok, _new_inst, value, env, ctx} ->
+            {value, env, ctx}
+
+          :not_found ->
+            {{:exception, "TypeError: object has no __next__"}, env, ctx}
+        end
+
+      {:iter_sum, val} ->
+        case Interpreter.to_iterable(val, env, ctx) do
+          {:ok, items, env, ctx} ->
+            if Enum.all?(items, &is_number/1) do
+              {Enum.sum(items), env, ctx}
+            else
+              {{:exception,
+                "TypeError: unsupported operand type(s) for +: sum() requires numeric items"},
+               env, ctx}
+            end
+
+          {:exception, _} = signal ->
+            {signal, env, ctx}
+        end
+
+      {:print_call, print_args, sep, end_str} ->
+        Interpreter.eval_print_call(print_args, sep, end_str, env, ctx)
+
+      {:map_call, func, list} ->
+        Iteration.eval_map_call(func, list, env, ctx)
+
+      {:filter_call, func, list} ->
+        Iteration.eval_filter_call(func, list, env, ctx)
+
+      {:super_call} ->
+        Interpreter.eval_super(env, ctx)
+
+      {:starmap_call, func, items} ->
+        Iteration.eval_starmap(func, items, env, ctx)
+
+      {:takewhile_call, predicate, items} ->
+        Iteration.eval_takewhile(predicate, items, env, ctx)
+
+      {:dropwhile_call, predicate, items} ->
+        Iteration.eval_dropwhile(predicate, items, env, ctx)
+
+      {:filterfalse_call, predicate, items} ->
+        Iteration.eval_filterfalse(predicate, items, env, ctx)
+
+      {:unittest_main} ->
+        Unittest.eval_unittest_main(env, ctx)
+
+      {:assert_raises, exc_type} ->
+        {{:assert_raises, exc_type}, env, ctx}
+
+      {:register_route, _method, _path, _handler} = signal ->
+        {signal, env, ctx}
+
+      {:exception, _msg} = signal ->
+        {signal, env, ctx}
+
+      value ->
+        {value, env, ctx}
+    end
+  end
+
+  @doc false
+  @spec handle_builtin_kw_result(term(), Env.t(), Ctx.t()) :: term()
+  def handle_builtin_kw_result(result, env, ctx) do
+    case result do
+      {:exception, _msg} = signal ->
+        {signal, env, ctx}
+
+      {:ctx_call, ctx_fun} ->
+        ctx_fun.(env, ctx)
+
+      {:mutate, new_object, return_value} ->
+        {:mutate, new_object, return_value, ctx}
+
+      {:io_call, io_fun} ->
+        ctx = Ctx.pause_compute(ctx)
+        {result, env, ctx} = io_fun.(env, ctx)
+        ctx = Ctx.resume_compute(ctx)
+        {result, env, ctx}
+
+      {:print_call, print_args, sep, end_str} ->
+        Interpreter.eval_print_call(print_args, sep, end_str, env, ctx)
+
+      {:sort_call, items, key_fn, reverse} ->
+        Interpreter.eval_sort(items, key_fn, reverse, env, ctx)
+
+      {:list_sort_call, items, key_fn, reverse} ->
+        case Interpreter.eval_sort(items, key_fn, reverse, env, ctx) do
+          {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+          {sorted, env, ctx} -> {{:mutate, sorted, nil}, env, ctx}
+        end
+
+      {:iter_sorted, val, key_fn, reverse} ->
+        case Interpreter.to_iterable(val, env, ctx) do
+          {:ok, items, env, ctx} -> Interpreter.eval_sort(items, key_fn, reverse, env, ctx)
+          {:exception, _} = signal -> {signal, env, ctx}
+        end
+
+      {:min_call, items, key_fn} ->
+        Interpreter.eval_minmax(items, key_fn, :min, env, ctx)
+
+      {:max_call, items, key_fn} ->
+        Interpreter.eval_minmax(items, key_fn, :max, env, ctx)
+
+      {:accumulate_call, items, func} ->
+        Iteration.eval_accumulate(items, func, env, ctx)
+
+      {:groupby_call, items, key_func} ->
+        Iteration.eval_groupby(items, key_func, env, ctx)
+
+      {:starmap_call, func, items} ->
+        Iteration.eval_starmap(func, items, env, ctx)
+
+      {:takewhile_call, predicate, items} ->
+        Iteration.eval_takewhile(predicate, items, env, ctx)
+
+      {:dropwhile_call, predicate, items} ->
+        Iteration.eval_dropwhile(predicate, items, env, ctx)
+
+      {:filterfalse_call, predicate, items} ->
+        Iteration.eval_filterfalse(predicate, items, env, ctx)
+
+      value ->
+        {value, env, ctx}
+    end
+  end
+
+  @spec iter_to_collection(
+          Interpreter.pyvalue(),
+          ([Interpreter.pyvalue()] -> Interpreter.pyvalue()),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  defp iter_to_collection(val, builder, env, ctx) do
+    case Interpreter.to_iterable(val, env, ctx) do
+      {:ok, items, env, ctx} -> {builder.(items), env, ctx}
+      {:exception, _} = signal -> {signal, env, ctx}
+    end
+  end
+
+  @spec handle_iter_instance(Interpreter.pyvalue(), Env.t(), Ctx.t()) :: eval_result()
+  defp handle_iter_instance(inst, env, ctx) do
+    case Dunder.call_dunder(inst, "__iter__", [], env, ctx) do
+      {:ok, {:instance, _, _} = iter_inst, env, ctx} ->
+        {token, ctx} = Ctx.new_instance_iterator(ctx, iter_inst)
+        {token, env, ctx}
+
+      {:ok, {:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {:ok, other, env, ctx} ->
+        case Builtins.materialize_iterable(other) do
+          {:ok, items} ->
+            {token, ctx} = Ctx.new_iterator(ctx, items)
+            {token, env, ctx}
+
+          {:pass, iter} ->
+            {iter, env, ctx}
+
+          :error ->
+            {{:exception, "TypeError: iter() returned non-iterator"}, env, ctx}
+        end
+
+      :not_found ->
+        {{:exception, "TypeError: '#{Helpers.py_type(inst)}' object is not iterable"}, env, ctx}
+    end
+  end
+end

--- a/lib/pyex/interpreter/call_support.ex
+++ b/lib/pyex/interpreter/call_support.ex
@@ -1,0 +1,129 @@
+defmodule Pyex.Interpreter.CallSupport do
+  @moduledoc """
+  Parameter binding and call-result bookkeeping helpers for `Pyex.Interpreter`.
+
+  Keeps the mechanical parts of function invocation separate from the main
+  callable dispatch so `call_function/5` can stay focused on callable kinds.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+
+  @typep call_result :: term()
+
+  @doc false
+  @spec bind_params(
+          [Parser.param()],
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: {Env.t(), Ctx.t()} | {:exception, String.t(), Ctx.t()}
+  def bind_params(params, args, kwargs, env, ctx) do
+    {regular, star_param, dstar_param} = split_variadic_params(params)
+    regular_names = Enum.map(regular, &elem(&1, 0))
+    defaults = Enum.map(regular, &elem(&1, 1))
+    n_regular = length(regular)
+    n_args = length(args)
+
+    has_star = star_param != nil
+    has_dstar = dstar_param != nil
+
+    if n_args > n_regular and not has_star do
+      {:exception,
+       "TypeError: function takes #{n_regular} positional arguments but #{n_args} were given",
+       ctx}
+    else
+      positional = Enum.take(args, n_regular)
+      extra_args = Enum.drop(args, n_regular)
+      padded = positional ++ List.duplicate(:__unset__, max(n_regular - n_args, 0))
+
+      consumed_kwargs =
+        MapSet.new(regular_names)
+        |> MapSet.intersection(MapSet.new(Map.keys(kwargs)))
+
+      result =
+        [regular_names, padded, defaults]
+        |> Enum.zip()
+        |> Enum.reduce_while({env, ctx}, fn {name, arg, default}, {env, ctx} ->
+          cond do
+            arg != :__unset__ ->
+              {:cont, {Env.put(env, name, arg), ctx}}
+
+            Map.has_key?(kwargs, name) ->
+              {:cont, {Env.put(env, name, Map.fetch!(kwargs, name)), ctx}}
+
+            default != nil ->
+              {val, _env, ctx} = Interpreter.eval(default, env, ctx)
+              {:cont, {Env.put(env, name, val), ctx}}
+
+            true ->
+              {:halt, {:exception, "TypeError: missing required argument: '#{name}'", ctx}}
+          end
+        end)
+
+      case result do
+        {:exception, _, _} = err ->
+          err
+
+        {env, ctx} ->
+          env = if has_star, do: Env.put(env, star_name(star_param), extra_args), else: env
+          extra_kwargs = Map.drop(kwargs, MapSet.to_list(consumed_kwargs))
+          env = if has_dstar, do: Env.put(env, dstar_name(dstar_param), extra_kwargs), else: env
+          {env, ctx}
+      end
+    end
+  end
+
+  @doc false
+  @spec update_profile_in_result(call_result(), String.t(), float()) :: call_result()
+  def update_profile_in_result({val, env, ctx}, name, elapsed_ms) do
+    {val, env, profile_record_call(ctx, name, elapsed_ms)}
+  end
+
+  def update_profile_in_result({val, env, ctx, extra}, name, elapsed_ms) do
+    {val, env, profile_record_call(ctx, name, elapsed_ms), extra}
+  end
+
+  @doc false
+  @spec decrement_depth(call_result()) :: call_result()
+  def decrement_depth({{:exception, _} = signal, env, ctx}),
+    do: {signal, env, %{ctx | call_depth: ctx.call_depth - 1}}
+
+  def decrement_depth({val, env, ctx, updated_func}),
+    do: {val, env, %{ctx | call_depth: ctx.call_depth - 1}, updated_func}
+
+  def decrement_depth({val, env, ctx}),
+    do: {val, env, %{ctx | call_depth: ctx.call_depth - 1}}
+
+  @spec split_variadic_params([Parser.param()]) ::
+          {[Parser.param()], Parser.param() | nil, Parser.param() | nil}
+  defp split_variadic_params(params) do
+    {regular_rev, star, dstar} =
+      Enum.reduce(params, {[], nil, nil}, fn param, {regular, star, dstar} ->
+        name = elem(param, 0)
+
+        cond do
+          String.starts_with?(name, "**") -> {regular, star, param}
+          String.starts_with?(name, "*") -> {regular, param, dstar}
+          true -> {[param | regular], star, dstar}
+        end
+      end)
+
+    {Enum.reverse(regular_rev), star, dstar}
+  end
+
+  @spec star_name(Parser.param()) :: String.t()
+  defp star_name(param), do: String.trim_leading(elem(param, 0), "*")
+
+  @spec dstar_name(Parser.param()) :: String.t()
+  defp dstar_name(param), do: String.trim_leading(elem(param, 0), "*")
+
+  @spec profile_record_call(Ctx.t(), String.t(), float()) :: Ctx.t()
+  defp profile_record_call(%Ctx{profile: nil} = ctx, _name, _elapsed_ms), do: ctx
+
+  defp profile_record_call(%Ctx{profile: profile} = ctx, name, elapsed_ms) do
+    call_counts = Map.update(profile.call_counts, name, 1, &(&1 + 1))
+    call = Map.update(profile.call, name, elapsed_ms, &(&1 + elapsed_ms))
+    %{ctx | profile: %{profile | call_counts: call_counts, call: call}}
+  end
+end

--- a/lib/pyex/interpreter/calls.ex
+++ b/lib/pyex/interpreter/calls.ex
@@ -1,0 +1,195 @@
+defmodule Pyex.Interpreter.Calls do
+  @moduledoc """
+  Call expression and mutation plumbing for `Pyex.Interpreter`.
+
+  Keeps call-site evaluation and write-back behavior together while the main
+  interpreter retains the public dispatch entrypoints.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+  alias Pyex.Interpreter.{Assignments, Helpers}
+
+  @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+
+  @doc """
+  Evaluates a method call rooted at a variable attribute access.
+  """
+  @spec eval_var_attr_call(Parser.ast_node(), [Parser.ast_node()], String.t(), Env.t(), Ctx.t()) ::
+          eval_result()
+  def eval_var_attr_call(func_expr, arg_exprs, var_name, env, ctx) do
+    case Interpreter.eval(func_expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {func, env, ctx} ->
+        case Interpreter.eval_call_args(arg_exprs, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {args, kwargs, env, ctx} ->
+            case Interpreter.call_function(func, args, kwargs, env, ctx) do
+              {:mutate, new_object, return_value, new_env, ctx} ->
+                {return_value, Env.put_at_source(new_env, var_name, new_object), ctx}
+
+              {:mutate, new_object, return_value, ctx} ->
+                {return_value, Env.put_at_source(env, var_name, new_object), ctx}
+
+              {{:exception, _} = signal, env, ctx} ->
+                {signal, env, ctx}
+
+              {result, env, ctx, _updated_func} ->
+                env = maybe_update_instance_var(env, var_name)
+                {result, env, ctx}
+
+              {result, env, ctx} ->
+                env = maybe_update_instance_var(env, var_name)
+                {result, env, ctx}
+            end
+        end
+    end
+  end
+
+  @doc """
+  Evaluates a general call expression.
+  """
+  @spec eval_call_expr(Parser.ast_node(), [Parser.ast_node()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_call_expr(func_expr, arg_exprs, env, ctx) do
+    case Interpreter.eval(func_expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {func, env, ctx} ->
+        case Interpreter.eval_call_args(arg_exprs, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {args, kwargs, env, ctx} ->
+            case Interpreter.call_function(func, args, kwargs, env, ctx) do
+              {:mutate, new_object, return_value, new_env, ctx} ->
+                target = mutate_target_expr(func_expr, arg_exprs)
+                new_env = mutate_target(target, new_object, new_env, ctx)
+                {return_value, new_env, ctx}
+
+              {:mutate, new_object, return_value, ctx} ->
+                target = mutate_target_expr(func_expr, arg_exprs)
+                env = mutate_target(target, new_object, env, ctx)
+                {return_value, env, ctx}
+
+              {{:exception, _} = signal, env, ctx} ->
+                {signal, env, ctx}
+
+              {result, env, ctx, updated_func} ->
+                env = Helpers.rebind_var(env, func_expr, updated_func)
+                {result, env, ctx}
+
+              {result, env, ctx} ->
+                {result, env, ctx}
+            end
+        end
+    end
+  end
+
+  @doc false
+  @spec call_method(
+          Interpreter.pyvalue(),
+          Interpreter.pyvalue(),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: term()
+  def call_method(instance, {:function, _, _, _, _} = func, args, kwargs, env, ctx) do
+    method_args = [instance | args]
+
+    case Interpreter.call_function(func, method_args, kwargs, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {result, env, ctx, _updated} ->
+        updated_instance = get_mutated_instance(env, instance)
+        env = rebind_instance(env, instance, updated_instance)
+        {result, env, ctx}
+
+      {result, env, ctx} ->
+        updated_instance = get_mutated_instance(env, instance)
+        env = rebind_instance(env, instance, updated_instance)
+        {result, env, ctx}
+    end
+  end
+
+  @spec mutate_target_expr(Parser.ast_node(), [Parser.ast_node()]) :: Parser.ast_node()
+  defp mutate_target_expr({:var, _, ["setattr"]}, [first_arg | _]), do: first_arg
+  defp mutate_target_expr(func_expr, _arg_exprs), do: func_expr
+
+  @spec mutate_target(Parser.ast_node(), Interpreter.pyvalue(), Env.t(), Ctx.t()) :: Env.t()
+  defp mutate_target({:getattr, _, [{:var, _, [var_name]}, _method]}, new_object, env, _ctx) do
+    Env.smart_put(env, var_name, new_object)
+  end
+
+  defp mutate_target(
+         {:getattr, _, [{:getattr, _, _} = inner_target, _method]},
+         new_object,
+         env,
+         ctx
+       ) do
+    case Assignments.setattr(inner_target, new_object, env, ctx) do
+      {_, env, _} -> env
+    end
+  end
+
+  defp mutate_target({:getattr, _, [{:call, _, _}, _method]}, new_object, env, _ctx) do
+    Env.smart_put(env, "self", new_object)
+  end
+
+  defp mutate_target(
+         {:getattr, _, [{:subscript, _, [container_expr, key_expr]}, _method]},
+         new_object,
+         env,
+         ctx
+       ) do
+    {container, env, ctx} = Interpreter.eval(container_expr, env, ctx)
+    {key, env, _ctx} = Interpreter.eval(key_expr, env, ctx)
+    new_container = Assignments.set_subscript_value(container, key, new_object)
+    mutate_target(container_expr, new_container, env, ctx)
+  end
+
+  defp mutate_target({:var, _, [var_name]}, new_object, env, _ctx) do
+    Env.smart_put(env, var_name, new_object)
+  end
+
+  defp mutate_target({:subscript, _, [expr, _index]}, new_object, env, ctx) do
+    mutate_target(expr, new_object, env, ctx)
+  end
+
+  defp mutate_target(_, _new_object, env, _ctx), do: env
+
+  @spec get_mutated_instance(Env.t(), Interpreter.pyvalue()) :: Interpreter.pyvalue()
+  defp get_mutated_instance(env, {:instance, _, _} = original) do
+    case Env.get(env, "self") do
+      {:ok, {:instance, _, _} = updated} -> updated
+      _ -> original
+    end
+  end
+
+  @spec rebind_instance(Env.t(), Interpreter.pyvalue(), Interpreter.pyvalue()) :: Env.t()
+  defp rebind_instance(env, _old, new) do
+    case Env.get(env, "self") do
+      {:ok, {:instance, _, _}} -> Env.smart_put(env, "self", new)
+      _ -> env
+    end
+  end
+
+  @spec maybe_update_instance_var(Env.t(), String.t()) :: Env.t()
+  defp maybe_update_instance_var(env, var_name) do
+    case Env.get(env, var_name) do
+      {:ok, {:instance, _, _}} ->
+        case Env.get(env, "self") do
+          {:ok, {:instance, _, _} = updated_self} -> Env.smart_put(env, var_name, updated_self)
+          _ -> env
+        end
+
+      _ ->
+        env
+    end
+  end
+end

--- a/lib/pyex/interpreter/class_lookup.ex
+++ b/lib/pyex/interpreter/class_lookup.ex
@@ -1,0 +1,90 @@
+defmodule Pyex.Interpreter.ClassLookup do
+  @moduledoc """
+  Class attribute lookup and MRO helpers for `Pyex.Interpreter`.
+
+  Keeps C3 linearization and attribute-owner resolution in one place so class
+  lookup rules stay separate from evaluation and call dispatch.
+  """
+
+  alias Pyex.Interpreter
+
+  @doc false
+  @spec resolve_class_attr(Interpreter.pyvalue(), String.t()) ::
+          {:ok, Interpreter.pyvalue()} | :error
+  def resolve_class_attr(class, attr) do
+    mro = c3_linearize(class)
+
+    Enum.find_value(mro, :error, fn {:class, _, _, class_attrs} ->
+      case Map.get(class_attrs, attr) do
+        nil -> nil
+        value -> {:ok, value}
+      end
+    end)
+  end
+
+  @doc false
+  @spec resolve_class_attr_with_owner(Interpreter.pyvalue(), String.t()) ::
+          {:ok, Interpreter.pyvalue(), Interpreter.pyvalue()} | :error
+  def resolve_class_attr_with_owner(class, attr) do
+    mro = c3_linearize(class)
+
+    Enum.find_value(mro, :error, fn {:class, _, _, class_attrs} = current_class ->
+      case Map.get(class_attrs, attr) do
+        nil -> nil
+        value -> {:ok, value, current_class}
+      end
+    end)
+  end
+
+  @spec c3_linearize(Interpreter.pyvalue()) :: [Interpreter.pyvalue()]
+  defp c3_linearize({:class, _, [], _} = class), do: [class]
+
+  defp c3_linearize({:class, _, bases, _} = class) do
+    parent_mros = Enum.map(bases, &c3_linearize/1)
+    [class | c3_merge(parent_mros ++ [bases])]
+  end
+
+  @spec c3_merge([[Interpreter.pyvalue()]]) :: [Interpreter.pyvalue()]
+  defp c3_merge(lists) do
+    lists = Enum.reject(lists, &(&1 == []))
+
+    case lists do
+      [] ->
+        []
+
+      _ ->
+        case find_c3_head(lists) do
+          {:ok, head} ->
+            remaining =
+              Enum.map(lists, fn list ->
+                case list do
+                  [^head | rest] -> rest
+                  _ -> Enum.reject(list, &(&1 == head))
+                end
+              end)
+
+            [head | c3_merge(remaining)]
+
+          :error ->
+            lists |> Enum.flat_map(& &1) |> Enum.uniq()
+        end
+    end
+  end
+
+  @spec find_c3_head([[Interpreter.pyvalue()]]) :: {:ok, Interpreter.pyvalue()} | :error
+  defp find_c3_head(lists) do
+    tails = lists |> Enum.flat_map(&tl_safe/1) |> MapSet.new()
+
+    Enum.find_value(lists, :error, fn
+      [head | _] ->
+        if MapSet.member?(tails, head), do: nil, else: {:ok, head}
+
+      [] ->
+        nil
+    end)
+  end
+
+  @spec tl_safe([Interpreter.pyvalue()]) :: [Interpreter.pyvalue()]
+  defp tl_safe([]), do: []
+  defp tl_safe([_ | rest]), do: rest
+end

--- a/lib/pyex/interpreter/collections.ex
+++ b/lib/pyex/interpreter/collections.ex
@@ -1,0 +1,251 @@
+defmodule Pyex.Interpreter.Collections do
+  @moduledoc """
+  Collection literal and comprehension evaluation helpers for `Pyex.Interpreter`.
+
+  Keeps tuple/list/dict/set construction together with comprehension execution
+  so the main interpreter can stay focused on dispatch.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+  alias Pyex.Interpreter.{ControlFlow, Helpers}
+
+  @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+  @typep comp_clause ::
+           {:comp_for, String.t() | [String.t()], Parser.ast_node()}
+           | {:comp_if, Parser.ast_node()}
+
+  @doc """
+  Evaluates tuple construction.
+  """
+  @spec eval_tuple([Parser.ast_node()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_tuple(elements, env, ctx) do
+    case Interpreter.eval_list(elements, env, ctx) do
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+      {values, env, ctx} -> {{:tuple, Enum.reverse(values)}, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates list construction.
+  """
+  @spec eval_list_literal([Parser.ast_node()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_list_literal(elements, env, ctx) do
+    case Interpreter.eval_list(elements, env, ctx) do
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+      {values, env, ctx} -> {{:py_list, values, length(values)}, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates dict construction.
+  """
+  @spec eval_dict_literal([{Parser.ast_node(), Parser.ast_node()}], Env.t(), Ctx.t()) ::
+          eval_result()
+  def eval_dict_literal(entries, env, ctx) do
+    eval_dict(entries, env, ctx)
+  end
+
+  @doc """
+  Evaluates set construction.
+  """
+  @spec eval_set_literal([Parser.ast_node()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_set_literal(elements, env, ctx) do
+    case Interpreter.eval_list(elements, env, ctx) do
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+      {values, env, ctx} -> {{:set, MapSet.new(values)}, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates a list comprehension.
+  """
+  @spec eval_list_comp(Parser.ast_node(), [comp_clause()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_list_comp(expr, clauses, env, ctx) do
+    case eval_comp_clauses(:list, expr, clauses, [], env, ctx) do
+      {result, env, ctx} when is_list(result) ->
+        items = Enum.reverse(result)
+        {{:py_list, Enum.reverse(items), length(items)}, env, ctx}
+
+      other ->
+        other
+    end
+  end
+
+  @doc """
+  Evaluates a generator expression.
+  """
+  @spec eval_gen_expr(Parser.ast_node(), [comp_clause()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_gen_expr(expr, clauses, env, ctx) do
+    case eval_comp_clauses(:list, expr, clauses, [], env, ctx) do
+      {result, env, ctx} when is_list(result) -> {{:generator, Enum.reverse(result)}, env, ctx}
+      other -> other
+    end
+  end
+
+  @doc """
+  Evaluates a dict comprehension.
+  """
+  @spec eval_dict_comp(Parser.ast_node(), Parser.ast_node(), [comp_clause()], Env.t(), Ctx.t()) ::
+          eval_result()
+  def eval_dict_comp(key_expr, val_expr, clauses, env, ctx) do
+    eval_comp_clauses(:dict, {key_expr, val_expr}, clauses, %{}, env, ctx)
+  end
+
+  @doc """
+  Evaluates a set comprehension.
+  """
+  @spec eval_set_comp(Parser.ast_node(), [comp_clause()], Env.t(), Ctx.t()) :: eval_result()
+  def eval_set_comp(expr, clauses, env, ctx) do
+    case eval_comp_clauses(:set, expr, clauses, MapSet.new(), env, ctx) do
+      {{:exception, _}, _, _} = result -> result
+      {set, env, ctx} -> {{:set, set}, env, ctx}
+    end
+  end
+
+  @spec eval_comp_clauses(
+          :list | :dict | :set,
+          Parser.ast_node() | {Parser.ast_node(), Parser.ast_node()},
+          [comp_clause()],
+          [Interpreter.pyvalue()] | map() | MapSet.t(),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  @dialyzer {:nowarn_function, eval_comp_clauses: 6}
+  defp eval_comp_clauses(:list, expr, [], acc, env, ctx) do
+    case Interpreter.eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+      {val, env, ctx} -> {[val | acc], env, ctx}
+    end
+  end
+
+  defp eval_comp_clauses(:dict, {key_expr, val_expr}, [], acc, env, ctx) do
+    case Interpreter.eval(key_expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {key, env, ctx} ->
+        case Interpreter.eval(val_expr, env, ctx) do
+          {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+          {val, env, ctx} -> {Map.put(acc, key, val), env, ctx}
+        end
+    end
+  end
+
+  defp eval_comp_clauses(:set, expr, [], acc, env, ctx) do
+    case Interpreter.eval(expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+      {val, env, ctx} -> {MapSet.put(acc, val), env, ctx}
+    end
+  end
+
+  defp eval_comp_clauses(kind, expr, [{:comp_if, condition} | rest_clauses], acc, env, ctx) do
+    case Interpreter.eval(condition, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {cond_val, env, ctx} ->
+        {taken, env, ctx} = Interpreter.eval_truthy(cond_val, env, ctx)
+
+        if taken do
+          eval_comp_clauses(kind, expr, rest_clauses, acc, env, ctx)
+        else
+          {acc, env, ctx}
+        end
+    end
+  end
+
+  defp eval_comp_clauses(
+         kind,
+         expr,
+         [{:comp_for, var_name, iterable_expr} | rest_clauses],
+         acc,
+         env,
+         ctx
+       ) do
+    case Interpreter.eval(iterable_expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {iterable, env, ctx} ->
+        case Interpreter.to_iterable(iterable, env, ctx) do
+          {:ok, items, env, ctx} ->
+            eval_comp_for_loop(kind, expr, var_name, items, rest_clauses, acc, env, ctx)
+
+          {:exception, msg} ->
+            {{:exception, msg}, env, ctx}
+        end
+    end
+  end
+
+  @spec eval_comp_for_loop(
+          :list | :dict | :set,
+          Parser.ast_node() | {Parser.ast_node(), Parser.ast_node()},
+          String.t() | [String.t()],
+          [Interpreter.pyvalue()],
+          [comp_clause()],
+          [Interpreter.pyvalue()] | map() | MapSet.t(),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  defp eval_comp_for_loop(_kind, _expr, _var_name, [], _rest_clauses, acc, env, ctx) do
+    {acc, env, ctx}
+  end
+
+  defp eval_comp_for_loop(kind, expr, var_name, [item | rest_items], rest_clauses, acc, env, ctx) do
+    case Ctx.check_deadline(ctx) do
+      {:exceeded, _} ->
+        {{:exception, "TimeoutError: execution exceeded time limit"}, env, ctx}
+
+      :ok ->
+        case ControlFlow.bind_loop_var(var_name, item, env) do
+          {:exception, msg} ->
+            {{:exception, msg}, env, ctx}
+
+          bound_env ->
+            case eval_comp_clauses(kind, expr, rest_clauses, acc, bound_env, ctx) do
+              {{:exception, _}, _, _} = error ->
+                error
+
+              {new_acc, _inner_env, ctx} ->
+                eval_comp_for_loop(
+                  kind,
+                  expr,
+                  var_name,
+                  rest_items,
+                  rest_clauses,
+                  new_acc,
+                  env,
+                  ctx
+                )
+            end
+        end
+    end
+  end
+
+  @spec eval_dict([{Parser.ast_node(), Parser.ast_node()}], Env.t(), Ctx.t()) :: eval_result()
+  defp eval_dict(entries, env, ctx) do
+    Enum.reduce_while(entries, {%{}, env, ctx}, fn {key_expr, val_expr}, {map, env, ctx} ->
+      case Interpreter.eval(key_expr, env, ctx) do
+        {{:exception, _} = signal, env, ctx} ->
+          {:halt, {signal, env, ctx}}
+
+        {key, env, ctx} ->
+          if unhashable?(key) do
+            {:halt,
+             {{:exception, "TypeError: unhashable type: '#{Helpers.py_type(key)}'"}, env, ctx}}
+          else
+            case Interpreter.eval(val_expr, env, ctx) do
+              {{:exception, _} = signal, env, ctx} -> {:halt, {signal, env, ctx}}
+              {val, env, ctx} -> {:cont, {Map.put(map, key, val), env, ctx}}
+            end
+          end
+      end
+    end)
+  end
+
+  @spec unhashable?(Interpreter.pyvalue()) :: boolean()
+  defp unhashable?(val) when is_list(val), do: true
+  defp unhashable?({:py_list, _, _}), do: true
+  defp unhashable?({:set, _}), do: true
+  defp unhashable?(_), do: false
+end

--- a/lib/pyex/interpreter/control_flow.ex
+++ b/lib/pyex/interpreter/control_flow.ex
@@ -1,0 +1,389 @@
+defmodule Pyex.Interpreter.ControlFlow do
+  @moduledoc """
+  Control-flow evaluation helpers for `Pyex.Interpreter`.
+
+  Keeps branching, loops, and try/except handling together so the main
+  interpreter can focus on dispatch while preserving `eval/3`.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+  alias Pyex.Interpreter.{Exceptions, Helpers}
+
+  @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+
+  @doc """
+  Evaluates an `if` statement.
+  """
+  @spec eval_if(
+          [
+            {Parser.ast_node(), [Parser.ast_node()]} | {:else, [Parser.ast_node()]}
+          ],
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def eval_if(clauses, env, ctx), do: eval_if_clauses(clauses, env, ctx)
+
+  @doc """
+  Evaluates a `while` loop.
+  """
+  @spec eval_while(
+          Parser.ast_node(),
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) ::
+          eval_result()
+  def eval_while(condition, body, else_body, env, ctx) do
+    case Ctx.check_deadline(ctx) do
+      {:exceeded, _} ->
+        {{:exception, "TimeoutError: execution exceeded time limit"}, env, ctx}
+
+      :ok ->
+        eval_while_body(condition, body, else_body, env, ctx)
+    end
+  end
+
+  @doc """
+  Evaluates a `for` loop.
+  """
+  @spec eval_for(
+          String.t() | [String.t()],
+          Parser.ast_node(),
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) ::
+          eval_result()
+  def eval_for(var_name, iterable_expr, body, else_body, env, ctx) do
+    case Interpreter.eval(iterable_expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {{:generator_error, items, exception_msg}, env, ctx} ->
+        case eval_for_items(var_name, items, body, else_body, env, ctx) do
+          {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+          {{:returned, _} = signal, env, ctx} -> {signal, env, ctx}
+          {{:break}, env, ctx} -> {{:exception, exception_msg}, env, ctx}
+          {_, env, ctx} -> {{:exception, exception_msg}, env, ctx}
+        end
+
+      {iterable, env, ctx} ->
+        case Interpreter.to_iterable(iterable, env, ctx) do
+          {:ok, items, env, ctx} -> eval_for_items(var_name, items, body, else_body, env, ctx)
+          {:exception, msg} -> {{:exception, msg}, env, ctx}
+        end
+    end
+  end
+
+  @doc false
+  @spec eval_for_items(
+          String.t() | [String.t()],
+          [Interpreter.pyvalue()],
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def eval_for_items(var_name, items, body, else_body, env, ctx) do
+    do_eval_for_items(var_name, items, body, else_body, env, ctx)
+  end
+
+  @doc false
+  @spec bind_loop_var(String.t() | [String.t()], Interpreter.pyvalue(), Env.t()) ::
+          Env.t() | {:exception, String.t()}
+  def bind_loop_var(var_name, item, env) when is_binary(var_name) do
+    Env.smart_put(env, var_name, item)
+  end
+
+  def bind_loop_var(var_names, item, env) when is_list(var_names) do
+    case unpack_for_item(var_names, item) do
+      {:ok, bindings} ->
+        Enum.reduce(bindings, env, fn {name, val}, acc -> Env.smart_put(acc, name, val) end)
+
+      {:exception, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Evaluates a `try` statement.
+  """
+  @spec eval_try(
+          [Parser.ast_node()],
+          [{String.t() | nil, String.t() | nil, [Parser.ast_node()]}],
+          [Parser.ast_node()] | nil,
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def eval_try(body, handlers, else_body, finally_body, env, ctx) do
+    result =
+      case Interpreter.eval_statements(body, env, ctx) do
+        {{:exception, msg}, body_env, ctx} ->
+          match_handler(handlers, msg, body_env, ctx)
+
+        {val, env, ctx} ->
+          if else_body do
+            Interpreter.eval_statements(else_body, env, ctx)
+          else
+            {val, env, ctx}
+          end
+      end
+
+    run_finally(result, finally_body)
+  end
+
+  @spec eval_if_clauses(
+          [
+            {Parser.ast_node(), [Parser.ast_node()]} | {:else, [Parser.ast_node()]}
+          ],
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  defp eval_if_clauses([], env, ctx), do: {nil, env, ctx}
+
+  defp eval_if_clauses([{:else, body} | _], env, ctx) do
+    Interpreter.eval_statements(body, env, ctx)
+  end
+
+  defp eval_if_clauses([{condition, body} | rest], env, ctx) do
+    case Interpreter.eval(condition, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {value, env, ctx} ->
+        {taken, env, ctx} = Interpreter.eval_truthy(value, env, ctx)
+
+        if taken do
+          Interpreter.eval_statements(body, env, ctx)
+        else
+          eval_if_clauses(rest, env, ctx)
+        end
+    end
+  end
+
+  @spec eval_while_body(
+          Parser.ast_node(),
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) ::
+          eval_result()
+  defp eval_while_body(condition, body, else_body, env, ctx) do
+    case Interpreter.eval(condition, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {value, env, ctx} ->
+        {taken, env, ctx} = Interpreter.eval_truthy(value, env, ctx)
+
+        if taken do
+          case Interpreter.eval_statements(body, env, ctx) do
+            {{:returned, _} = signal, env, ctx} ->
+              {signal, env, ctx}
+
+            {{:break}, env, ctx} ->
+              {nil, env, ctx}
+
+            {{:exception, _} = signal, env, ctx} ->
+              {signal, env, ctx}
+
+            {{:yielded, val, cont}, env, ctx} ->
+              {{:yielded, val, cont ++ [{:cont_while, condition, body, else_body}]}, env, ctx}
+
+            {{:continue}, env, ctx} ->
+              eval_while(condition, body, else_body, env, ctx)
+
+            {_, env, ctx} ->
+              eval_while(condition, body, else_body, env, ctx)
+          end
+        else
+          eval_loop_else(else_body, env, ctx)
+        end
+    end
+  end
+
+  @spec do_eval_for_items(
+          String.t() | [String.t()],
+          [Interpreter.pyvalue()],
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) ::
+          eval_result()
+  defp do_eval_for_items(_var_name, [], _body, else_body, env, ctx) do
+    eval_loop_else(else_body, env, ctx)
+  end
+
+  defp do_eval_for_items(var_names, [item | rest], body, else_body, env, ctx)
+       when is_list(var_names) do
+    case Ctx.check_deadline(ctx) do
+      {:exceeded, _} ->
+        {{:exception, "TimeoutError: execution exceeded time limit"}, env, ctx}
+
+      :ok ->
+        ctx = Ctx.record(ctx, :loop, nil)
+
+        case unpack_for_item(var_names, item) do
+          {:ok, bindings} ->
+            env =
+              Enum.reduce(bindings, env, fn {name, val}, acc -> Env.smart_put(acc, name, val) end)
+
+            case Interpreter.eval_statements(body, env, ctx) do
+              {{:returned, _} = signal, env, ctx} ->
+                {signal, env, ctx}
+
+              {{:break}, env, ctx} ->
+                {nil, env, ctx}
+
+              {{:exception, _} = signal, env, ctx} ->
+                {signal, env, ctx}
+
+              {{:yielded, val, cont}, env, ctx} ->
+                {{:yielded, val, cont ++ [{:cont_for, var_names, rest, body, else_body}]}, env,
+                 ctx}
+
+              {{:continue}, env, ctx} ->
+                do_eval_for_items(var_names, rest, body, else_body, env, ctx)
+
+              {_, env, ctx} ->
+                do_eval_for_items(var_names, rest, body, else_body, env, ctx)
+            end
+
+          {:exception, msg} ->
+            {{:exception, msg}, env, ctx}
+        end
+    end
+  end
+
+  defp do_eval_for_items(var_name, [item | rest], body, else_body, env, ctx) do
+    case Ctx.check_deadline(ctx) do
+      {:exceeded, _} ->
+        {{:exception, "TimeoutError: execution exceeded time limit"}, env, ctx}
+
+      :ok ->
+        ctx = Ctx.record(ctx, :loop, nil)
+        env = Env.smart_put(env, var_name, item)
+
+        case Interpreter.eval_statements(body, env, ctx) do
+          {{:returned, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {{:break}, env, ctx} ->
+            {nil, env, ctx}
+
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {{:yielded, val, cont}, env, ctx} ->
+            {{:yielded, val, cont ++ [{:cont_for, var_name, rest, body, else_body}]}, env, ctx}
+
+          {{:continue}, env, ctx} ->
+            do_eval_for_items(var_name, rest, body, else_body, env, ctx)
+
+          {_, env, ctx} ->
+            do_eval_for_items(var_name, rest, body, else_body, env, ctx)
+        end
+    end
+  end
+
+  @spec eval_loop_else([Parser.ast_node()] | nil, Env.t(), Ctx.t()) :: eval_result()
+  defp eval_loop_else(nil, env, ctx), do: {nil, env, ctx}
+  defp eval_loop_else(else_body, env, ctx), do: Interpreter.eval_statements(else_body, env, ctx)
+
+  @spec unpack_for_item([String.t()], Interpreter.pyvalue()) ::
+          {:ok, [{String.t(), Interpreter.pyvalue()}]} | {:exception, String.t()}
+  defp unpack_for_item(names, {:tuple, items}), do: unpack_for_list(names, items)
+
+  defp unpack_for_item(names, {:py_list, reversed, _}),
+    do: unpack_for_list(names, Enum.reverse(reversed))
+
+  defp unpack_for_item(names, items) when is_list(items), do: unpack_for_list(names, items)
+
+  defp unpack_for_item(_names, val) do
+    {:exception, "TypeError: cannot unpack non-iterable #{Helpers.py_type(val)} object"}
+  end
+
+  @spec unpack_for_list([String.t()], [Interpreter.pyvalue()]) ::
+          {:ok, [{String.t(), Interpreter.pyvalue()}]} | {:exception, String.t()}
+  defp unpack_for_list(names, items) do
+    if length(names) == length(items) do
+      {:ok, Enum.zip(names, items)}
+    else
+      {:exception,
+       "ValueError: not enough values to unpack (expected #{length(names)}, got #{length(items)})"}
+    end
+  end
+
+  @spec run_finally(eval_result(), [Parser.ast_node()] | nil) :: eval_result()
+  defp run_finally(result, nil), do: result
+
+  defp run_finally({original_signal, env, ctx}, finally_body) do
+    case Interpreter.eval_statements(finally_body, env, ctx) do
+      {{:exception, _} = new_signal, env, ctx} ->
+        {new_signal, env, ctx}
+
+      {{:returned, _} = new_signal, env, ctx} ->
+        {new_signal, env, ctx}
+
+      {_val, env, ctx} ->
+        {original_signal, env, ctx}
+    end
+  end
+
+  @spec match_handler(
+          [{String.t() | [String.t()] | nil, String.t() | nil, [Parser.ast_node()]}],
+          String.t(),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  defp match_handler([], message, env, ctx) do
+    {{:exception, message}, env, ctx}
+  end
+
+  defp match_handler([{nil, nil, handler_body} | _], message, env, ctx) do
+    env = Env.put(env, "__current_exception__", message)
+    ctx = %{ctx | exception_instance: nil}
+    Interpreter.eval_statements(handler_body, env, ctx)
+  end
+
+  defp match_handler([{exc_names, var_name, handler_body} | rest], message, env, ctx) do
+    matches =
+      case exc_names do
+        names when is_list(names) -> Enum.any?(names, &exception_matches?(&1, message))
+        name -> exception_matches?(name, message)
+      end
+
+    if matches do
+      env = Env.put(env, "__current_exception__", message)
+
+      env =
+        if var_name do
+          exc_value =
+            case ctx.exception_instance do
+              {:instance, _, _} = inst -> inst
+              _ -> Exceptions.synthesize_exception_instance(message)
+            end
+
+          Env.put(env, var_name, exc_value)
+        else
+          env
+        end
+
+      ctx = %{ctx | exception_instance: nil}
+      Interpreter.eval_statements(handler_body, env, ctx)
+    else
+      match_handler(rest, message, env, ctx)
+    end
+  end
+
+  @spec exception_matches?(String.t(), String.t()) :: boolean()
+  defp exception_matches?("Exception", _message), do: true
+
+  defp exception_matches?(exc_name, message),
+    do: message == exc_name or String.starts_with?(message, exc_name <> ":")
+end

--- a/lib/pyex/interpreter/dunder.ex
+++ b/lib/pyex/interpreter/dunder.ex
@@ -1,0 +1,76 @@
+defmodule Pyex.Interpreter.Dunder do
+  @moduledoc """
+  Dunder-method dispatch for `Pyex.Interpreter`.
+
+  Keeps instance and file-handle special method lookup separate from the main
+  evaluator while preserving the interpreter's existing call semantics.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter}
+  alias Pyex.Interpreter.ClassLookup
+
+  @doc false
+  @spec call_dunder(Interpreter.pyvalue(), String.t(), [Interpreter.pyvalue()], Env.t(), Ctx.t()) ::
+          {:ok, Interpreter.pyvalue(), Env.t(), Ctx.t()} | :not_found
+  def call_dunder(instance, method, args, env, ctx) do
+    case call_dunder_mut(instance, method, args, env, ctx) do
+      {:ok, _new_obj, return_val, env, ctx} -> {:ok, return_val, env, ctx}
+      :not_found -> :not_found
+    end
+  end
+
+  @doc false
+  @spec call_dunder_mut(
+          Interpreter.pyvalue(),
+          String.t(),
+          [Interpreter.pyvalue()],
+          Env.t(),
+          Ctx.t()
+        ) :: {:ok, Interpreter.pyvalue(), Interpreter.pyvalue(), Env.t(), Ctx.t()} | :not_found
+  def call_dunder_mut(
+        {:instance, {:class, _, _, _} = class, _} = instance,
+        method,
+        args,
+        env,
+        ctx
+      ) do
+    case ClassLookup.resolve_class_attr(class, method) do
+      {:ok, {:function, _, _, _, _} = func} ->
+        case Interpreter.call_function({:bound_method, instance, func}, args, %{}, env, ctx) do
+          {:mutate, new_obj, return_val, new_env, ctx} ->
+            {:ok, new_obj, return_val, new_env, ctx}
+
+          {{:exception, _} = signal, env, ctx} ->
+            {:ok, instance, signal, env, ctx}
+        end
+
+      {:ok, {:builtin, fun}} ->
+        case Interpreter.call_function({:builtin, fun}, [instance | args], %{}, env, ctx) do
+          {:mutate, new_obj, return_val, ctx} ->
+            {:ok, new_obj, return_val, env, ctx}
+
+          {{:exception, _} = signal, env, ctx} ->
+            {:ok, instance, signal, env, ctx}
+
+          {return_val, env, ctx} ->
+            {:ok, instance, return_val, env, ctx}
+        end
+
+      _ ->
+        :not_found
+    end
+  end
+
+  def call_dunder_mut({:file_handle, _id} = handle, "__enter__", [], env, ctx) do
+    {:ok, handle, handle, env, ctx}
+  end
+
+  def call_dunder_mut({:file_handle, id} = handle, "__exit__", _args, env, ctx) do
+    case Ctx.close_handle(ctx, id) do
+      {:ok, ctx} -> {:ok, handle, nil, env, ctx}
+      {:error, _} -> {:ok, handle, nil, env, ctx}
+    end
+  end
+
+  def call_dunder_mut(_, _, _, _, _), do: :not_found
+end

--- a/lib/pyex/interpreter/exceptions.ex
+++ b/lib/pyex/interpreter/exceptions.ex
@@ -1,0 +1,120 @@
+defmodule Pyex.Interpreter.Exceptions do
+  @moduledoc """
+  Exception construction and `raise` evaluation helpers for `Pyex.Interpreter`.
+
+  Keeps exception statement semantics together so the main interpreter can
+  dispatch without carrying all raise-specific branches inline.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+  alias Pyex.Interpreter.Helpers
+
+  @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+
+  @doc """
+  Evaluates a `raise` statement.
+  """
+  @spec eval_raise(Parser.ast_node() | nil, Parser.meta(), Env.t(), Ctx.t()) :: eval_result()
+  def eval_raise(nil, _meta, env, ctx) do
+    case Env.get(env, "__current_exception__") do
+      {:ok, msg} ->
+        {{:exception, msg}, env, ctx}
+
+      :undefined ->
+        {{:exception, "RuntimeError: No active exception to re-raise"}, env, ctx}
+    end
+  end
+
+  def eval_raise(expr, meta, env, ctx) do
+    case expr do
+      {:call, _, [{:var, _, [exc_name]}, args]} when is_list(args) ->
+        eval_raise_exc_class(exc_name, args, meta, env, ctx)
+
+      {:call, _, [{:var, _, [exc_name]}, args, _kwargs]} when is_list(args) ->
+        eval_raise_exc_class(exc_name, args, meta, env, ctx)
+
+      {:var, _, [exc_name]} ->
+        {{:exception, exc_name}, env, ctx}
+
+      _ ->
+        case Interpreter.eval(expr, env, ctx) do
+          {{:exception, _} = signal, _env, _ctx} ->
+            {signal, env, ctx}
+
+          {value, env, ctx} ->
+            msg =
+              case value do
+                msg when is_binary(msg) -> "Exception: #{msg}"
+                _ -> "Exception: #{inspect(value)}"
+              end
+
+            {{:exception, msg}, env, ctx}
+        end
+    end
+  end
+
+  @doc false
+  @spec synthesize_exception_instance(String.t()) :: Interpreter.pyvalue()
+  def synthesize_exception_instance(message) do
+    {class_name, msg} =
+      case String.split(message, ": ", parts: 2) do
+        [name, m] -> {name, m}
+        [name] -> {name, ""}
+      end
+
+    {:instance, {:class, class_name, [], %{}}, %{"args" => {:tuple, [msg]}}}
+  end
+
+  @spec eval_raise_exc_class(String.t(), [Parser.ast_node()], Parser.meta(), Env.t(), Ctx.t()) ::
+          eval_result()
+  defp eval_raise_exc_class(exc_name, args, _meta, env, ctx) do
+    case Env.get(env, exc_name) do
+      {:ok, {:class, _, _, _} = class} ->
+        case Interpreter.eval_list(args, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {rev_values, env, ctx} ->
+            values = Enum.reverse(rev_values)
+            msg = format_exc_msg(exc_name, values)
+
+            case Interpreter.call_function(class, values, %{}, env, ctx) do
+              {{:exception, _}, env, ctx} ->
+                instance = {:instance, class, %{"args" => {:tuple, values}}}
+                ctx = %{ctx | exception_instance: instance}
+                {{:exception, msg}, env, ctx}
+
+              {instance, env, ctx} ->
+                ctx = %{ctx | exception_instance: instance}
+                {{:exception, msg}, env, ctx}
+            end
+        end
+
+      _ ->
+        case Interpreter.eval_list(args, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {rev_values, env, ctx} ->
+            values = Enum.reverse(rev_values)
+            msg = format_exc_msg(exc_name, values)
+
+            instance =
+              {:instance, {:class, exc_name, [], %{}}, %{"args" => {:tuple, values}}}
+
+            ctx = %{ctx | exception_instance: instance}
+            {{:exception, msg}, env, ctx}
+        end
+    end
+  end
+
+  @spec format_exc_msg(String.t(), [Interpreter.pyvalue()]) :: String.t()
+  defp format_exc_msg(exc_name, values) do
+    case values do
+      [] -> exc_name
+      [m] when is_binary(m) -> "#{exc_name}: #{m}"
+      [m] -> "#{exc_name}: #{Helpers.py_str(m)}"
+      _ -> "#{exc_name}: #{values |> Enum.map(&Helpers.py_str/1) |> Enum.join(", ")}"
+    end
+  end
+end

--- a/lib/pyex/interpreter/fstring_format.ex
+++ b/lib/pyex/interpreter/fstring_format.ex
@@ -1,0 +1,346 @@
+defmodule Pyex.Interpreter.FstringFormat do
+  @moduledoc """
+  Python format mini-language implementation for f-string format specs.
+
+  Parses and applies format specs like `:.2f`, `:>10`, `:<14`, `:*^10`,
+  `:>18,.2f`, `:05d`, etc.
+
+  Format spec grammar: `[[fill]align][sign][#][0][width][grouping][.precision][type]`
+  """
+
+  alias Pyex.Interpreter.Helpers
+
+  @doc """
+  Applies a Python format spec string to a value.
+
+  Returns the formatted string or `{:exception, message}`.
+  """
+  @spec apply_format_spec(Pyex.Interpreter.pyvalue(), String.t()) ::
+          String.t() | {:exception, String.t()}
+  def apply_format_spec(val, spec_str) do
+    {:ok, spec} = parse_spec(spec_str)
+    format_value(val, spec)
+  end
+
+  # Internal spec struct
+  defp parse_spec(str) do
+    {fill, align, str} = parse_fill_align(str)
+    {sign, str} = parse_sign(str)
+    {alt, str} = parse_alt(str)
+    {zero_pad, str} = parse_zero_pad(str)
+    {width, str} = parse_width(str)
+    {grouping, str} = parse_grouping(str)
+    {precision, str} = parse_precision(str)
+    type = str
+
+    # If zero-pad is set and no fill/align, use 0-fill right-aligned
+    {fill, align} =
+      if zero_pad and fill == nil and align == nil do
+        {"0", ">"}
+      else
+        {fill || " ", align}
+      end
+
+    {:ok,
+     %{
+       fill: fill,
+       align: align,
+       sign: sign,
+       alt: alt,
+       width: width,
+       grouping: grouping,
+       precision: precision,
+       type: type
+     }}
+  end
+
+  # Parse optional [fill]align
+  defp parse_fill_align(str) do
+    case str do
+      # Two-char fill+align: e.g., "*^", "0>"
+      <<fill::utf8, align, rest::binary>> when align in [?<, ?>, ?^, ?=] ->
+        {<<fill::utf8>>, <<align>>, rest}
+
+      # One-char align only
+      <<align, rest::binary>> when align in [?<, ?>, ?^, ?=] ->
+        {nil, <<align>>, rest}
+
+      _ ->
+        {nil, nil, str}
+    end
+  end
+
+  defp parse_sign(<<"+", rest::binary>>), do: {"+", rest}
+  defp parse_sign(<<"-", rest::binary>>), do: {"-", rest}
+  defp parse_sign(<<" ", rest::binary>>), do: {" ", rest}
+  defp parse_sign(str), do: {nil, str}
+
+  defp parse_alt(<<"#", rest::binary>>), do: {true, rest}
+  defp parse_alt(str), do: {false, str}
+
+  defp parse_zero_pad(<<"0", rest::binary>>), do: {true, rest}
+  defp parse_zero_pad(str), do: {false, str}
+
+  defp parse_width(str), do: consume_digits(str)
+
+  defp parse_grouping(<<",", rest::binary>>), do: {",", rest}
+  defp parse_grouping(<<"_", rest::binary>>), do: {"_", rest}
+  defp parse_grouping(str), do: {nil, str}
+
+  defp parse_precision(<<".", rest::binary>>) do
+    {digits, rest} = consume_digits(rest)
+    {digits || 0, rest}
+  end
+
+  defp parse_precision(str), do: {nil, str}
+
+  defp consume_digits(str), do: consume_digits(str, <<>>)
+
+  defp consume_digits(<<d, rest::binary>>, acc) when d in ?0..?9 do
+    consume_digits(rest, <<acc::binary, d>>)
+  end
+
+  defp consume_digits(rest, <<>>), do: {nil, rest}
+  defp consume_digits(rest, acc), do: {String.to_integer(acc), rest}
+
+  # Format a value with parsed spec
+  defp format_value(val, spec) do
+    case spec.type do
+      "f" -> format_float(val, spec)
+      "d" -> format_int(val, spec)
+      "s" -> format_string(val, spec)
+      "e" -> format_scientific(val, spec, "e")
+      "E" -> format_scientific(val, spec, "E")
+      "x" -> format_base(val, spec, 16, false)
+      "X" -> format_base(val, spec, 16, true)
+      "o" -> format_base(val, spec, 8, false)
+      "b" -> format_base(val, spec, 2, false)
+      "%" -> format_percentage(val, spec)
+      "" -> format_default(val, spec)
+      _ -> {:exception, "ValueError: Unknown format code '#{spec.type}'"}
+    end
+  end
+
+  defp format_float(val, spec) when is_number(val) do
+    precision = spec.precision || 6
+    float_val = val / 1
+    formatted = :erlang.float_to_binary(float_val, decimals: precision)
+    formatted = maybe_group(formatted, spec.grouping)
+    apply_alignment(formatted, spec, val)
+  end
+
+  defp format_float({:pyex_decimal, d}, spec) do
+    precision = spec.precision || 6
+    formatted = format_decimal_fixed(d, precision)
+    formatted = maybe_group(formatted, spec.grouping)
+    apply_alignment(formatted, spec, {:pyex_decimal, d})
+  end
+
+  defp format_float(val, _spec) do
+    {:exception,
+     "ValueError: Unknown format code 'f' for object of type '#{Helpers.py_type(val)}'"}
+  end
+
+  defp format_int(val, spec) when is_integer(val) do
+    formatted = Integer.to_string(val)
+    formatted = maybe_group(formatted, spec.grouping)
+    apply_alignment(formatted, spec, val)
+  end
+
+  defp format_int(val, spec) when is_float(val) do
+    format_int(trunc(val), spec)
+  end
+
+  defp format_int(val, _spec) do
+    {:exception,
+     "ValueError: Unknown format code 'd' for object of type '#{Helpers.py_type(val)}'"}
+  end
+
+  defp format_string(val, spec) when is_binary(val) do
+    formatted =
+      case spec.precision do
+        nil -> val
+        p -> String.slice(val, 0, p)
+      end
+
+    apply_alignment(formatted, spec, val)
+  end
+
+  defp format_string(val, spec) do
+    format_string(Helpers.py_str(val), spec)
+  end
+
+  defp format_scientific(val, spec, e_char) when is_number(val) do
+    precision = spec.precision || 6
+    float_val = val / 1
+    formatted = :io_lib.format(~c"~.#{precision}e", [float_val]) |> IO.iodata_to_binary()
+    formatted = normalize_exponent(formatted)
+
+    formatted =
+      if e_char == "E", do: String.upcase(formatted), else: formatted
+
+    apply_alignment(formatted, spec, val)
+  end
+
+  defp format_scientific(val, _spec, _e_char) do
+    {:exception,
+     "ValueError: Unknown format code 'e' for object of type '#{Helpers.py_type(val)}'"}
+  end
+
+  defp format_base(val, spec, base, upcase) when is_integer(val) do
+    formatted =
+      if val < 0 do
+        "-" <> Integer.to_string(-val, base)
+      else
+        Integer.to_string(val, base)
+      end
+
+    formatted = if upcase, do: String.upcase(formatted), else: String.downcase(formatted)
+
+    formatted =
+      if spec.alt do
+        prefix =
+          case base do
+            16 -> if(upcase, do: "0X", else: "0x")
+            8 -> "0o"
+            2 -> "0b"
+          end
+
+        if val < 0,
+          do: "-" <> prefix <> String.trim_leading(formatted, "-"),
+          else: prefix <> formatted
+      else
+        formatted
+      end
+
+    apply_alignment(formatted, spec, val)
+  end
+
+  defp format_base(val, _spec, _base, _upcase) do
+    {:exception, "ValueError: Unknown format code for object of type '#{Helpers.py_type(val)}'"}
+  end
+
+  defp format_percentage(val, spec) when is_number(val) do
+    precision = spec.precision || 6
+    float_val = val * 100.0
+    formatted = :erlang.float_to_binary(float_val, decimals: precision) <> "%"
+    apply_alignment(formatted, spec, val)
+  end
+
+  defp format_percentage(val, _spec) do
+    {:exception,
+     "ValueError: Unknown format code '%' for object of type '#{Helpers.py_type(val)}'"}
+  end
+
+  defp format_default(val, spec) when is_integer(val) do
+    formatted = Integer.to_string(val)
+    formatted = maybe_group(formatted, spec.grouping)
+    apply_alignment(formatted, spec, val)
+  end
+
+  defp format_default(val, spec) when is_float(val) do
+    # Python default float formatting
+    formatted = format_default_float(val)
+    formatted = maybe_group(formatted, spec.grouping)
+    apply_alignment(formatted, spec, val)
+  end
+
+  defp format_default(val, spec) when is_binary(val) do
+    format_string(val, spec)
+  end
+
+  defp format_default(val, spec) do
+    format_string(Helpers.py_str(val), spec)
+  end
+
+  defp format_default_float(f) do
+    # Python uses repr-style float formatting by default
+    s = Float.to_string(f)
+    # Erlang Float.to_string may add extra precision;
+    # just use it as is since it generally matches Python well enough
+    s
+  end
+
+  # Apply comma/underscore grouping to the integer part of a number string
+  defp maybe_group(str, nil), do: str
+
+  defp maybe_group(str, sep) do
+    {neg, str} =
+      case str do
+        "-" <> rest -> {"-", rest}
+        _ -> {"", str}
+      end
+
+    case String.split(str, ".") do
+      [int_part] ->
+        neg <> group_digits(int_part, sep)
+
+      [int_part, dec_part] ->
+        neg <> group_digits(int_part, sep) <> "." <> dec_part
+    end
+  end
+
+  defp group_digits(str, sep) do
+    str
+    |> String.reverse()
+    |> String.to_charlist()
+    |> Enum.chunk_every(3)
+    |> Enum.map(&List.to_string/1)
+    |> Enum.join(sep)
+    |> String.reverse()
+  end
+
+  # Apply alignment and width
+  defp apply_alignment(str, %{width: nil}, _val), do: str
+
+  defp apply_alignment(str, spec, val) do
+    width = spec.width
+    len = String.length(str)
+
+    if len >= width do
+      str
+    else
+      padding = width - len
+      fill = spec.fill || " "
+
+      case spec.align || default_align(val) do
+        "<" ->
+          str <> String.duplicate(fill, padding)
+
+        ">" ->
+          String.duplicate(fill, padding) <> str
+
+        "^" ->
+          left = div(padding, 2)
+          right = padding - left
+          String.duplicate(fill, left) <> str <> String.duplicate(fill, right)
+
+        "=" ->
+          # Pad after sign
+          case str do
+            <<sign, rest::binary>> when sign in [?+, ?-, ?\s] ->
+              <<sign>> <> String.duplicate(fill, padding) <> rest
+
+            _ ->
+              String.duplicate(fill, padding) <> str
+          end
+      end
+    end
+  end
+
+  @spec format_decimal_fixed(Decimal.t(), non_neg_integer()) :: String.t()
+  defp format_decimal_fixed(d, precision) do
+    d
+    |> Decimal.round(precision)
+    |> Decimal.to_string()
+  end
+
+  # Python defaults: numbers right-align, strings left-align.
+  defp default_align(val) when is_integer(val) or is_float(val), do: ">"
+  defp default_align({:pyex_decimal, _}), do: ">"
+  defp default_align(_), do: "<"
+
+  defp normalize_exponent(str) do
+    Regex.replace(~r/e([+-])(\d)$/, str, "e\\g{1}0\\2")
+  end
+end

--- a/lib/pyex/interpreter/helpers.ex
+++ b/lib/pyex/interpreter/helpers.ex
@@ -45,6 +45,7 @@ defmodule Pyex.Interpreter.Helpers do
   def py_type({:pandas_series, _}), do: "Series"
   def py_type({:pandas_rolling, _, _}), do: "Rolling"
   def py_type({:pandas_dataframe, _}), do: "DataFrame"
+  def py_type({:pyex_decimal, _}), do: "Decimal"
   def py_type(_), do: "object"
 
   @doc """
@@ -100,6 +101,7 @@ defmodule Pyex.Interpreter.Helpers do
   def py_str({:range, s, e, st}),
     do: if(st == 1, do: "range(#{s}, #{e})", else: "range(#{s}, #{e}, #{st})")
 
+  def py_str({:pyex_decimal, d}), do: Decimal.to_string(d)
   def py_str({:generator, _}), do: "<generator object>"
   def py_str({:generator_error, _, _}), do: "<generator object>"
   def py_str({:iterator, _}), do: "<iterator object>"
@@ -111,6 +113,7 @@ defmodule Pyex.Interpreter.Helpers do
   """
   @spec py_repr_fmt(Pyex.Interpreter.pyvalue()) :: String.t()
   def py_repr_fmt(val) when is_binary(val), do: "'" <> escape_repr(val) <> "'"
+  def py_repr_fmt({:pyex_decimal, d}), do: "Decimal('#{Decimal.to_string(d)}')"
   def py_repr_fmt(val), do: py_str(val)
 
   @doc """
@@ -144,6 +147,8 @@ defmodule Pyex.Interpreter.Helpers do
   def truthy?(map) when map == %{}, do: false
   def truthy?({:tuple, []}), do: false
   def truthy?({:set, s}), do: MapSet.size(s) > 0
+
+  def truthy?({:pyex_decimal, d}), do: not Decimal.equal?(d, Decimal.new(0))
 
   def truthy?({:range, start, stop, step}),
     do: Builtins.range_length({:range, start, stop, step}) > 0
@@ -197,6 +202,7 @@ defmodule Pyex.Interpreter.Helpers do
   def to_python_view(map) when is_map(map),
     do: Map.new(map, fn {k, v} -> {k, to_python_view(v)} end)
 
+  def to_python_view({:pyex_decimal, _} = d), do: d
   def to_python_view(val), do: val
 
   @doc false

--- a/lib/pyex/interpreter/import.ex
+++ b/lib/pyex/interpreter/import.ex
@@ -11,6 +11,68 @@ defmodule Pyex.Interpreter.Import do
   alias Pyex.{Builtins, Ctx, Env, Interpreter}
 
   @doc """
+  Evaluates an `import ...` statement.
+  """
+  @spec eval_import([String.t() | {String.t(), String.t() | nil}], Env.t(), Ctx.t()) ::
+          {nil, Env.t(), Ctx.t()} | {{:exception, String.t()}, Env.t(), Ctx.t()}
+  def eval_import(imports, env, ctx) when is_list(imports) do
+    Enum.reduce_while(imports, {nil, env, ctx}, fn import_spec, {_, env, ctx} ->
+      {module_name, alias_name} =
+        case import_spec do
+          {module_name, alias_name} -> {module_name, alias_name}
+          module_name when is_binary(module_name) -> {module_name, nil}
+        end
+
+      bind_as = alias_name || module_name
+
+      case resolve_module(module_name, env, ctx) do
+        {:ok, module_value, ctx} ->
+          {:cont, {nil, Env.put(env, bind_as, module_value), ctx}}
+
+        {:import_error, msg, ctx} ->
+          {:halt, {{:exception, msg}, env, ctx}}
+
+        {:unknown_module, ctx} ->
+          {:halt,
+           {{:exception,
+             "ImportError: no module named '#{module_name}'#{import_hint(module_name)}"}, env,
+            ctx}}
+      end
+    end)
+  end
+
+  @doc """
+  Evaluates a `from ... import ...` statement.
+  """
+  @spec eval_from_import(String.t(), [{String.t(), String.t() | nil}], Env.t(), Ctx.t()) ::
+          {nil, Env.t(), Ctx.t()} | {{:exception, String.t()}, Env.t(), Ctx.t()}
+  def eval_from_import(module_name, names, env, ctx) do
+    case resolve_module(module_name, env, ctx) do
+      {:ok, module_value, ctx} when is_map(module_value) ->
+        Enum.reduce_while(names, {nil, env, ctx}, fn {name, alias_name}, {_, env, ctx} ->
+          bind_as = alias_name || name
+
+          case Map.fetch(module_value, name) do
+            {:ok, value} ->
+              {:cont, {nil, Env.put(env, bind_as, value), ctx}}
+
+            :error ->
+              {:halt,
+               {{:exception, "ImportError: cannot import name '#{name}' from '#{module_name}'"},
+                env, ctx}}
+          end
+        end)
+
+      {:import_error, msg, ctx} ->
+        {{:exception, msg}, env, ctx}
+
+      {:unknown_module, ctx} ->
+        {{:exception, "ImportError: no module named '#{module_name}'#{import_hint(module_name)}"},
+         env, ctx}
+    end
+  end
+
+  @doc """
   Returns a helpful error suffix for unknown module names.
   """
   @spec import_hint(String.t()) :: String.t()

--- a/lib/pyex/interpreter/invocation.ex
+++ b/lib/pyex/interpreter/invocation.ex
@@ -1,0 +1,395 @@
+defmodule Pyex.Interpreter.Invocation do
+  @moduledoc """
+  User-function and bound-method invocation for `Pyex.Interpreter`.
+
+  Keeps the closure setup, generator handling, and method rebinding paths out
+  of the main interpreter module while preserving `call_function/5` as the
+  public entrypoint.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+  alias Pyex.Interpreter.{BuiltinResults, CallSupport, ClassLookup, Helpers}
+
+  @doc false
+  @spec call_user_function(
+          Interpreter.pyvalue(),
+          String.t(),
+          [Parser.param()],
+          [Parser.ast_node()],
+          Env.t(),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  def call_user_function(func, name, params, body, closure_env, args, kwargs, env, ctx) do
+    if ctx.call_depth >= ctx.max_call_depth do
+      {{:exception, "RecursionError: maximum recursion depth exceeded"}, env, ctx}
+    else
+      ctx = %{ctx | call_depth: ctx.call_depth + 1}
+
+      fresh_closure = Env.put_global_scope(closure_env, Env.global_scope(env))
+      base_env = Env.push_scope(Env.put(fresh_closure, name, func))
+
+      case CallSupport.bind_params(params, args, kwargs, base_env, ctx) do
+        {:exception, msg, ctx} ->
+          ctx = %{ctx | call_depth: ctx.call_depth - 1}
+          {{:exception, msg}, env, ctx}
+
+        {call_env, ctx} ->
+          t0 = if ctx.profile, do: System.monotonic_time(:microsecond)
+
+          result =
+            if Interpreter.contains_yield?(body) do
+              eval_generator_function(body, call_env, env, ctx)
+            else
+              eval_regular_function(func, fresh_closure, body, call_env, env, ctx)
+            end
+
+          result = maybe_record_profile(result, name, t0)
+          CallSupport.decrement_depth(result)
+      end
+    end
+  end
+
+  @doc false
+  @spec call_bound_method(
+          Interpreter.pyvalue(),
+          Interpreter.pyvalue(),
+          Interpreter.pyvalue() | nil,
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  def call_bound_method(
+        instance,
+        {:function, fname, params, body, closure_env},
+        defining_class,
+        args,
+        kwargs,
+        env,
+        ctx
+      ) do
+    method_args = [instance | args]
+    fresh_closure = Env.put_global_scope(closure_env, Env.global_scope(env))
+    func = {:function, fname, params, body, closure_env}
+    base_env = Env.push_scope(Env.put(fresh_closure, fname, func))
+
+    base_env =
+      if defining_class, do: Env.put(base_env, "__class__", defining_class), else: base_env
+
+    case CallSupport.bind_params(params, method_args, kwargs, base_env, ctx) do
+      {:exception, msg, ctx} ->
+        {{:exception, msg}, env, ctx}
+
+      {call_env, ctx} ->
+        {result, post_call_env, ctx} = Interpreter.eval_statements(body, call_env, ctx)
+        env = Env.propagate_scopes(env, fresh_closure, post_call_env)
+        return_val = Helpers.unwrap(result)
+
+        updated_self =
+          case Env.get(post_call_env, "self") do
+            {:ok, {:instance, _, _} = updated} -> updated
+            _ -> instance
+          end
+
+        {:mutate, updated_self, return_val, env, ctx}
+    end
+  end
+
+  @doc false
+  @spec call_builtin((list() -> term()), [Interpreter.pyvalue()], Env.t(), Ctx.t()) ::
+          Interpreter.call_result()
+  def call_builtin(fun, args, env, ctx) do
+    result =
+      try do
+        fun.(args)
+      rescue
+        FunctionClauseError ->
+          {:exception, "TypeError: invalid arguments"}
+
+        e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
+          {:exception, "TypeError: #{Exception.message(e)}"}
+      end
+
+    BuiltinResults.handle_builtin_result(result, env, ctx)
+  end
+
+  @doc false
+  @spec call_builtin_kw(
+          (list(), %{optional(String.t()) => Interpreter.pyvalue()} -> term()),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  def call_builtin_kw(fun, args, kwargs, env, ctx) do
+    result =
+      try do
+        fun.(args, kwargs)
+      rescue
+        FunctionClauseError ->
+          {:exception, "TypeError: invalid arguments"}
+
+        e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
+          {:exception, "TypeError: #{Exception.message(e)}"}
+      end
+
+    BuiltinResults.handle_builtin_kw_result(result, env, ctx)
+  end
+
+  @doc false
+  @spec call_bound_builtin_kw(
+          Interpreter.pyvalue(),
+          (list(), %{optional(String.t()) => Interpreter.pyvalue()} -> term()),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  def call_bound_builtin_kw(instance, fun, args, kwargs, env, ctx) do
+    case fun.([instance | args], kwargs) do
+      {:exception, _} = signal ->
+        {signal, env, ctx}
+
+      {:mutate, new_obj, return_val, new_ctx} ->
+        {:mutate, new_obj, return_val, new_ctx}
+
+      result ->
+        {result, env, ctx}
+    end
+  end
+
+  @doc false
+  @spec call_bound_builtin(
+          Interpreter.pyvalue(),
+          (list() -> term()),
+          [Interpreter.pyvalue()],
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  def call_bound_builtin(instance, fun, args, env, ctx) do
+    case fun.([instance | args]) do
+      {:exception, _} = signal ->
+        {signal, env, ctx}
+
+      result ->
+        {result, env, ctx}
+    end
+  end
+
+  @doc false
+  @spec call_class(
+          Interpreter.pyvalue(),
+          String.t(),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  def call_class({:class, _, _, _} = class, name, args, kwargs, env, ctx) do
+    instance = {:instance, class, %{}}
+
+    case ClassLookup.resolve_class_attr_with_owner(class, "__init__") do
+      {:ok, {:function, init_name, params, body, closure_env}, defining_class} ->
+        call_class_init(
+          instance,
+          init_name,
+          params,
+          body,
+          closure_env,
+          defining_class,
+          args,
+          kwargs,
+          env,
+          ctx
+        )
+
+      {:ok, {:builtin_kw, fun}, _defining_class} ->
+        case fun.([instance | args], kwargs) do
+          {:instance, _, _} = updated_instance ->
+            {updated_instance, env, ctx}
+
+          {:exception, _} = signal ->
+            {signal, env, ctx}
+        end
+
+      :error ->
+        if args == [] do
+          {instance, env, ctx}
+        else
+          {{:exception, "TypeError: #{name}() takes 0 arguments but #{length(args)} were given"},
+           env, ctx}
+        end
+    end
+  end
+
+  @doc false
+  @spec call_callable_instance(
+          Interpreter.pyvalue(),
+          Interpreter.pyvalue(),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  def call_callable_instance(instance, class, args, kwargs, env, ctx) do
+    case ClassLookup.resolve_class_attr(class, "__call__") do
+      {:ok, {:function, _, _, _, _} = func} ->
+        Interpreter.call_function({:bound_method, instance, func}, args, kwargs, env, ctx)
+
+      _ ->
+        {{:exception, "TypeError: '#{Helpers.py_type(instance)}' object is not callable"}, env,
+         ctx}
+    end
+  end
+
+  @spec eval_generator_function([Parser.ast_node()], Env.t(), Env.t(), Ctx.t()) ::
+          Interpreter.call_result()
+  defp eval_generator_function(body, call_env, env, ctx) do
+    case ctx.generator_mode do
+      :defer ->
+        gen_ctx = %{ctx | generator_mode: :defer_inner}
+
+        case Interpreter.eval_statements(body, call_env, gen_ctx) do
+          {{:yielded, val, cont}, gen_env, gen_ctx} ->
+            ctx = sync_generator_ctx(ctx, gen_ctx)
+            {{:generator_suspended, val, cont, gen_env}, env, ctx}
+
+          {{:exception, _} = signal, _post_env, gen_ctx} ->
+            ctx = sync_generator_ctx(ctx, gen_ctx)
+            {signal, env, ctx}
+
+          {_, _post_env, gen_ctx} ->
+            ctx = sync_generator_ctx(ctx, gen_ctx)
+            {{:generator, []}, env, ctx}
+        end
+
+      _ ->
+        prev_acc = ctx.generator_acc
+        gen_ctx = %{ctx | generator_mode: :accumulate, generator_acc: []}
+        {result, _post_call_env, gen_ctx} = Interpreter.eval_statements(body, call_env, gen_ctx)
+        yields = Enum.reverse(gen_ctx.generator_acc || [])
+
+        ctx = %{
+          ctx
+          | compute: gen_ctx.compute,
+            compute_started_at: gen_ctx.compute_started_at,
+            generator_mode: ctx.generator_mode,
+            generator_acc: prev_acc,
+            event_count: gen_ctx.event_count,
+            file_ops: gen_ctx.file_ops
+        }
+
+        case result do
+          {:exception, "TimeoutError:" <> _ = msg} ->
+            {{:exception, msg}, env, ctx}
+
+          {:exception, msg} ->
+            {{:generator_error, yields, msg}, env, ctx}
+
+          _ ->
+            {{:generator, yields}, env, ctx}
+        end
+    end
+  end
+
+  @spec eval_regular_function(
+          Interpreter.pyvalue(),
+          Env.t(),
+          [Parser.ast_node()],
+          Env.t(),
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  defp eval_regular_function(func, fresh_closure, body, call_env, env, ctx) do
+    {result, post_call_env, ctx} = Interpreter.eval_statements(body, call_env, ctx)
+    env = Env.propagate_scopes(env, fresh_closure, post_call_env)
+    return_val = Helpers.unwrap(result)
+
+    if Helpers.has_scope_declarations?(post_call_env) do
+      return_val = Helpers.refresh_closure(return_val, post_call_env)
+      updated_func = Helpers.refresh_closure(func, post_call_env)
+      {return_val, env, ctx, updated_func}
+    else
+      updated_func = Helpers.update_closure_env(func, post_call_env)
+      {return_val, env, ctx, updated_func}
+    end
+  end
+
+  @spec maybe_record_profile(Interpreter.call_result(), String.t(), integer() | nil) ::
+          Interpreter.call_result()
+  defp maybe_record_profile(result, _name, nil), do: result
+
+  defp maybe_record_profile(result, name, t0) do
+    elapsed_us = System.monotonic_time(:microsecond) - t0
+    elapsed_ms = elapsed_us / 1000.0
+    CallSupport.update_profile_in_result(result, name, elapsed_ms)
+  end
+
+  @spec sync_generator_ctx(Ctx.t(), Ctx.t()) :: Ctx.t()
+  defp sync_generator_ctx(ctx, gen_ctx) do
+    %{
+      ctx
+      | compute: gen_ctx.compute,
+        compute_started_at: gen_ctx.compute_started_at,
+        event_count: gen_ctx.event_count,
+        file_ops: gen_ctx.file_ops
+    }
+  end
+
+  @spec call_class_init(
+          Interpreter.pyvalue(),
+          String.t(),
+          [Parser.param()],
+          [Parser.ast_node()],
+          Env.t(),
+          Interpreter.pyvalue(),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  defp call_class_init(
+         instance,
+         init_name,
+         params,
+         body,
+         closure_env,
+         defining_class,
+         args,
+         kwargs,
+         env,
+         ctx
+       ) do
+    init_args = [instance | args]
+    fresh_closure = Env.put_global_scope(closure_env, Env.global_scope(env))
+    init_fn = {:function, init_name, params, body, closure_env}
+    base_env = Env.push_scope(Env.put(fresh_closure, init_name, init_fn))
+    base_env = Env.put(base_env, "__class__", defining_class)
+
+    case CallSupport.bind_params(params, init_args, kwargs, base_env, ctx) do
+      {:exception, msg, ctx} ->
+        {{:exception, msg}, env, ctx}
+
+      {call_env, ctx} ->
+        {result, post_call_env, ctx} = Interpreter.eval_statements(body, call_env, ctx)
+        env = Env.propagate_scopes(env, fresh_closure, post_call_env)
+
+        case result do
+          {:exception, _} = signal ->
+            {signal, env, ctx}
+
+          _ ->
+            final_self =
+              case Env.get(post_call_env, "self") do
+                {:ok, {:instance, _, _} = updated} -> updated
+                _ -> instance
+              end
+
+            {final_self, env, ctx}
+        end
+    end
+  end
+end

--- a/lib/pyex/interpreter/iterables.ex
+++ b/lib/pyex/interpreter/iterables.ex
@@ -1,0 +1,110 @@
+defmodule Pyex.Interpreter.Iterables do
+  @moduledoc """
+  Iterable and iterator protocol helpers for `Pyex.Interpreter`.
+
+  Keeps iterable coercion, iterator draining, and instance-backed iterator state
+  updates separate from the main evaluator.
+  """
+
+  alias Pyex.{Builtins, Ctx, Env, Interpreter}
+  alias Pyex.Interpreter.{Dunder, Helpers}
+
+  @doc false
+  @spec to_iterable(Interpreter.pyvalue(), Env.t(), Ctx.t()) ::
+          {:ok, [Interpreter.pyvalue()], Env.t(), Ctx.t()} | {:exception, String.t()}
+  def to_iterable({:py_list, reversed, _len}, env, ctx),
+    do: {:ok, Enum.reverse(reversed), env, ctx}
+
+  def to_iterable(list, env, ctx) when is_list(list), do: {:ok, list, env, ctx}
+  def to_iterable(str, env, ctx) when is_binary(str), do: {:ok, String.codepoints(str), env, ctx}
+
+  def to_iterable(map, env, ctx) when is_map(map),
+    do: {:ok, map |> Builtins.visible_dict() |> Map.keys(), env, ctx}
+
+  def to_iterable({:tuple, elements}, env, ctx), do: {:ok, elements, env, ctx}
+  def to_iterable({:set, set}, env, ctx), do: {:ok, MapSet.to_list(set), env, ctx}
+  def to_iterable({:frozenset, set}, env, ctx), do: {:ok, MapSet.to_list(set), env, ctx}
+
+  def to_iterable({:range, _, _, _} = range, env, ctx) do
+    case Builtins.range_to_list(range) do
+      {:exception, _} = err -> err
+      list -> {:ok, list, env, ctx}
+    end
+  end
+
+  def to_iterable({:generator, items}, env, ctx), do: {:ok, items, env, ctx}
+  def to_iterable({:generator_error, items, _msg}, env, ctx), do: {:ok, items, env, ctx}
+  def to_iterable({:iterator, id}, env, ctx), do: {:ok, Ctx.iter_items(ctx, id), env, ctx}
+
+  def to_iterable({:instance, _, _} = inst, env, ctx) do
+    case Dunder.call_dunder(inst, "__iter__", [], env, ctx) do
+      {:ok, result, env, ctx} ->
+        case result do
+          {:exception, _} = signal ->
+            signal
+
+          {:instance, _, _} = iter ->
+            drain_iterator(iter, [], env, ctx)
+
+          other ->
+            to_iterable(other, env, ctx)
+        end
+
+      :not_found ->
+        {:exception, "TypeError: '#{Helpers.py_type(inst)}' object is not iterable"}
+    end
+  end
+
+  def to_iterable(val, _env, _ctx) do
+    {:exception, "TypeError: '#{Helpers.py_type(val)}' object is not iterable"}
+  end
+
+  @doc false
+  @spec eval_instance_next(
+          Interpreter.pyvalue(),
+          non_neg_integer(),
+          :no_default | {:default, Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+  def eval_instance_next(inst, id, default_opt, env, ctx) do
+    case Dunder.call_dunder_mut(inst, "__next__", [], env, ctx) do
+      {:ok, _new_inst, {:exception, "StopIteration" <> _}, env, ctx} ->
+        ctx = Ctx.delete_iterator(ctx, id)
+
+        case default_opt do
+          {:default, default} -> {default, env, ctx}
+          :no_default -> {{:exception, "StopIteration"}, env, ctx}
+        end
+
+      {:ok, _new_inst, {:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {:ok, new_inst, value, env, ctx} ->
+        ctx = Ctx.update_instance_iterator(ctx, id, new_inst)
+        {value, env, ctx}
+
+      :not_found ->
+        {{:exception, "TypeError: object has no __next__"}, env, ctx}
+    end
+  end
+
+  @spec drain_iterator(Interpreter.pyvalue(), [Interpreter.pyvalue()], Env.t(), Ctx.t()) ::
+          {:ok, [Interpreter.pyvalue()], Env.t(), Ctx.t()} | {:exception, String.t()}
+  defp drain_iterator(iter, acc, env, ctx) do
+    case Dunder.call_dunder_mut(iter, "__next__", [], env, ctx) do
+      {:ok, new_iter, {:exception, "StopIteration" <> _}, env, ctx} ->
+        _ = new_iter
+        {:ok, Enum.reverse(acc), env, ctx}
+
+      {:ok, _new_iter, {:exception, _} = signal, _env, _ctx} ->
+        signal
+
+      {:ok, new_iter, value, env, ctx} ->
+        drain_iterator(new_iter, [value | acc], env, ctx)
+
+      :not_found ->
+        {:exception, "TypeError: '#{Helpers.py_type(iter)}' object is not an iterator"}
+    end
+  end
+end

--- a/lib/pyex/interpreter/protocols.ex
+++ b/lib/pyex/interpreter/protocols.ex
@@ -1,0 +1,84 @@
+defmodule Pyex.Interpreter.Protocols do
+  @moduledoc """
+  Python protocol helpers for string conversion and truthiness.
+
+  Keeps `__str__`, `__repr__`, `__bool__`, and `__len__` fallback rules together
+  so protocol semantics stay separate from the main evaluator.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter}
+  alias Pyex.Interpreter.{Dunder, Helpers}
+
+  @doc false
+  @spec eval_py_str(Interpreter.pyvalue(), Env.t(), Ctx.t()) :: {String.t(), Env.t(), Ctx.t()}
+  def eval_py_str({:instance, _, _} = inst, env, ctx) do
+    case Dunder.call_dunder(inst, "__str__", [], env, ctx) do
+      {:ok, str, env, ctx} when is_binary(str) ->
+        {str, env, ctx}
+
+      _ ->
+        case Dunder.call_dunder(inst, "__repr__", [], env, ctx) do
+          {:ok, str, env, ctx} when is_binary(str) -> {str, env, ctx}
+          _ -> {Helpers.py_str(inst), env, ctx}
+        end
+    end
+  end
+
+  def eval_py_str(val, env, ctx), do: {Helpers.py_str(val), env, ctx}
+
+  @doc false
+  @spec dunder_str_fallback(Interpreter.pyvalue(), String.t(), Env.t(), Ctx.t()) ::
+          {:ok, String.t(), Env.t(), Ctx.t()} | :error
+  def dunder_str_fallback({:instance, _, attrs} = inst, "__str__", env, ctx) do
+    case Dunder.call_dunder(inst, "__repr__", [], env, ctx) do
+      {:ok, str, env, ctx} when is_binary(str) ->
+        {:ok, str, env, ctx}
+
+      _ ->
+        case Map.get(attrs, "args") do
+          {:tuple, [single]} when is_binary(single) ->
+            {:ok, single, env, ctx}
+
+          {:tuple, items} when is_list(items) and items != [] ->
+            {:ok, items |> Enum.map(&Helpers.py_str/1) |> Enum.join(", "), env, ctx}
+
+          _ ->
+            {:ok, Helpers.py_str(inst), env, ctx}
+        end
+    end
+  end
+
+  def dunder_str_fallback({:instance, _, _} = inst, "__repr__", env, ctx) do
+    {:ok, Helpers.py_str(inst), env, ctx}
+  end
+
+  def dunder_str_fallback(inst, "__bool__", env, ctx) do
+    case Dunder.call_dunder(inst, "__len__", [], env, ctx) do
+      {:ok, len, env, ctx} when is_integer(len) ->
+        {:ok, len > 0, env, ctx}
+
+      _ ->
+        {:ok, true, env, ctx}
+    end
+  end
+
+  def dunder_str_fallback(_, _, _, _), do: :error
+
+  @doc false
+  @spec eval_truthy(Interpreter.pyvalue(), Env.t(), Ctx.t()) :: {boolean(), Env.t(), Ctx.t()}
+  def eval_truthy({:instance, _, _} = inst, env, ctx) do
+    case Dunder.call_dunder(inst, "__bool__", [], env, ctx) do
+      {:ok, result, env, ctx} ->
+        {Helpers.truthy?(result), env, ctx}
+
+      :not_found ->
+        case Dunder.call_dunder(inst, "__len__", [], env, ctx) do
+          {:ok, result, env, ctx} when is_integer(result) -> {result != 0, env, ctx}
+          {:ok, _, env, ctx} -> {true, env, ctx}
+          :not_found -> {true, env, ctx}
+        end
+    end
+  end
+
+  def eval_truthy(val, env, ctx), do: {Helpers.truthy?(val), env, ctx}
+end

--- a/lib/pyex/interpreter/statements.ex
+++ b/lib/pyex/interpreter/statements.ex
@@ -1,0 +1,123 @@
+defmodule Pyex.Interpreter.Statements do
+  @moduledoc """
+  Simple statement evaluation helpers for `Pyex.Interpreter`.
+
+  Keeps small statement families together so the main interpreter can focus
+  on dispatch while preserving the public `eval/3` entrypoint.
+  """
+
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+  alias Pyex.Interpreter.Helpers
+
+  @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
+
+  @doc """
+  Evaluates an `assert` statement.
+  """
+  @spec eval_assert(Parser.ast_node(), Parser.ast_node() | nil, Env.t(), Ctx.t()) :: eval_result()
+  def eval_assert(condition, msg_expr, env, ctx) do
+    case Interpreter.eval(condition, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {value, env, ctx} ->
+        {taken, env, ctx} = Interpreter.eval_truthy(value, env, ctx)
+
+        if taken do
+          {nil, env, ctx}
+        else
+          eval_assert_message(msg_expr, env, ctx)
+        end
+    end
+  end
+
+  @doc """
+  Evaluates `del name`.
+  """
+  @spec eval_del_var(String.t(), Env.t(), Ctx.t()) :: eval_result()
+  def eval_del_var(var_name, env, ctx) do
+    {nil, Env.delete(env, var_name), ctx}
+  end
+
+  @doc """
+  Evaluates `del obj[key]` for name-backed containers.
+  """
+  @spec eval_del_subscript(String.t(), Parser.ast_node(), Env.t(), Ctx.t()) :: eval_result()
+  def eval_del_subscript(var_name, key_expr, env, ctx) do
+    case Env.get(env, var_name) do
+      {:ok, obj} when is_map(obj) ->
+        case Interpreter.eval(key_expr, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {key, env, ctx} ->
+            {nil, Env.put(env, var_name, Map.delete(obj, key)), ctx}
+        end
+
+      {:ok, {:py_list, reversed, len}} ->
+        case Interpreter.eval(key_expr, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {idx, env, ctx} when is_integer(idx) ->
+            real_idx = if idx < 0, do: len + idx, else: idx
+            new_reversed = List.delete_at(reversed, len - 1 - real_idx)
+            {nil, Env.put(env, var_name, {:py_list, new_reversed, len - 1}), ctx}
+
+          {_, env, ctx} ->
+            {{:exception, "TypeError: list indices must be integers"}, env, ctx}
+        end
+
+      {:ok, obj} when is_list(obj) ->
+        case Interpreter.eval(key_expr, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {idx, env, ctx} when is_integer(idx) ->
+            {nil, Env.put(env, var_name, List.delete_at(obj, idx)), ctx}
+
+          {_, env, ctx} ->
+            {{:exception, "TypeError: list indices must be integers"}, env, ctx}
+        end
+
+      {:ok, _} ->
+        {{:exception, "TypeError: object does not support item deletion"}, env, ctx}
+
+      :undefined ->
+        {{:exception, "NameError: name '#{var_name}' is not defined"}, env, ctx}
+    end
+  end
+
+  @doc """
+  Evaluates `pass`.
+  """
+  @spec eval_pass(Env.t(), Ctx.t()) :: eval_result()
+  def eval_pass(env, ctx), do: {nil, env, ctx}
+
+  @doc """
+  Evaluates `break`.
+  """
+  @spec eval_break(Env.t(), Ctx.t()) :: eval_result()
+  def eval_break(env, ctx), do: {{:break}, env, ctx}
+
+  @doc """
+  Evaluates `continue`.
+  """
+  @spec eval_continue(Env.t(), Ctx.t()) :: eval_result()
+  def eval_continue(env, ctx), do: {{:continue}, env, ctx}
+
+  @spec eval_assert_message(Parser.ast_node() | nil, Env.t(), Ctx.t()) :: eval_result()
+  defp eval_assert_message(nil, env, ctx) do
+    {{:exception, "AssertionError"}, env, ctx}
+  end
+
+  defp eval_assert_message(msg_expr, env, ctx) do
+    case Interpreter.eval(msg_expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {msg_val, env, ctx} ->
+        {{:exception, "AssertionError: #{Helpers.py_str(msg_val)}"}, env, ctx}
+    end
+  end
+end

--- a/lib/pyex/lambda.ex
+++ b/lib/pyex/lambda.ex
@@ -169,16 +169,14 @@ defmodule Pyex.Lambda do
 
   When the handler returns a `StreamingResponse`, the body is
   returned as a lazy `Enumerable` of string chunks, suitable
-  for piping to Phoenix/Plug chunk-by-chunk. A linked process
-  is spawned to run the Python handler; generator `yield`
-  statements produce chunks lazily via message passing.
+  for piping to Phoenix/Plug chunk-by-chunk. Streaming is driven
+  by generator continuations resumed through `Stream.resource/3`.
 
   When the handler returns a non-streaming response, the body
   is wrapped in a single-element list for a uniform API.
 
-  The spawned process is linked to the caller. If the caller
-  dies (e.g. client disconnect), the interpreter process is
-  cleaned up automatically.
+  The caller controls how much of the stream is consumed. Halting
+  enumeration early stops further generator resumption.
 
   ## Return
 
@@ -263,7 +261,7 @@ defmodule Pyex.Lambda do
       {:ok, ast} ->
         ctx = %{ctx | compute: 0.0, compute_started_at: System.monotonic_time()}
 
-        case Interpreter.run_with_ctx(ast, Builtins.env(), ctx) do
+        case Interpreter.run_with_ctx(ast, Builtins.runtime_env(ctx), ctx) do
           {:ok, _value, env, ctx} -> {:ok, env, ctx}
           {:error, msg} -> {:error, Error.from_message(msg)}
         end

--- a/lib/pyex/parser.ex
+++ b/lib/pyex/parser.ex
@@ -8,6 +8,11 @@ defmodule Pyex.Parser do
   """
 
   alias Pyex.Lexer
+  alias Pyex.Parser.Comprehensions
+  alias Pyex.Parser.ControlFlow
+  alias Pyex.Parser.Definitions
+  alias Pyex.Parser.Imports
+  alias Pyex.Parser.Match
 
   @type meta :: [line: pos_integer()]
 
@@ -75,10 +80,6 @@ defmodule Pyex.Parser do
           {String.t(), ast_node() | nil}
           | {String.t(), ast_node() | nil, String.t()}
 
-  @typep comp_clause ::
-           {:comp_for, String.t() | [String.t()], ast_node()}
-           | {:comp_if, ast_node()}
-
   @typep parse_result :: {:ok, ast_node(), [Lexer.token()]} | {:error, String.t()}
 
   @doc """
@@ -100,9 +101,14 @@ defmodule Pyex.Parser do
     end
   end
 
+  @doc false
+  @spec parse_block([Lexer.token()]) ::
+          {:ok, [ast_node()], [Lexer.token()]} | {:error, String.t()}
+  def parse_block(tokens), do: parse_block(tokens, [])
+
   @spec parse_block([Lexer.token()], [ast_node()]) ::
           {:ok, [ast_node()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_block(tokens, acc \\ [])
+  defp parse_block(tokens, acc)
   defp parse_block([], acc), do: {:ok, Enum.reverse(acc), []}
   defp parse_block([:dedent | rest], acc), do: {:ok, Enum.reverse(acc), rest}
   defp parse_block([:newline | rest], acc), do: parse_block(rest, acc)
@@ -116,15 +122,15 @@ defmodule Pyex.Parser do
 
   @spec parse_statement([Lexer.token()]) :: parse_result()
   defp parse_statement([{:keyword, _line, "def"} | rest]) do
-    parse_function_def(rest)
+    Definitions.parse_function_def(rest)
   end
 
   defp parse_statement([{:keyword, _line, "class"} | rest]) do
-    parse_class_def(rest)
+    Definitions.parse_class_def(rest)
   end
 
   defp parse_statement([{:keyword, line, "with"} | rest]) do
-    parse_with(rest, line)
+    Definitions.parse_with(rest, line)
   end
 
   defp parse_statement([{:keyword, line, "return"} | rest]) do
@@ -169,27 +175,27 @@ defmodule Pyex.Parser do
   end
 
   defp parse_statement([{:keyword, _line, "if"} | rest]) do
-    parse_if(rest)
+    ControlFlow.parse_if(rest)
   end
 
   defp parse_statement([{:keyword, _line, "while"} | rest]) do
-    parse_while(rest)
+    ControlFlow.parse_while(rest)
   end
 
   defp parse_statement([{:keyword, _line, "for"} | rest]) do
-    parse_for(rest)
+    ControlFlow.parse_for(rest)
   end
 
   defp parse_statement([{:keyword, line, "from"} | rest]) do
-    parse_from_import(rest, line)
+    Imports.parse_from_import(rest, line)
   end
 
   defp parse_statement([{:keyword, line, "import"} | rest]) do
-    parse_import(rest, line)
+    Imports.parse_import(rest, line)
   end
 
   defp parse_statement([{:keyword, _line, "try"} | rest]) do
-    parse_try(rest)
+    ControlFlow.parse_try(rest)
   end
 
   defp parse_statement([{:keyword, line, "raise"} | rest]) do
@@ -313,7 +319,7 @@ defmodule Pyex.Parser do
   }
 
   defp parse_statement([{:name, line, "match"} | rest] = tokens) do
-    case try_match(rest, line) do
+    case Match.try_match(rest, line) do
       {:ok, _, _} = result -> result
       :not_match -> parse_name_statement(tokens, line, "match")
     end
@@ -653,922 +659,40 @@ defmodule Pyex.Parser do
     end
   end
 
-  @spec parse_function_def([Lexer.token()]) :: parse_result()
-  defp parse_function_def([{:name, line, name}, {:op, _, :lparen} | rest]) do
-    case parse_params(rest) do
-      {:ok, params, rest} ->
-        rest = skip_return_annotation(rest)
-
-        case rest do
-          [{:op, _, :colon}, :newline, :indent | rest] ->
-            case parse_block(rest) do
-              {:ok, body, rest} ->
-                {:ok, {:def, [line: line], [name, params, body]}, drop_newline(rest)}
-
-              {:error, _} = error ->
-                error
-            end
-
-          _ ->
-            {:error, "expected ':' after function definition on line #{line}"}
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_function_def(tokens) do
-    {:error, "expected function name at #{token_line(tokens)}"}
-  end
-
-  @spec parse_with([Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_with(rest, line) do
-    case parse_expression(rest) do
-      {:ok, expr,
-       [{:keyword, _, "as"}, {:name, _, name}, {:op, _, :colon}, :newline, :indent | rest]} ->
-        case parse_block(rest) do
-          {:ok, body, rest} ->
-            {:ok, {:with, [line: line], [expr, name, body]}, drop_newline(rest)}
-
-          {:error, _} = error ->
-            error
-        end
-
-      {:ok, expr, [{:op, _, :colon}, :newline, :indent | rest]} ->
-        case parse_block(rest) do
-          {:ok, body, rest} ->
-            {:ok, {:with, [line: line], [expr, nil, body]}, drop_newline(rest)}
-
-          {:error, _} = error ->
-            error
-        end
-
-      {:ok, _expr, _rest} ->
-        {:error, "expected ':' after with statement on line #{line}"}
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  @spec parse_class_def([Lexer.token()]) :: parse_result()
-  defp parse_class_def([{:name, line, name}, {:op, _, :lparen} | rest]) do
-    case parse_base_classes(rest) do
-      {:ok, bases, rest} ->
-        case rest do
-          [{:op, _, :colon}, :newline, :indent | rest] ->
-            case parse_block(rest) do
-              {:ok, body, rest} ->
-                {:ok, {:class, [line: line], [name, bases, body]}, drop_newline(rest)}
-
-              {:error, _} = error ->
-                error
-            end
-
-          _ ->
-            {:error, "expected ':' after class definition on line #{line}"}
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_class_def([{:name, line, name}, {:op, _, :colon}, :newline, :indent | rest]) do
-    case parse_block(rest) do
-      {:ok, body, rest} ->
-        {:ok, {:class, [line: line], [name, [], body]}, drop_newline(rest)}
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_class_def(tokens) do
-    {:error, "expected class name at #{token_line(tokens)}"}
-  end
-
-  @spec parse_base_classes([Lexer.token()], [String.t()]) ::
-          {:ok, [String.t()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_base_classes(tokens, acc \\ [])
-  defp parse_base_classes([{:op, _, :rparen} | rest], acc), do: {:ok, Enum.reverse(acc), rest}
-
-  defp parse_base_classes([{:op, _, :comma} | rest], acc) do
-    parse_base_classes(rest, acc)
-  end
-
-  defp parse_base_classes([{:name, _, name}, {:op, _, :dot}, {:name, _, attr} | rest], acc) do
-    parse_base_classes(rest, [{:dotted, name, attr} | acc])
-  end
-
-  defp parse_base_classes([{:name, _, name} | rest], acc) do
-    parse_base_classes(rest, [name | acc])
-  end
-
-  defp parse_base_classes(tokens, _acc) do
-    {:error, "unexpected token in class bases at #{token_line(tokens)}"}
-  end
-
-  @spec parse_params([Lexer.token()], [param()]) ::
-          {:ok, [param()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_params(tokens, acc \\ [])
-
-  defp parse_params([{:op, _, :rparen} | rest], acc) do
-    {:ok, Enum.reverse(acc), rest}
-  end
-
-  defp parse_params([{:op, _, :comma} | rest], acc) do
-    parse_params(rest, acc)
-  end
-
-  defp parse_params([{:name, _, name}, {:op, _, :colon} | rest], acc) do
-    {type_str, rest} = collect_type_annotation(rest)
-
-    case rest do
-      [{:op, _, :assign} | rest] ->
-        with {:ok, default, rest} <- parse_expression(rest) do
-          parse_params(rest, [{name, default, type_str} | acc])
-        end
-
-      _ ->
-        parse_params(rest, [{name, nil, type_str} | acc])
-    end
-  end
-
-  defp parse_params([{:name, _, name}, {:op, _, :assign} | rest], acc) do
-    with {:ok, default, rest} <- parse_expression(rest) do
-      parse_params(rest, [{name, default} | acc])
-    end
-  end
-
-  defp parse_params([{:op, _, :double_star}, {:name, _, name} | rest], acc) do
-    parse_params(rest, [{"**" <> name, nil} | acc])
-  end
-
-  defp parse_params([{:op, _, :star}, {:name, _, name} | rest], acc) do
-    parse_params(rest, [{"*" <> name, nil} | acc])
-  end
-
-  defp parse_params([{:name, _, name} | rest], acc) do
-    parse_params(rest, [{name, nil} | acc])
-  end
-
-  defp parse_params(tokens, _acc) do
-    {:error, "unexpected token in parameter list at #{token_line(tokens)}"}
-  end
-
-  @spec parse_if([Lexer.token()]) :: parse_result()
-  defp parse_if(tokens) do
-    with {:ok, condition, rest} <- parse_expression(tokens) do
-      case rest do
-        [{:op, _, :colon}, :newline, :indent | block_rest] ->
-          with {:ok, body, rest} <- parse_block(block_rest),
-               {:ok, else_clauses, rest} <- parse_elif_else(rest) do
-            line = node_line(condition)
-            {:ok, {:if, [line: line], [{condition, body} | else_clauses]}, drop_newline(rest)}
-          end
-
-        [{:op, _, :colon} | inline_rest] ->
-          with {:ok, stmt, rest} <- parse_inline_body(inline_rest) do
-            {:ok, else_clauses, rest} = parse_elif_else(rest)
-            line = node_line(condition)
-            {:ok, {:if, [line: line], [{condition, [stmt]} | else_clauses]}, drop_newline(rest)}
-          end
-
-        _ ->
-          {:error, "expected ':' after if at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  @spec parse_elif_else([Lexer.token()]) ::
-          {:ok, [{ast_node(), [ast_node()]} | {:else, [ast_node()]}], [Lexer.token()]}
-          | {:error, String.t()}
-  defp parse_elif_else([{:keyword, _, "elif"} | rest]) do
-    with {:ok, condition, rest} <- parse_expression(rest) do
-      case rest do
-        [{:op, _, :colon}, :newline, :indent | block_rest] ->
-          with {:ok, body, rest} <- parse_block(block_rest),
-               {:ok, more, rest} <- parse_elif_else(rest) do
-            {:ok, [{condition, body} | more], rest}
-          end
-
-        [{:op, _, :colon} | inline_rest] ->
-          with {:ok, stmt, rest} <- parse_inline_body(inline_rest) do
-            {:ok, more, rest} = parse_elif_else(rest)
-            {:ok, [{condition, [stmt]} | more], rest}
-          end
-
-        _ ->
-          {:error, "expected ':' after elif at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  defp parse_elif_else([{:keyword, _, "else"}, {:op, _, :colon}, :newline, :indent | rest]) do
-    case parse_block(rest) do
-      {:ok, body, rest} -> {:ok, [{:else, body}], rest}
-      {:error, _} = error -> error
-    end
-  end
-
-  defp parse_elif_else([{:keyword, _, "else"}, {:op, _, :colon} | rest]) do
-    case parse_inline_body(rest) do
-      {:ok, stmt, rest} -> {:ok, [{:else, [stmt]}], rest}
-      {:error, _} = error -> error
-    end
-  end
-
-  defp parse_elif_else(rest), do: {:ok, [], rest}
-
-  @spec parse_while([Lexer.token()]) :: parse_result()
-  defp parse_while(tokens) do
-    with {:ok, condition, rest} <- parse_expression(tokens),
-         {:ok, rest} <- expect_block_start(rest, "while") do
-      case parse_block(rest) do
-        {:ok, body, rest} ->
-          {:ok, else_body, rest} = parse_loop_else(rest)
-          line = node_line(condition)
-          {:ok, {:while, [line: line], [condition, body, else_body]}, drop_newline(rest)}
-
-        {:error, _} = error ->
-          error
-      end
-    end
-  end
-
-  @spec parse_for([Lexer.token()]) :: parse_result()
-  defp parse_for([{:name, line, first_name}, {:op, _, :comma} | rest]) do
-    case collect_for_vars(rest, [first_name]) do
-      {:ok, var_names, rest} ->
-        with {:ok, iterable, rest} <- parse_expression(rest),
-             {:ok, rest} <- expect_block_start(rest, "for") do
-          case parse_block(rest) do
-            {:ok, body, rest} ->
-              {:ok, else_body, rest} = parse_loop_else(rest)
-
-              {:ok, {:for, [line: line], [var_names, iterable, body, else_body]},
-               drop_newline(rest)}
-
-            {:error, _} = error ->
-              error
-          end
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_for([{:name, line, var_name}, {:keyword, _, "in"} | rest]) do
-    with {:ok, iterable, rest} <- parse_expression(rest),
-         {:ok, rest} <- expect_block_start(rest, "for") do
-      case parse_block(rest) do
-        {:ok, body, rest} ->
-          {:ok, else_body, rest} = parse_loop_else(rest)
-          {:ok, {:for, [line: line], [var_name, iterable, body, else_body]}, drop_newline(rest)}
-
-        {:error, _} = error ->
-          error
-      end
-    end
-  end
-
-  defp parse_for(tokens) do
-    {:error, "expected variable name after 'for' at #{token_line(tokens)}"}
-  end
-
-  @spec parse_loop_else([Lexer.token()]) ::
-          {:ok, [ast_node()] | nil, [Lexer.token()]} | {:error, String.t()}
-  defp parse_loop_else([{:keyword, _, "else"}, {:op, _, :colon}, :newline, :indent | rest]) do
-    case parse_block(rest) do
-      {:ok, else_body, rest} -> {:ok, else_body, rest}
-      {:error, _} = error -> error
-    end
-  end
-
-  defp parse_loop_else(rest), do: {:ok, nil, rest}
-
-  @spec collect_for_vars([Lexer.token()], [String.t()]) ::
-          {:ok, [String.t()], [Lexer.token()]} | {:error, String.t()}
-  defp collect_for_vars([{:name, _, name}, {:keyword, _, "in"} | rest], acc) do
-    {:ok, Enum.reverse([name | acc]), rest}
-  end
-
-  defp collect_for_vars([{:name, _, name}, {:op, _, :comma} | rest], acc) do
-    collect_for_vars(rest, [name | acc])
-  end
-
-  defp collect_for_vars(tokens, _acc) do
-    {:error, "expected variable name in for loop at #{token_line(tokens)}"}
-  end
-
-  @spec parse_comp_clauses([Lexer.token()], [comp_clause()]) ::
-          {:ok, [comp_clause()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_comp_clauses([{:keyword, _, "if"} | rest], acc) do
-    with {:ok, filter, rest} <- parse_or(rest) do
-      parse_comp_clauses(rest, [{:comp_if, filter} | acc])
-    end
-  end
-
-  defp parse_comp_clauses([{:keyword, _, "for"} | rest], acc) do
-    parse_comp_for_clause(rest, acc)
-  end
-
-  defp parse_comp_clauses(rest, acc) do
-    {:ok, Enum.reverse(acc), rest}
-  end
-
-  @spec parse_comp_for_clause([Lexer.token()], [comp_clause()]) ::
-          {:ok, [comp_clause()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_comp_for_clause(
-         [{:name, _, first_name}, {:op, _, :comma} | rest],
-         acc
-       ) do
-    case collect_for_vars(rest, [first_name]) do
-      {:ok, var_names, rest} ->
-        with {:ok, iterable, rest} <- parse_or(rest) do
-          parse_comp_clauses(rest, [{:comp_for, var_names, iterable} | acc])
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_comp_for_clause(
-         [{:name, _, var_name}, {:keyword, _, "in"} | rest],
-         acc
-       ) do
-    with {:ok, iterable, rest} <- parse_or(rest) do
-      parse_comp_clauses(rest, [{:comp_for, var_name, iterable} | acc])
-    end
-  end
-
-  defp parse_comp_for_clause(tokens, _acc) do
-    {:error, "expected variable name after 'for' in comprehension at #{token_line(tokens)}"}
-  end
-
-  @spec parse_import([Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_import([{:name, line, first} | rest], _line) do
-    {module_name, rest} = parse_dotted_name(first, rest)
-
-    # Parse first module (possibly with alias)
-    {first_import, rest} =
-      case rest do
-        [{:keyword, _, "as"}, {:name, _, alias_name} | rest] ->
-          {{module_name, alias_name}, rest}
-
-        _ ->
-          {{module_name, nil}, rest}
-      end
-
-    # Check for comma-separated imports
-    case rest do
-      [{:op, _, :comma} | rest] ->
-        # Parse additional imports
-        case parse_import_list(rest, [first_import]) do
-          {:ok, imports, rest} ->
-            {:ok, {:import, [line: line], imports}, drop_newline(rest)}
-
-          {:error, _} = error ->
-            error
-        end
-
-      _ ->
-        {:ok, {:import, [line: line], [first_import]}, drop_newline(rest)}
-    end
-  end
-
-  defp parse_import(tokens, line) do
-    {:error, "expected module name after 'import' on line #{line} at #{token_line(tokens)}"}
-  end
-
-  @spec parse_import_list([Lexer.token()], [{String.t(), String.t() | nil}]) ::
-          {:ok, [{String.t(), String.t() | nil}], [Lexer.token()]} | {:error, String.t()}
-  defp parse_import_list(tokens, acc) do
-    case tokens do
-      [{:name, _, name} | rest] ->
-        {module_name, rest} = parse_dotted_name(name, rest)
-
-        {import_spec, rest} =
-          case rest do
-            [{:keyword, _, "as"}, {:name, _, alias_name} | rest] ->
-              {{module_name, alias_name}, rest}
-
-            _ ->
-              {{module_name, nil}, rest}
-          end
-
-        new_acc = [import_spec | acc]
-
-        case rest do
-          [{:op, _, :comma} | rest] ->
-            parse_import_list(rest, new_acc)
-
-          _ ->
-            {:ok, Enum.reverse(new_acc), rest}
-        end
-
-      _ ->
-        {:error, "expected module name after ',' at #{token_line(tokens)}"}
-    end
-  end
-
-  @spec parse_from_import([Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_from_import([{:name, _, first} | rest], line) do
-    {module_name, rest} = parse_dotted_name(first, rest)
-
-    case rest do
-      [{:keyword, _, "import"} | rest] ->
-        case parse_import_names(rest) do
-          {:ok, names, rest} ->
-            {:ok, {:from_import, [line: line], [module_name, names]}, drop_newline(rest)}
-
-          {:error, _} = error ->
-            error
-        end
-
-      _ ->
-        {:error, "expected 'import' after module name on line #{line} at #{token_line(rest)}"}
-    end
-  end
-
-  defp parse_from_import(tokens, line) do
-    {:error, "expected module name after 'from' on line #{line} at #{token_line(tokens)}"}
-  end
-
-  @spec parse_dotted_name(String.t(), [Lexer.token()]) :: {String.t(), [Lexer.token()]}
-  defp parse_dotted_name(acc, [{:op, _, :dot}, {:name, _, part} | rest]) do
-    parse_dotted_name(acc <> "." <> part, rest)
-  end
-
-  defp parse_dotted_name(acc, rest), do: {acc, rest}
-
-  @spec parse_import_names([Lexer.token()]) ::
-          {:ok, [{String.t(), String.t() | nil}], [Lexer.token()]} | {:error, String.t()}
-  defp parse_import_names(tokens, acc \\ [])
-
-  defp parse_import_names(
-         [{:name, _, name}, {:keyword, _, "as"}, {:name, _, alias_name} | rest],
-         acc
-       ) do
-    case rest do
-      [{:op, _, :comma} | rest] -> parse_import_names(rest, [{name, alias_name} | acc])
-      _ -> {:ok, Enum.reverse([{name, alias_name} | acc]), rest}
-    end
-  end
-
-  defp parse_import_names([{:name, _, name} | rest], acc) do
-    case rest do
-      [{:op, _, :comma} | rest] -> parse_import_names(rest, [{name, nil} | acc])
-      _ -> {:ok, Enum.reverse([{name, nil} | acc]), rest}
-    end
-  end
-
-  defp parse_import_names(tokens, _acc) do
-    {:error, "expected name after 'import' at #{token_line(tokens)}"}
-  end
-
-  @spec parse_try([Lexer.token()]) :: parse_result()
-  defp parse_try(tokens) do
-    with {:ok, rest} <- expect_block_start(tokens, "try"),
-         {:ok, body, rest} <- parse_block(rest),
-         {:ok, handlers, rest} <- parse_except_clauses(rest),
-         {:ok, else_body, rest} <- parse_try_else(rest),
-         {:ok, finally_body, rest} <- parse_try_finally(rest) do
-      line =
-        case body do
-          [{_, [line: l], _} | _] -> l
-          _ -> 1
-        end
-
-      {:ok, {:try, [line: line], [body, handlers, else_body, finally_body]}, drop_newline(rest)}
-    end
-  end
-
-  @spec parse_try_else([Lexer.token()]) ::
-          {:ok, [ast_node()] | nil, [Lexer.token()]} | {:error, String.t()}
-  defp parse_try_else([{:keyword, _, "else"}, {:op, _, :colon}, :newline, :indent | rest]) do
-    case parse_block(rest) do
-      {:ok, else_body, rest} -> {:ok, else_body, rest}
-      {:error, _} = error -> error
-    end
-  end
-
-  defp parse_try_else(rest), do: {:ok, nil, rest}
-
-  @spec parse_try_finally([Lexer.token()]) ::
-          {:ok, [ast_node()] | nil, [Lexer.token()]} | {:error, String.t()}
-  defp parse_try_finally([{:keyword, _, "finally"}, {:op, _, :colon}, :newline, :indent | rest]) do
-    case parse_block(rest) do
-      {:ok, finally_body, rest} -> {:ok, finally_body, rest}
-      {:error, _} = error -> error
-    end
-  end
-
-  defp parse_try_finally(rest), do: {:ok, nil, rest}
-
-  @typep except_clause ::
-           {String.t() | [String.t()] | nil, String.t() | nil, [ast_node()]}
-
-  @spec parse_except_clauses([Lexer.token()], [except_clause()]) ::
-          {:ok, [except_clause()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_except_clauses(tokens, acc \\ [])
-
-  defp parse_except_clauses([{:keyword, _, "except"} | rest], acc) do
-    case rest do
-      [{:op, _, :colon}, :newline, :indent | rest] ->
-        case parse_block(rest) do
-          {:ok, handler_body, rest} ->
-            clause = {nil, nil, handler_body}
-            parse_except_clauses(rest, [clause | acc])
-
-          {:error, _} = error ->
-            error
-        end
-
-      [{:op, _, :lparen} | paren_rest] ->
-        case collect_except_names(paren_rest, []) do
-          {:ok, names, [{:keyword, _, "as"}, {:name, _, var_name} | after_as]} ->
-            with {:ok, after_as} <- expect_block_start(after_as, "except"),
-                 {:ok, handler_body, after_as} <- parse_block(after_as) do
-              clause = {names, var_name, handler_body}
-              parse_except_clauses(after_as, [clause | acc])
-            end
-
-          {:ok, names, after_paren} ->
-            with {:ok, after_paren} <- expect_block_start(after_paren, "except"),
-                 {:ok, handler_body, after_paren} <- parse_block(after_paren) do
-              clause = {names, nil, handler_body}
-              parse_except_clauses(after_paren, [clause | acc])
-            end
-
-          {:error, _} = error ->
-            error
-        end
-
-      [{:name, _, exc_name}, {:keyword, _, "as"}, {:name, _, var_name} | rest] ->
-        with {:ok, rest} <- expect_block_start(rest, "except"),
-             {:ok, handler_body, rest} <- parse_block(rest) do
-          clause = {exc_name, var_name, handler_body}
-          parse_except_clauses(rest, [clause | acc])
-        end
-
-      [{:name, _, exc_name} | rest] ->
-        with {:ok, rest} <- expect_block_start(rest, "except"),
-             {:ok, handler_body, rest} <- parse_block(rest) do
-          clause = {exc_name, nil, handler_body}
-          parse_except_clauses(rest, [clause | acc])
-        end
-
-      _ ->
-        {:error, "expected ':' or exception name after 'except' at #{token_line(rest)}"}
-    end
-  end
-
-  defp parse_except_clauses(rest, acc) do
-    {:ok, Enum.reverse(acc), rest}
-  end
-
-  @spec collect_except_names([Lexer.token()], [String.t()]) ::
-          {:ok, [String.t()], [Lexer.token()]} | {:error, String.t()}
-  defp collect_except_names([{:name, _, name}, {:op, _, :rparen} | rest], acc) do
-    {:ok, Enum.reverse([name | acc]), rest}
-  end
-
-  defp collect_except_names([{:name, _, name}, {:op, _, :comma} | rest], acc) do
-    collect_except_names(rest, [name | acc])
-  end
-
-  defp collect_except_names(tokens, _acc) do
-    {:error, "expected exception name in except tuple at #{token_line(tokens)}"}
-  end
-
+  @doc false
   @spec expect_block_start([Lexer.token()], String.t()) ::
           {:ok, [Lexer.token()]} | {:error, String.t()}
-  defp expect_block_start([{:op, _, :colon}, :newline, :indent | rest], _ctx) do
+  def expect_block_start([{:op, _, :colon}, :newline, :indent | rest], _ctx) do
     {:ok, rest}
   end
 
-  defp expect_block_start(tokens, ctx) do
+  def expect_block_start(tokens, ctx) do
     {:error, "expected ':' after #{ctx} at #{token_line(tokens)}"}
   end
 
-  @typep match_pattern ::
-           {:match_wildcard, meta(), []}
-           | {:match_capture, meta(), [String.t()]}
-           | {:match_or, meta(), [match_pattern()]}
-           | {:match_sequence, meta(), [match_pattern()]}
-           | {:match_mapping, meta(), [{ast_node(), match_pattern()}]}
-           | {:match_class, meta(), [term()]}
-           | {:match_star, meta(), [String.t() | nil]}
-           | ast_node()
-
-  @typep match_case :: {match_pattern(), ast_node() | nil, [ast_node()]}
-
-  @spec try_match([Lexer.token()], pos_integer()) ::
-          {:ok, ast_node(), [Lexer.token()]} | :not_match
-  defp try_match(tokens, line) do
-    with {:ok, subject, [{:op, _, :colon}, :newline, :indent | rest]} <- parse_expression(tokens),
-         {:ok, cases, rest} <- parse_match_cases(rest) do
-      {:ok, {:match, [line: line], [subject, cases]}, drop_newline(rest)}
-    else
-      _ -> :not_match
-    end
-  end
-
-  @spec parse_match_cases([Lexer.token()], [match_case()]) ::
-          {:ok, [match_case()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_cases(tokens, acc \\ [])
-
-  defp parse_match_cases([{:name, _, "case"} | rest], acc) do
-    with {:ok, pattern, rest} <- parse_match_pattern(rest),
-         {:ok, guard, rest} <- parse_match_guard(rest),
-         {:ok, rest} <- expect_block_start(rest, "case"),
-         {:ok, body, rest} <- parse_block(rest) do
-      parse_match_cases(rest, [{pattern, guard, body} | acc])
-    end
-  end
-
-  defp parse_match_cases([:dedent | rest], acc) do
-    {:ok, Enum.reverse(acc), rest}
-  end
-
-  defp parse_match_cases([:newline | rest], acc) do
-    parse_match_cases(rest, acc)
-  end
-
-  defp parse_match_cases(rest, acc) do
-    {:ok, Enum.reverse(acc), rest}
-  end
-
-  @spec parse_match_guard([Lexer.token()]) ::
-          {:ok, ast_node() | nil, [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_guard([{:keyword, _, "if"} | rest]) do
-    with {:ok, guard_expr, rest} <- parse_expression(rest) do
-      {:ok, guard_expr, rest}
-    end
-  end
-
-  defp parse_match_guard(tokens), do: {:ok, nil, tokens}
-
-  @spec parse_match_pattern([Lexer.token()]) ::
-          {:ok, match_pattern(), [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_pattern(tokens) do
-    with {:ok, pattern, rest} <- parse_match_pattern_atom(tokens) do
-      parse_match_or(pattern, rest)
-    end
-  end
-
-  @spec parse_match_or(match_pattern(), [Lexer.token()]) ::
-          {:ok, match_pattern(), [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_or(left, [{:op, _, :pipe} | rest]) do
-    with {:ok, right, rest} <- parse_match_pattern_atom(rest) do
-      alts =
-        case left do
-          {:match_or, _, existing} -> existing ++ [right]
-          _ -> [left, right]
-        end
-
-      parse_match_or({:match_or, [line: node_line(left)], alts}, rest)
-    end
-  end
-
-  defp parse_match_or(pattern, rest), do: {:ok, pattern, rest}
-
-  @spec parse_match_pattern_atom([Lexer.token()]) ::
-          {:ok, match_pattern(), [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_pattern_atom([{:name, line, "_"} | rest]) do
-    {:ok, {:match_wildcard, [line: line], []}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:keyword, line, "None"} | rest]) do
-    {:ok, {:lit, [line: line], [nil]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:keyword, line, "True"} | rest]) do
-    {:ok, {:lit, [line: line], [true]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:keyword, line, "False"} | rest]) do
-    {:ok, {:lit, [line: line], [false]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:integer, line, value} | rest]) do
-    {:ok, {:lit, [line: line], [value]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:float, line, value} | rest]) do
-    {:ok, {:lit, [line: line], [value]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:op, line, :minus}, {:integer, _, value} | rest]) do
-    {:ok, {:lit, [line: line], [-value]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:op, line, :minus}, {:float, _, value} | rest]) do
-    {:ok, {:lit, [line: line], [-value]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:string, line, value} | rest]) do
-    {:ok, {:lit, [line: line], [value]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:fstring, line, parts} | rest]) do
-    {:ok, {:fstring, [line: line], [parts]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:op, _, :star}, {:name, line, "_"} | rest]) do
-    {:ok, {:match_star, [line: line], [nil]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:op, _, :star}, {:name, line, name} | rest]) do
-    {:ok, {:match_star, [line: line], [name]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:op, line, :lbracket} | rest]) do
-    with {:ok, patterns, rest} <- parse_match_pattern_list(rest, []) do
-      {:ok, {:match_sequence, [line: line], patterns}, rest}
-    end
-  end
-
-  defp parse_match_pattern_atom([{:op, line, :lparen} | rest]) do
-    with {:ok, patterns, rest} <- parse_match_pattern_tuple(rest, []) do
-      {:ok, {:match_sequence, [line: line], patterns}, rest}
-    end
-  end
-
-  defp parse_match_pattern_atom([{:op, line, :lbrace} | rest]) do
-    with {:ok, pairs, rest} <- parse_match_mapping_entries(rest, []) do
-      {:ok, {:match_mapping, [line: line], pairs}, rest}
-    end
-  end
-
-  defp parse_match_pattern_atom([{:name, line, name}, {:op, _, :dot}, {:name, _, attr} | rest]) do
-    {:ok, {:getattr, [line: line], [{:var, [line: line], [name]}, attr]}, rest}
-  end
-
-  defp parse_match_pattern_atom([{:name, line, name}, {:op, _, :lparen} | rest]) do
-    with {:ok, pos_patterns, kw_patterns, rest} <- parse_match_class_args(rest, [], []) do
-      {:ok, {:match_class, [line: line], [name, pos_patterns, kw_patterns]}, rest}
-    end
-  end
-
-  defp parse_match_pattern_atom([{:name, line, name} | rest]) do
-    {:ok, {:match_capture, [line: line], [name]}, rest}
-  end
-
-  defp parse_match_pattern_atom(tokens) do
-    {:error, "unexpected token in match pattern at #{token_line(tokens)}"}
-  end
-
-  @spec parse_match_pattern_list([Lexer.token()], [match_pattern()]) ::
-          {:ok, [match_pattern()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_pattern_list([{:op, _, :rbracket} | rest], acc) do
-    {:ok, Enum.reverse(acc), rest}
-  end
-
-  defp parse_match_pattern_list(tokens, acc) do
-    with {:ok, pattern, rest} <- parse_match_pattern(tokens) do
-      case rest do
-        [{:op, _, :comma} | rest] -> parse_match_pattern_list(rest, [pattern | acc])
-        [{:op, _, :rbracket} | rest] -> {:ok, Enum.reverse([pattern | acc]), rest}
-        _ -> {:error, "expected ',' or ']' in match pattern list at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  @spec parse_match_pattern_tuple([Lexer.token()], [match_pattern()]) ::
-          {:ok, [match_pattern()], [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_pattern_tuple([{:op, _, :rparen} | rest], acc) do
-    {:ok, Enum.reverse(acc), rest}
-  end
-
-  defp parse_match_pattern_tuple(tokens, acc) do
-    with {:ok, pattern, rest} <- parse_match_pattern(tokens) do
-      case rest do
-        [{:op, _, :comma} | rest] -> parse_match_pattern_tuple(rest, [pattern | acc])
-        [{:op, _, :rparen} | rest] -> {:ok, Enum.reverse([pattern | acc]), rest}
-        _ -> {:error, "expected ',' or ')' in match pattern tuple at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  @spec parse_match_mapping_entries([Lexer.token()], [{ast_node(), match_pattern()}]) ::
-          {:ok, [{ast_node(), match_pattern()}], [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_mapping_entries([{:op, _, :rbrace} | rest], acc) do
-    {:ok, Enum.reverse(acc), rest}
-  end
-
-  defp parse_match_mapping_entries(tokens, acc) do
-    with {:ok, key, [{:op, _, :colon} | rest]} <- parse_match_mapping_key(tokens),
-         {:ok, value_pattern, rest} <- parse_match_pattern(rest) do
-      case rest do
-        [{:op, _, :comma} | rest] ->
-          parse_match_mapping_entries(rest, [{key, value_pattern} | acc])
-
-        [{:op, _, :rbrace} | rest] ->
-          {:ok, Enum.reverse([{key, value_pattern} | acc]), rest}
-
-        _ ->
-          {:error, "expected ',' or '}' in match mapping at #{token_line(rest)}"}
-      end
-    else
-      {:ok, _, rest} -> {:error, "expected ':' in match mapping at #{token_line(rest)}"}
-      {:error, _} = error -> error
-    end
-  end
-
-  @spec parse_match_mapping_key([Lexer.token()]) ::
-          {:ok, ast_node(), [Lexer.token()]} | {:error, String.t()}
-  defp parse_match_mapping_key([{:string, line, value} | rest]) do
-    {:ok, {:lit, [line: line], [value]}, rest}
-  end
-
-  defp parse_match_mapping_key([{:integer, line, value} | rest]) do
-    {:ok, {:lit, [line: line], [value]}, rest}
-  end
-
-  defp parse_match_mapping_key([{:float, line, value} | rest]) do
-    {:ok, {:lit, [line: line], [value]}, rest}
-  end
-
-  defp parse_match_mapping_key([{:keyword, line, "None"} | rest]) do
-    {:ok, {:lit, [line: line], [nil]}, rest}
-  end
-
-  defp parse_match_mapping_key([{:keyword, line, "True"} | rest]) do
-    {:ok, {:lit, [line: line], [true]}, rest}
-  end
-
-  defp parse_match_mapping_key([{:keyword, line, "False"} | rest]) do
-    {:ok, {:lit, [line: line], [false]}, rest}
-  end
-
-  defp parse_match_mapping_key(tokens) do
-    {:error, "expected literal key in match mapping at #{token_line(tokens)}"}
-  end
-
-  @spec parse_match_class_args(
-          [Lexer.token()],
-          [match_pattern()],
-          [{String.t(), match_pattern()}]
-        ) ::
-          {:ok, [match_pattern()], [{String.t(), match_pattern()}], [Lexer.token()]}
-          | {:error, String.t()}
-  defp parse_match_class_args([{:op, _, :rparen} | rest], pos_acc, kw_acc) do
-    {:ok, Enum.reverse(pos_acc), Enum.reverse(kw_acc), rest}
-  end
-
-  defp parse_match_class_args(
-         [{:name, _, name}, {:op, _, :assign} | rest],
-         pos_acc,
-         kw_acc
-       ) do
-    with {:ok, pattern, rest} <- parse_match_pattern(rest) do
-      case rest do
-        [{:op, _, :comma} | rest] ->
-          parse_match_class_args(rest, pos_acc, [{name, pattern} | kw_acc])
-
-        [{:op, _, :rparen} | rest] ->
-          {:ok, Enum.reverse(pos_acc), Enum.reverse([{name, pattern} | kw_acc]), rest}
-
-        _ ->
-          {:error, "expected ',' or ')' in match class pattern at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  defp parse_match_class_args(tokens, pos_acc, kw_acc) do
-    with {:ok, pattern, rest} <- parse_match_pattern(tokens) do
-      case rest do
-        [{:op, _, :comma} | rest] ->
-          parse_match_class_args(rest, [pattern | pos_acc], kw_acc)
-
-        [{:op, _, :rparen} | rest] ->
-          {:ok, Enum.reverse([pattern | pos_acc]), Enum.reverse(kw_acc), rest}
-
-        _ ->
-          {:error, "expected ',' or ')' in match class pattern at #{token_line(rest)}"}
-      end
-    end
-  end
-
+  @doc false
   @spec parse_inline_body([Lexer.token()]) :: parse_result()
-  defp parse_inline_body(tokens) do
+  def parse_inline_body(tokens) do
     parse_statement(tokens)
   end
 
+  @doc false
+  @spec parse_or([Lexer.token()]) :: parse_result()
+  def parse_or(tokens) do
+    with {:ok, left, rest} <- parse_and(tokens) do
+      parse_or_rest(left, rest)
+    end
+  end
+
+  @doc false
   @spec parse_expression([Lexer.token()]) :: parse_result()
-  defp parse_expression([{:name, line, name}, {:op, _, :walrus} | rest]) do
+  def parse_expression([{:name, line, name}, {:op, _, :walrus} | rest]) do
     with {:ok, expr, rest} <- parse_expression(rest) do
       {:ok, {:walrus, [line: line], [name, expr]}, rest}
     end
   end
 
-  defp parse_expression(tokens) do
+  def parse_expression(tokens) do
     with {:ok, expr, rest} <- parse_or(tokens) do
       parse_ternary(expr, rest)
     end
@@ -1591,13 +715,6 @@ defmodule Pyex.Parser do
   end
 
   defp parse_ternary(expr, rest), do: {:ok, expr, rest}
-
-  @spec parse_or([Lexer.token()]) :: parse_result()
-  defp parse_or(tokens) do
-    with {:ok, left, rest} <- parse_and(tokens) do
-      parse_or_rest(left, rest)
-    end
-  end
 
   @spec parse_or_rest(ast_node(), [Lexer.token()]) :: parse_result()
   defp parse_or_rest(left, [{:keyword, _, "or"} | rest]) do
@@ -1969,7 +1086,7 @@ defmodule Pyex.Parser do
         [{:keyword, _, "for"} | for_rest] ->
           line = node_line(expr)
 
-          case parse_gen_expr_body(expr, for_rest, line) do
+          case Comprehensions.parse_gen_expr_body(expr, for_rest, line) do
             {:ok, gen_expr, [{:op, _, :rparen} | rest]} ->
               {:ok, Enum.reverse([gen_expr | acc]), rest}
 
@@ -1986,7 +1103,7 @@ defmodule Pyex.Parser do
               [{:keyword, _, "for"} | for_rest] ->
                 line = node_line(full_expr)
 
-                case parse_gen_expr_body(full_expr, for_rest, line) do
+                case Comprehensions.parse_gen_expr_body(full_expr, for_rest, line) do
                   {:ok, gen_expr, [{:op, _, :rparen} | rest]} ->
                     {:ok, Enum.reverse([gen_expr | acc]), rest}
 
@@ -2036,35 +1153,15 @@ defmodule Pyex.Parser do
   end
 
   defp parse_atom([{:op, line, :lparen} | rest]) do
-    case rest do
-      [{:op, _, :rparen} | rest] ->
-        {:ok, {:tuple, [line: line], [[]]}, rest}
-
-      _ ->
-        with {:ok, expr, rest} <- parse_expression(rest) do
-          case rest do
-            [{:keyword, _, "for"} | for_rest] ->
-              parse_gen_expr(expr, for_rest, line, :rparen)
-
-            [{:op, _, :comma} | rest] ->
-              parse_tuple_rest(rest, line, [expr])
-
-            [{:op, _, :rparen} | rest] ->
-              {:ok, expr, rest}
-
-            _ ->
-              {:error, "expected ')' at #{token_line(rest)}"}
-          end
-        end
-    end
+    Comprehensions.parse_parenthesized(rest, line)
   end
 
   defp parse_atom([{:op, line, :lbracket} | rest]) do
-    parse_list_literal(rest, line)
+    Comprehensions.parse_list_literal(rest, line)
   end
 
   defp parse_atom([{:op, line, :lbrace} | rest]) do
-    parse_dict_literal(rest, line)
+    Comprehensions.parse_dict_literal(rest, line)
   end
 
   defp parse_atom([{:keyword, line, "await"} | _]) do
@@ -2085,353 +1182,6 @@ defmodule Pyex.Parser do
 
   defp parse_atom(tokens) do
     {:error, "unexpected token at #{token_line(tokens)}: #{inspect_tokens(tokens)}"}
-  end
-
-  @spec parse_list_literal([Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_list_literal([{:op, _, :rbracket} | rest], line) do
-    {:ok, {:list, [line: line], [[]]}, rest}
-  end
-
-  defp parse_list_literal(tokens, line) do
-    with {:ok, expr, rest} <- parse_or(tokens) do
-      case rest do
-        [{:keyword, _, "for"} | rest] ->
-          parse_list_comp(expr, rest, line)
-
-        [{:keyword, _, "if"} | _] = rest ->
-          with {:ok, full_expr, rest} <- parse_ternary(expr, rest) do
-            case rest do
-              [{:keyword, _, "for"} | for_rest] ->
-                parse_list_comp(full_expr, for_rest, line)
-
-              _ ->
-                parse_list_elements_rest(rest, line, [full_expr])
-            end
-          end
-
-        _ ->
-          parse_list_elements_rest(rest, line, [expr])
-      end
-    end
-  end
-
-  @spec parse_list_elements_rest([Lexer.token()], pos_integer(), [ast_node()]) :: parse_result()
-  defp parse_list_elements_rest(rest, line, acc) do
-    case rest do
-      [{:op, _, :comma} | rest] ->
-        parse_list_elements(rest, line, acc)
-
-      [{:op, _, :rbracket} | rest] ->
-        {:ok, {:list, [line: line], [Enum.reverse(acc)]}, rest}
-
-      _ ->
-        {:error, "expected ',' or ']' in list at #{token_line(rest)}"}
-    end
-  end
-
-  @spec parse_list_elements([Lexer.token()], pos_integer(), [ast_node()]) :: parse_result()
-  defp parse_list_elements([{:op, _, :rbracket} | rest], line, acc) do
-    {:ok, {:list, [line: line], [Enum.reverse(acc)]}, rest}
-  end
-
-  defp parse_list_elements(tokens, line, acc) do
-    with {:ok, expr, rest} <- parse_expression(tokens) do
-      case rest do
-        [{:op, _, :comma} | rest] ->
-          parse_list_elements(rest, line, [expr | acc])
-
-        [{:op, _, :rbracket} | rest] ->
-          {:ok, {:list, [line: line], [Enum.reverse([expr | acc])]}, rest}
-
-        _ ->
-          {:error, "expected ',' or ']' in list at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  @spec parse_list_comp(ast_node(), [Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_list_comp(expr, [{:name, _, first_name}, {:op, _, :comma} | rest], line) do
-    case collect_for_vars(rest, [first_name]) do
-      {:ok, var_names, rest} ->
-        with {:ok, iterable, rest} <- parse_or(rest),
-             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-          all_clauses = [{:comp_for, var_names, iterable} | clauses]
-
-          case rest do
-            [{:op, _, :rbracket} | rest] ->
-              {:ok, {:list_comp, [line: line], [expr, all_clauses]}, rest}
-
-            _ ->
-              {:error, "expected ']' after list comprehension at #{token_line(rest)}"}
-          end
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_list_comp(expr, [{:name, _, var_name}, {:keyword, _, "in"} | rest], line) do
-    with {:ok, iterable, rest} <- parse_or(rest),
-         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-      all_clauses = [{:comp_for, var_name, iterable} | clauses]
-
-      case rest do
-        [{:op, _, :rbracket} | rest] ->
-          {:ok, {:list_comp, [line: line], [expr, all_clauses]}, rest}
-
-        _ ->
-          {:error, "expected ']' after list comprehension at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  defp parse_list_comp(_expr, tokens, _line) do
-    {:error, "expected variable name after 'for' in list comprehension at #{token_line(tokens)}"}
-  end
-
-  @spec parse_gen_expr(ast_node(), [Lexer.token()], pos_integer(), :rparen) :: parse_result()
-  defp parse_gen_expr(expr, [{:name, _, first_name}, {:op, _, :comma} | rest], line, _closer) do
-    case collect_for_vars(rest, [first_name]) do
-      {:ok, var_names, rest} ->
-        with {:ok, iterable, rest} <- parse_or(rest),
-             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-          all_clauses = [{:comp_for, var_names, iterable} | clauses]
-
-          case rest do
-            [{:op, _, :rparen} | rest] ->
-              {:ok, {:gen_expr, [line: line], [expr, all_clauses]}, rest}
-
-            _ ->
-              {:error, "expected ')' after generator expression at #{token_line(rest)}"}
-          end
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_gen_expr(expr, [{:name, _, var_name}, {:keyword, _, "in"} | rest], line, _closer) do
-    with {:ok, iterable, rest} <- parse_or(rest),
-         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-      all_clauses = [{:comp_for, var_name, iterable} | clauses]
-
-      case rest do
-        [{:op, _, :rparen} | rest] ->
-          {:ok, {:gen_expr, [line: line], [expr, all_clauses]}, rest}
-
-        _ ->
-          {:error, "expected ')' after generator expression at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  defp parse_gen_expr(_expr, tokens, _line, _closer) do
-    {:error,
-     "expected variable name after 'for' in generator expression at #{token_line(tokens)}"}
-  end
-
-  @spec parse_gen_expr_body(ast_node(), [Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_gen_expr_body(
-         expr,
-         [{:name, _, first_name}, {:op, _, :comma} | rest],
-         line
-       ) do
-    case collect_for_vars(rest, [first_name]) do
-      {:ok, var_names, rest} ->
-        with {:ok, iterable, rest} <- parse_or(rest),
-             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-          all_clauses = [{:comp_for, var_names, iterable} | clauses]
-          {:ok, {:gen_expr, [line: line], [expr, all_clauses]}, rest}
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_gen_expr_body(
-         expr,
-         [{:name, _, var_name}, {:keyword, _, "in"} | rest],
-         line
-       ) do
-    with {:ok, iterable, rest} <- parse_or(rest),
-         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-      all_clauses = [{:comp_for, var_name, iterable} | clauses]
-      {:ok, {:gen_expr, [line: line], [expr, all_clauses]}, rest}
-    end
-  end
-
-  defp parse_gen_expr_body(_expr, tokens, _line) do
-    {:error,
-     "expected variable name after 'for' in generator expression at #{token_line(tokens)}"}
-  end
-
-  @spec parse_dict_literal([Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_dict_literal([{:op, _, :rbrace} | rest], line) do
-    {:ok, {:dict, [line: line], [[]]}, rest}
-  end
-
-  defp parse_dict_literal(tokens, line) do
-    parse_dict_entries(tokens, line, [])
-  end
-
-  @spec parse_dict_entries([Lexer.token()], pos_integer(), [{ast_node(), ast_node()}]) ::
-          parse_result()
-  defp parse_dict_entries(tokens, line, acc) do
-    with {:ok, key, rest} <- parse_or(tokens) do
-      case rest do
-        [{:op, _, :colon} | rest] ->
-          with {:ok, value, rest} <- parse_or(rest) do
-            case rest do
-              [{:keyword, _, "for"} | comp_rest] when acc == [] ->
-                parse_dict_comp(key, value, comp_rest, line)
-
-              _ ->
-                pair = {key, value}
-
-                case rest do
-                  [{:op, _, :comma}, {:op, _, :rbrace} | rest] ->
-                    {:ok, {:dict, [line: line], [Enum.reverse([pair | acc])]}, rest}
-
-                  [{:op, _, :comma} | rest] ->
-                    parse_dict_entries(rest, line, [pair | acc])
-
-                  [{:op, _, :rbrace} | rest] ->
-                    {:ok, {:dict, [line: line], [Enum.reverse([pair | acc])]}, rest}
-
-                  _ ->
-                    {:error, "expected ',' or '}' in dict at #{token_line(rest)}"}
-                end
-            end
-          end
-
-        [{:keyword, _, "for"} | comp_rest] when acc == [] ->
-          parse_set_comp(key, comp_rest, line)
-
-        [{:op, _, :comma} | set_rest] when acc == [] ->
-          parse_set_entries(set_rest, line, [key])
-
-        [{:op, _, :rbrace} | set_rest] when acc == [] ->
-          {:ok, {:set, [line: line], [[key]]}, set_rest}
-
-        _ ->
-          {:error, "expected ':' in dict entry at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  @spec parse_set_entries([Lexer.token()], pos_integer(), [ast_node()]) :: parse_result()
-  defp parse_set_entries([{:op, _, :rbrace} | rest], line, acc) do
-    {:ok, {:set, [line: line], [Enum.reverse(acc)]}, rest}
-  end
-
-  defp parse_set_entries(tokens, line, acc) do
-    with {:ok, elem, rest} <- parse_or(tokens) do
-      case rest do
-        [{:op, _, :comma} | rest] ->
-          parse_set_entries(rest, line, [elem | acc])
-
-        [{:op, _, :rbrace} | rest] ->
-          {:ok, {:set, [line: line], [Enum.reverse([elem | acc])]}, rest}
-
-        _ ->
-          {:error, "expected ',' or '}' in set literal at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  @spec parse_set_comp(ast_node(), [Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_set_comp(expr, [{:name, _, first_name}, {:op, _, :comma} | rest], line) do
-    case collect_for_vars(rest, [first_name]) do
-      {:ok, var_names, rest} ->
-        with {:ok, iterable, rest} <- parse_or(rest),
-             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-          all_clauses = [{:comp_for, var_names, iterable} | clauses]
-
-          case rest do
-            [{:op, _, :rbrace} | rest] ->
-              {:ok, {:set_comp, [line: line], [expr, all_clauses]}, rest}
-
-            _ ->
-              {:error, "expected '}' after set comprehension at #{token_line(rest)}"}
-          end
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_set_comp(expr, [{:name, _, var_name}, {:keyword, _, "in"} | rest], line) do
-    with {:ok, iterable, rest} <- parse_or(rest),
-         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-      all_clauses = [{:comp_for, var_name, iterable} | clauses]
-
-      case rest do
-        [{:op, _, :rbrace} | rest] ->
-          {:ok, {:set_comp, [line: line], [expr, all_clauses]}, rest}
-
-        _ ->
-          {:error, "expected '}' after set comprehension at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  defp parse_set_comp(_expr, tokens, _line) do
-    {:error, "expected variable name in set comprehension at #{token_line(tokens)}"}
-  end
-
-  @spec parse_dict_comp(ast_node(), ast_node(), [Lexer.token()], pos_integer()) :: parse_result()
-  defp parse_dict_comp(
-         key_expr,
-         val_expr,
-         [{:name, _, first_name}, {:op, _, :comma} | rest],
-         line
-       ) do
-    case collect_for_vars(rest, [first_name]) do
-      {:ok, var_names, rest} ->
-        with {:ok, iterable, rest} <- parse_or(rest),
-             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-          all_clauses = [{:comp_for, var_names, iterable} | clauses]
-
-          case rest do
-            [{:op, _, :rbrace} | rest] ->
-              {:ok, {:dict_comp, [line: line], [key_expr, val_expr, all_clauses]}, rest}
-
-            _ ->
-              {:error, "expected '}' after dict comprehension at #{token_line(rest)}"}
-          end
-        end
-
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp parse_dict_comp(
-         key_expr,
-         val_expr,
-         [{:name, _, var_name}, {:keyword, _, "in"} | rest],
-         line
-       ) do
-    with {:ok, iterable, rest} <- parse_or(rest),
-         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
-      all_clauses = [{:comp_for, var_name, iterable} | clauses]
-
-      case rest do
-        [{:op, _, :rbrace} | rest] ->
-          {:ok, {:dict_comp, [line: line], [key_expr, val_expr, all_clauses]}, rest}
-
-        _ ->
-          {:error, "expected '}' after dict comprehension at #{token_line(rest)}"}
-      end
-    end
-  end
-
-  defp parse_dict_comp(_key_expr, _val_expr, tokens, _line) do
-    {:error, "expected variable name in dict comprehension at #{token_line(tokens)}"}
   end
 
   @spec try_multi_assign([Lexer.token()], pos_integer(), [String.t() | {:starred, String.t()}]) ::
@@ -2537,26 +1287,6 @@ defmodule Pyex.Parser do
     {:error, "unexpected token in lambda params at #{token_line(tokens)}"}
   end
 
-  @spec parse_tuple_rest([Lexer.token()], pos_integer(), [ast_node()]) :: parse_result()
-  defp parse_tuple_rest([{:op, _, :rparen} | rest], line, acc) do
-    {:ok, {:tuple, [line: line], [Enum.reverse(acc)]}, rest}
-  end
-
-  defp parse_tuple_rest(tokens, line, acc) do
-    with {:ok, expr, rest} <- parse_expression(tokens) do
-      case rest do
-        [{:op, _, :comma} | rest] ->
-          parse_tuple_rest(rest, line, [expr | acc])
-
-        [{:op, _, :rparen} | rest] ->
-          {:ok, {:tuple, [line: line], [Enum.reverse([expr | acc])]}, rest}
-
-        _ ->
-          {:error, "expected ',' or ')' in tuple at #{token_line(rest)}"}
-      end
-    end
-  end
-
   @spec parse_fstring_parts(String.t(), pos_integer()) ::
           {:ok, [{:lit, String.t()} | {:expr, ast_node()}]} | {:error, String.t()}
   defp parse_fstring_parts(template, line) do
@@ -2575,12 +1305,20 @@ defmodule Pyex.Parser do
     acc = if buf == "", do: acc, else: [{:lit, buf} | acc]
 
     case extract_brace_content(rest, 0, <<>>) do
-      {:ok, expr_str, rest} ->
+      {:ok, full_content, rest} ->
+        {expr_str, format_spec} = split_format_spec(full_content)
+
         case Lexer.tokenize(expr_str) do
           {:ok, tokens} ->
             case parse_expression(tokens) do
               {:ok, expr, _} ->
-                parse_fstring_parts(rest, line, <<>>, [{:expr, expr} | acc])
+                part =
+                  case format_spec do
+                    nil -> {:expr, expr}
+                    spec -> {:expr, expr, spec}
+                  end
+
+                parse_fstring_parts(rest, line, <<>>, [part | acc])
 
               {:error, msg} ->
                 {:error, "f-string expression error: #{msg}"}
@@ -2601,6 +1339,58 @@ defmodule Pyex.Parser do
 
   @spec extract_brace_content(String.t(), non_neg_integer(), String.t()) ::
           {:ok, String.t(), String.t()} | {:error, String.t()}
+  # Splits "expr:spec" at the colon that is NOT inside brackets, parens, or strings.
+  # Returns {expr_str, format_spec | nil}.
+  @spec split_format_spec(String.t()) :: {String.t(), String.t() | nil}
+  defp split_format_spec(content) do
+    split_format_spec(content, 0, 0, 0, false, nil, <<>>)
+  end
+
+  defp split_format_spec(<<>>, _bd, _pd, _sd, _in_str, _qch, acc),
+    do: {acc, nil}
+
+  # Handle string delimiters
+  defp split_format_spec(<<q, rest::binary>>, bd, pd, sd, false, nil, acc)
+       when q in [?', ?"] do
+    split_format_spec(rest, bd, pd, sd, true, q, <<acc::binary, q>>)
+  end
+
+  defp split_format_spec(<<q, rest::binary>>, bd, pd, sd, true, q, acc) do
+    split_format_spec(rest, bd, pd, sd, false, nil, <<acc::binary, q>>)
+  end
+
+  # Don't split inside strings
+  defp split_format_spec(<<c, rest::binary>>, bd, pd, sd, true, qch, acc) do
+    split_format_spec(rest, bd, pd, sd, true, qch, <<acc::binary, c>>)
+  end
+
+  # Track bracket/paren depth
+  defp split_format_spec(<<"[", rest::binary>>, bd, pd, sd, in_str, qch, acc),
+    do: split_format_spec(rest, bd + 1, pd, sd, in_str, qch, <<acc::binary, "[">>)
+
+  defp split_format_spec(<<"]", rest::binary>>, bd, pd, sd, in_str, qch, acc) when bd > 0,
+    do: split_format_spec(rest, bd - 1, pd, sd, in_str, qch, <<acc::binary, "]">>)
+
+  defp split_format_spec(<<"(", rest::binary>>, bd, pd, sd, in_str, qch, acc),
+    do: split_format_spec(rest, bd, pd + 1, sd, in_str, qch, <<acc::binary, "(">>)
+
+  defp split_format_spec(<<")", rest::binary>>, bd, pd, sd, in_str, qch, acc) when pd > 0,
+    do: split_format_spec(rest, bd, pd - 1, sd, in_str, qch, <<acc::binary, ")">>)
+
+  defp split_format_spec(<<"{", rest::binary>>, bd, pd, sd, in_str, qch, acc),
+    do: split_format_spec(rest, bd, pd, sd + 1, in_str, qch, <<acc::binary, "{">>)
+
+  defp split_format_spec(<<"}", rest::binary>>, bd, pd, sd, in_str, qch, acc) when sd > 0,
+    do: split_format_spec(rest, bd, pd, sd - 1, in_str, qch, <<acc::binary, "}">>)
+
+  # Colon at depth 0 → split point
+  defp split_format_spec(<<":", rest::binary>>, 0, 0, 0, false, nil, acc),
+    do: {acc, rest}
+
+  # Regular character
+  defp split_format_spec(<<c, rest::binary>>, bd, pd, sd, in_str, qch, acc),
+    do: split_format_spec(rest, bd, pd, sd, in_str, qch, <<acc::binary, c>>)
+
   defp extract_brace_content(<<>>, _depth, _acc), do: {:error, "unterminated f-string expression"}
 
   defp extract_brace_content(<<"}", rest::binary>>, 0, acc), do: {:ok, acc, rest}
@@ -2658,13 +1448,6 @@ defmodule Pyex.Parser do
   defp drop_newline([:newline | rest]), do: rest
   defp drop_newline(rest), do: rest
 
-  @spec skip_return_annotation([Lexer.token()]) :: [Lexer.token()]
-  defp skip_return_annotation([{:op, _, :minus}, {:op, _, :gt} | rest]) do
-    skip_type_annotation(rest)
-  end
-
-  defp skip_return_annotation(tokens), do: tokens
-
   @spec collect_type_annotation([Lexer.token()]) :: {String.t(), [Lexer.token()]}
   defp collect_type_annotation([{:name, _, name} | rest]) do
     {subscript, rest} = collect_type_subscript(rest)
@@ -2673,11 +1456,6 @@ defmodule Pyex.Parser do
 
   defp collect_type_annotation([{:keyword, _, "None"} | rest]), do: {"None", rest}
   defp collect_type_annotation(tokens), do: {"", tokens}
-
-  @spec skip_type_annotation([Lexer.token()]) :: [Lexer.token()]
-  defp skip_type_annotation([{:name, _, _} | rest]), do: skip_type_subscript(rest)
-  defp skip_type_annotation([{:keyword, _, "None"} | rest]), do: rest
-  defp skip_type_annotation(tokens), do: tokens
 
   @spec collect_type_subscript([Lexer.token()]) :: {String.t(), [Lexer.token()]}
   defp collect_type_subscript([{:op, _, :lbracket} | rest]) do
@@ -2715,24 +1493,14 @@ defmodule Pyex.Parser do
   defp collect_brackets([], _depth, acc),
     do: {acc |> Enum.reverse() |> Enum.join(), []}
 
-  @spec skip_type_subscript([Lexer.token()]) :: [Lexer.token()]
-  defp skip_type_subscript([{:op, _, :lbracket} | rest]), do: skip_brackets(rest, 1)
-  defp skip_type_subscript(tokens), do: tokens
-
-  @spec skip_brackets([Lexer.token()], non_neg_integer()) :: [Lexer.token()]
-  defp skip_brackets(tokens, 0), do: tokens
-  defp skip_brackets([{:op, _, :lbracket} | rest], depth), do: skip_brackets(rest, depth + 1)
-  defp skip_brackets([{:op, _, :rbracket} | rest], depth), do: skip_brackets(rest, depth - 1)
-  defp skip_brackets([_ | rest], depth), do: skip_brackets(rest, depth)
-  defp skip_brackets([], _depth), do: []
-
   @spec token_line([Lexer.token()]) :: String.t()
   defp token_line([{_, line, _} | _]), do: "line #{line}"
   defp token_line(_), do: "end of input"
 
+  @doc false
   @spec node_line(ast_node() | term()) :: pos_integer()
-  defp node_line({_, [line: line], _}), do: line
-  defp node_line(_), do: 1
+  def node_line({_, [line: line], _}), do: line
+  def node_line(_), do: 1
 
   @spec inspect_tokens([Lexer.token()]) :: String.t()
   defp inspect_tokens(tokens) do

--- a/lib/pyex/parser/comprehensions.ex
+++ b/lib/pyex/parser/comprehensions.ex
@@ -1,0 +1,452 @@
+defmodule Pyex.Parser.Comprehensions do
+  @moduledoc """
+  Comprehension and collection-literal parsing helpers for `Pyex.Parser`.
+
+  Keeps generator expressions and collection literals that can lower into
+  comprehensions together so the main parser can focus on statement and
+  expression dispatch.
+  """
+
+  alias Pyex.{Lexer, Parser}
+
+  @typep parse_result :: {:ok, Parser.ast_node(), [Lexer.token()]} | {:error, String.t()}
+  @typep comp_clause ::
+           {:comp_for, String.t() | [String.t()], Parser.ast_node()}
+           | {:comp_if, Parser.ast_node()}
+
+  @doc """
+  Parses a parenthesized expression, tuple, or generator expression.
+  """
+  @spec parse_parenthesized([Lexer.token()], pos_integer()) :: parse_result()
+  def parse_parenthesized([{:op, _, :rparen} | rest], line) do
+    {:ok, {:tuple, [line: line], [[]]}, rest}
+  end
+
+  def parse_parenthesized(tokens, line) do
+    with {:ok, expr, rest} <- Parser.parse_expression(tokens) do
+      case rest do
+        [{:keyword, _, "for"} | for_rest] ->
+          parse_gen_expr(expr, for_rest, line)
+
+        [{:op, _, :comma} | rest] ->
+          parse_tuple_rest(rest, line, [expr])
+
+        [{:op, _, :rparen} | rest] ->
+          {:ok, expr, rest}
+
+        _ ->
+          {:error, "expected ')' at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @doc """
+  Parses a list literal or list comprehension.
+  """
+  @spec parse_list_literal([Lexer.token()], pos_integer()) :: parse_result()
+  def parse_list_literal([{:op, _, :rbracket} | rest], line) do
+    {:ok, {:list, [line: line], [[]]}, rest}
+  end
+
+  def parse_list_literal(tokens, line) do
+    with {:ok, expr, rest} <- Parser.parse_or(tokens) do
+      case rest do
+        [{:keyword, _, "for"} | for_rest] ->
+          parse_list_comp(expr, for_rest, line)
+
+        [{:keyword, _, "if"} | _] ->
+          with {:ok, full_expr, rest} <- Parser.parse_expression(tokens) do
+            case rest do
+              [{:keyword, _, "for"} | for_rest] ->
+                parse_list_comp(full_expr, for_rest, line)
+
+              _ ->
+                parse_list_elements_rest(rest, line, [full_expr])
+            end
+          end
+
+        _ ->
+          parse_list_elements_rest(rest, line, [expr])
+      end
+    end
+  end
+
+  @doc """
+  Parses a dict literal, set literal, dict comprehension, or set comprehension.
+  """
+  @spec parse_dict_literal([Lexer.token()], pos_integer()) :: parse_result()
+  def parse_dict_literal([{:op, _, :rbrace} | rest], line) do
+    {:ok, {:dict, [line: line], [[]]}, rest}
+  end
+
+  def parse_dict_literal(tokens, line) do
+    parse_dict_entries(tokens, line, [])
+  end
+
+  @doc """
+  Parses a generator-expression body after the leading `for`.
+  """
+  @spec parse_gen_expr_body(Parser.ast_node(), [Lexer.token()], pos_integer()) :: parse_result()
+  def parse_gen_expr_body(expr, [{:name, _, first_name}, {:op, _, :comma} | rest], line) do
+    case collect_for_vars(rest, [first_name]) do
+      {:ok, var_names, rest} ->
+        with {:ok, iterable, rest} <- Parser.parse_or(rest),
+             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+          clauses = [{:comp_for, var_names, iterable} | clauses]
+          {:ok, {:gen_expr, [line: line], [expr, clauses]}, rest}
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  def parse_gen_expr_body(expr, [{:name, _, var_name}, {:keyword, _, "in"} | rest], line) do
+    with {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, var_name, iterable} | clauses]
+      {:ok, {:gen_expr, [line: line], [expr, clauses]}, rest}
+    end
+  end
+
+  def parse_gen_expr_body(_expr, tokens, _line) do
+    {:error,
+     "expected variable name after 'for' in generator expression at #{token_line(tokens)}"}
+  end
+
+  @spec parse_list_elements_rest([Lexer.token()], pos_integer(), [Parser.ast_node()]) ::
+          parse_result()
+  defp parse_list_elements_rest(rest, line, acc) do
+    case rest do
+      [{:op, _, :comma} | rest] -> parse_list_elements(rest, line, acc)
+      [{:op, _, :rbracket} | rest] -> {:ok, {:list, [line: line], [Enum.reverse(acc)]}, rest}
+      _ -> {:error, "expected ',' or ']' in list at #{token_line(rest)}"}
+    end
+  end
+
+  @spec parse_list_elements([Lexer.token()], pos_integer(), [Parser.ast_node()]) :: parse_result()
+  defp parse_list_elements([{:op, _, :rbracket} | rest], line, acc) do
+    {:ok, {:list, [line: line], [Enum.reverse(acc)]}, rest}
+  end
+
+  defp parse_list_elements(tokens, line, acc) do
+    with {:ok, expr, rest} <- Parser.parse_expression(tokens) do
+      case rest do
+        [{:op, _, :comma} | rest] ->
+          parse_list_elements(rest, line, [expr | acc])
+
+        [{:op, _, :rbracket} | rest] ->
+          {:ok, {:list, [line: line], [Enum.reverse([expr | acc])]}, rest}
+
+        _ ->
+          {:error, "expected ',' or ']' in list at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @spec parse_list_comp(Parser.ast_node(), [Lexer.token()], pos_integer()) :: parse_result()
+  defp parse_list_comp(expr, [{:name, _, first_name}, {:op, _, :comma} | rest], line) do
+    case collect_for_vars(rest, [first_name]) do
+      {:ok, var_names, rest} ->
+        with {:ok, iterable, rest} <- Parser.parse_or(rest),
+             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+          clauses = [{:comp_for, var_names, iterable} | clauses]
+
+          case rest do
+            [{:op, _, :rbracket} | rest] ->
+              {:ok, {:list_comp, [line: line], [expr, clauses]}, rest}
+
+            _ ->
+              {:error, "expected ']' after list comprehension at #{token_line(rest)}"}
+          end
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp parse_list_comp(expr, [{:name, _, var_name}, {:keyword, _, "in"} | rest], line) do
+    with {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, var_name, iterable} | clauses]
+
+      case rest do
+        [{:op, _, :rbracket} | rest] -> {:ok, {:list_comp, [line: line], [expr, clauses]}, rest}
+        _ -> {:error, "expected ']' after list comprehension at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  defp parse_list_comp(_expr, tokens, _line) do
+    {:error, "expected variable name after 'for' in list comprehension at #{token_line(tokens)}"}
+  end
+
+  @spec parse_gen_expr(Parser.ast_node(), [Lexer.token()], pos_integer()) :: parse_result()
+  defp parse_gen_expr(expr, [{:name, _, first_name}, {:op, _, :comma} | rest], line) do
+    case collect_for_vars(rest, [first_name]) do
+      {:ok, var_names, rest} ->
+        with {:ok, iterable, rest} <- Parser.parse_or(rest),
+             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+          clauses = [{:comp_for, var_names, iterable} | clauses]
+
+          case rest do
+            [{:op, _, :rparen} | rest] -> {:ok, {:gen_expr, [line: line], [expr, clauses]}, rest}
+            _ -> {:error, "expected ')' after generator expression at #{token_line(rest)}"}
+          end
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp parse_gen_expr(expr, [{:name, _, var_name}, {:keyword, _, "in"} | rest], line) do
+    with {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, var_name, iterable} | clauses]
+
+      case rest do
+        [{:op, _, :rparen} | rest] -> {:ok, {:gen_expr, [line: line], [expr, clauses]}, rest}
+        _ -> {:error, "expected ')' after generator expression at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  defp parse_gen_expr(_expr, tokens, _line) do
+    {:error,
+     "expected variable name after 'for' in generator expression at #{token_line(tokens)}"}
+  end
+
+  @spec parse_tuple_rest([Lexer.token()], pos_integer(), [Parser.ast_node()]) :: parse_result()
+  defp parse_tuple_rest([{:op, _, :rparen} | rest], line, acc) do
+    {:ok, {:tuple, [line: line], [Enum.reverse(acc)]}, rest}
+  end
+
+  defp parse_tuple_rest(tokens, line, acc) do
+    with {:ok, expr, rest} <- Parser.parse_expression(tokens) do
+      case rest do
+        [{:op, _, :comma} | rest] ->
+          parse_tuple_rest(rest, line, [expr | acc])
+
+        [{:op, _, :rparen} | rest] ->
+          {:ok, {:tuple, [line: line], [Enum.reverse([expr | acc])]}, rest}
+
+        _ ->
+          {:error, "expected ',' or ')' in tuple at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @spec parse_dict_entries([Lexer.token()], pos_integer(), [
+          {Parser.ast_node(), Parser.ast_node()}
+        ]) ::
+          parse_result()
+  defp parse_dict_entries(tokens, line, acc) do
+    with {:ok, key, rest} <- Parser.parse_or(tokens) do
+      case rest do
+        [{:op, _, :colon} | rest] ->
+          with {:ok, value, rest} <- Parser.parse_or(rest) do
+            case rest do
+              [{:keyword, _, "for"} | comp_rest] when acc == [] ->
+                parse_dict_comp(key, value, comp_rest, line)
+
+              _ ->
+                pair = {key, value}
+
+                case rest do
+                  [{:op, _, :comma}, {:op, _, :rbrace} | rest] ->
+                    {:ok, {:dict, [line: line], [Enum.reverse([pair | acc])]}, rest}
+
+                  [{:op, _, :comma} | rest] ->
+                    parse_dict_entries(rest, line, [pair | acc])
+
+                  [{:op, _, :rbrace} | rest] ->
+                    {:ok, {:dict, [line: line], [Enum.reverse([pair | acc])]}, rest}
+
+                  _ ->
+                    {:error, "expected ',' or '}' in dict at #{token_line(rest)}"}
+                end
+            end
+          end
+
+        [{:keyword, _, "for"} | comp_rest] when acc == [] ->
+          parse_set_comp(key, comp_rest, line)
+
+        [{:op, _, :comma} | set_rest] when acc == [] ->
+          parse_set_entries(set_rest, line, [key])
+
+        [{:op, _, :rbrace} | set_rest] when acc == [] ->
+          {:ok, {:set, [line: line], [[key]]}, set_rest}
+
+        _ ->
+          {:error, "expected ':' in dict entry at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @spec parse_set_entries([Lexer.token()], pos_integer(), [Parser.ast_node()]) :: parse_result()
+  defp parse_set_entries([{:op, _, :rbrace} | rest], line, acc) do
+    {:ok, {:set, [line: line], [Enum.reverse(acc)]}, rest}
+  end
+
+  defp parse_set_entries(tokens, line, acc) do
+    with {:ok, elem, rest} <- Parser.parse_or(tokens) do
+      case rest do
+        [{:op, _, :comma} | rest] ->
+          parse_set_entries(rest, line, [elem | acc])
+
+        [{:op, _, :rbrace} | rest] ->
+          {:ok, {:set, [line: line], [Enum.reverse([elem | acc])]}, rest}
+
+        _ ->
+          {:error, "expected ',' or '}' in set literal at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @spec parse_set_comp(Parser.ast_node(), [Lexer.token()], pos_integer()) :: parse_result()
+  defp parse_set_comp(expr, [{:name, _, first_name}, {:op, _, :comma} | rest], line) do
+    case collect_for_vars(rest, [first_name]) do
+      {:ok, var_names, rest} ->
+        with {:ok, iterable, rest} <- Parser.parse_or(rest),
+             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+          clauses = [{:comp_for, var_names, iterable} | clauses]
+
+          case rest do
+            [{:op, _, :rbrace} | rest] -> {:ok, {:set_comp, [line: line], [expr, clauses]}, rest}
+            _ -> {:error, "expected '}' after set comprehension at #{token_line(rest)}"}
+          end
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp parse_set_comp(expr, [{:name, _, var_name}, {:keyword, _, "in"} | rest], line) do
+    with {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, var_name, iterable} | clauses]
+
+      case rest do
+        [{:op, _, :rbrace} | rest] -> {:ok, {:set_comp, [line: line], [expr, clauses]}, rest}
+        _ -> {:error, "expected '}' after set comprehension at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  defp parse_set_comp(_expr, tokens, _line) do
+    {:error, "expected variable name in set comprehension at #{token_line(tokens)}"}
+  end
+
+  @spec parse_dict_comp(Parser.ast_node(), Parser.ast_node(), [Lexer.token()], pos_integer()) ::
+          parse_result()
+  defp parse_dict_comp(
+         key_expr,
+         val_expr,
+         [{:name, _, first_name}, {:op, _, :comma} | rest],
+         line
+       ) do
+    case collect_for_vars(rest, [first_name]) do
+      {:ok, var_names, rest} ->
+        with {:ok, iterable, rest} <- Parser.parse_or(rest),
+             {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+          clauses = [{:comp_for, var_names, iterable} | clauses]
+
+          case rest do
+            [{:op, _, :rbrace} | rest] ->
+              {:ok, {:dict_comp, [line: line], [key_expr, val_expr, clauses]}, rest}
+
+            _ ->
+              {:error, "expected '}' after dict comprehension at #{token_line(rest)}"}
+          end
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp parse_dict_comp(
+         key_expr,
+         val_expr,
+         [{:name, _, var_name}, {:keyword, _, "in"} | rest],
+         line
+       ) do
+    with {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, var_name, iterable} | clauses]
+
+      case rest do
+        [{:op, _, :rbrace} | rest] ->
+          {:ok, {:dict_comp, [line: line], [key_expr, val_expr, clauses]}, rest}
+
+        _ ->
+          {:error, "expected '}' after dict comprehension at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  defp parse_dict_comp(_key_expr, _val_expr, tokens, _line) do
+    {:error, "expected variable name in dict comprehension at #{token_line(tokens)}"}
+  end
+
+  @spec parse_comp_clauses([Lexer.token()], [comp_clause()]) ::
+          {:ok, [comp_clause()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_comp_clauses([{:keyword, _, "if"} | rest], acc) do
+    with {:ok, filter, rest} <- Parser.parse_or(rest) do
+      parse_comp_clauses(rest, [{:comp_if, filter} | acc])
+    end
+  end
+
+  defp parse_comp_clauses([{:keyword, _, "for"} | rest], acc) do
+    parse_comp_for_clause(rest, acc)
+  end
+
+  defp parse_comp_clauses(rest, acc) do
+    {:ok, Enum.reverse(acc), rest}
+  end
+
+  @spec parse_comp_for_clause([Lexer.token()], [comp_clause()]) ::
+          {:ok, [comp_clause()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_comp_for_clause([{:name, _, first_name}, {:op, _, :comma} | rest], acc) do
+    case collect_for_vars(rest, [first_name]) do
+      {:ok, var_names, rest} ->
+        with {:ok, iterable, rest} <- Parser.parse_or(rest) do
+          parse_comp_clauses(rest, [{:comp_for, var_names, iterable} | acc])
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp parse_comp_for_clause([{:name, _, var_name}, {:keyword, _, "in"} | rest], acc) do
+    with {:ok, iterable, rest} <- Parser.parse_or(rest) do
+      parse_comp_clauses(rest, [{:comp_for, var_name, iterable} | acc])
+    end
+  end
+
+  defp parse_comp_for_clause(tokens, _acc) do
+    {:error, "expected variable name after 'for' in comprehension at #{token_line(tokens)}"}
+  end
+
+  @spec collect_for_vars([Lexer.token()], [String.t()]) ::
+          {:ok, [String.t()], [Lexer.token()]} | {:error, String.t()}
+  defp collect_for_vars([{:name, _, name}, {:keyword, _, "in"} | rest], acc) do
+    {:ok, Enum.reverse([name | acc]), rest}
+  end
+
+  defp collect_for_vars([{:name, _, name}, {:op, _, :comma} | rest], acc) do
+    collect_for_vars(rest, [name | acc])
+  end
+
+  defp collect_for_vars(tokens, _acc) do
+    {:error, "expected variable name in for loop at #{token_line(tokens)}"}
+  end
+
+  @spec token_line([Lexer.token()]) :: String.t()
+  defp token_line([{_, line, _} | _]), do: "line #{line}"
+  defp token_line(_), do: "end of input"
+end

--- a/lib/pyex/parser/control_flow.ex
+++ b/lib/pyex/parser/control_flow.ex
@@ -1,0 +1,274 @@
+defmodule Pyex.Parser.ControlFlow do
+  @moduledoc """
+  Control-flow statement parsing helpers for `Pyex.Parser`.
+
+  Keeps statement-specific parsing for `if`, `while`, `for`, and `try`
+  outside the main parser module while preserving the existing parser API.
+  """
+
+  alias Pyex.{Lexer, Parser}
+
+  @typep parse_result :: {:ok, Parser.ast_node(), [Lexer.token()]} | {:error, String.t()}
+  @typep branch_clause :: {Parser.ast_node(), [Parser.ast_node()]} | {:else, [Parser.ast_node()]}
+  @typep except_clause :: {String.t() | [String.t()] | nil, String.t() | nil, [Parser.ast_node()]}
+
+  @doc """
+  Parses an `if` statement.
+  """
+  @spec parse_if([Lexer.token()]) :: parse_result()
+  def parse_if(tokens) do
+    with {:ok, condition, rest} <- Parser.parse_expression(tokens) do
+      case rest do
+        [{:op, _, :colon}, :newline, :indent | block_rest] ->
+          with {:ok, body, rest} <- Parser.parse_block(block_rest),
+               {:ok, else_clauses, rest} <- parse_elif_else(rest) do
+            line = Parser.node_line(condition)
+            {:ok, {:if, [line: line], [{condition, body} | else_clauses]}, drop_newline(rest)}
+          end
+
+        [{:op, _, :colon} | inline_rest] ->
+          with {:ok, stmt, rest} <- Parser.parse_inline_body(inline_rest),
+               {:ok, else_clauses, rest} <- parse_elif_else(rest) do
+            line = Parser.node_line(condition)
+            {:ok, {:if, [line: line], [{condition, [stmt]} | else_clauses]}, drop_newline(rest)}
+          end
+
+        _ ->
+          {:error, "expected ':' after if at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @doc """
+  Parses a `while` loop.
+  """
+  @spec parse_while([Lexer.token()]) :: parse_result()
+  def parse_while(tokens) do
+    with {:ok, condition, rest} <- Parser.parse_expression(tokens),
+         {:ok, rest} <- expect_block_start(rest, "while"),
+         {:ok, body, rest} <- Parser.parse_block(rest),
+         {:ok, else_body, rest} <- parse_loop_else(rest) do
+      line = Parser.node_line(condition)
+      {:ok, {:while, [line: line], [condition, body, else_body]}, drop_newline(rest)}
+    end
+  end
+
+  @doc """
+  Parses a `for` loop.
+  """
+  @spec parse_for([Lexer.token()]) :: parse_result()
+  def parse_for([{:name, line, first_name}, {:op, _, :comma} | rest]) do
+    with {:ok, var_names, rest} <- collect_for_vars(rest, [first_name]),
+         {:ok, iterable, rest} <- Parser.parse_expression(rest),
+         {:ok, rest} <- expect_block_start(rest, "for"),
+         {:ok, body, rest} <- Parser.parse_block(rest),
+         {:ok, else_body, rest} <- parse_loop_else(rest) do
+      {:ok, {:for, [line: line], [var_names, iterable, body, else_body]}, drop_newline(rest)}
+    end
+  end
+
+  def parse_for([{:name, line, var_name}, {:keyword, _, "in"} | rest]) do
+    with {:ok, iterable, rest} <- Parser.parse_expression(rest),
+         {:ok, rest} <- expect_block_start(rest, "for"),
+         {:ok, body, rest} <- Parser.parse_block(rest),
+         {:ok, else_body, rest} <- parse_loop_else(rest) do
+      {:ok, {:for, [line: line], [var_name, iterable, body, else_body]}, drop_newline(rest)}
+    end
+  end
+
+  def parse_for(tokens) do
+    {:error, "expected variable name after 'for' at #{token_line(tokens)}"}
+  end
+
+  @doc """
+  Parses a `try` statement.
+  """
+  @spec parse_try([Lexer.token()]) :: parse_result()
+  def parse_try(tokens) do
+    with {:ok, rest} <- expect_block_start(tokens, "try"),
+         {:ok, body, rest} <- Parser.parse_block(rest),
+         {:ok, handlers, rest} <- parse_except_clauses(rest),
+         {:ok, else_body, rest} <- parse_try_else(rest),
+         {:ok, finally_body, rest} <- parse_try_finally(rest) do
+      line =
+        case body do
+          [{_, [line: body_line], _} | _] -> body_line
+          _ -> 1
+        end
+
+      {:ok, {:try, [line: line], [body, handlers, else_body, finally_body]}, drop_newline(rest)}
+    end
+  end
+
+  @spec parse_elif_else([Lexer.token()]) ::
+          {:ok, [branch_clause()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_elif_else([{:keyword, _, "elif"} | rest]) do
+    with {:ok, condition, rest} <- Parser.parse_expression(rest) do
+      case rest do
+        [{:op, _, :colon}, :newline, :indent | block_rest] ->
+          with {:ok, body, rest} <- Parser.parse_block(block_rest),
+               {:ok, more, rest} <- parse_elif_else(rest) do
+            {:ok, [{condition, body} | more], rest}
+          end
+
+        [{:op, _, :colon} | inline_rest] ->
+          with {:ok, stmt, rest} <- Parser.parse_inline_body(inline_rest),
+               {:ok, more, rest} <- parse_elif_else(rest) do
+            {:ok, [{condition, [stmt]} | more], rest}
+          end
+
+        _ ->
+          {:error, "expected ':' after elif at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  defp parse_elif_else([{:keyword, _, "else"}, {:op, _, :colon}, :newline, :indent | rest]) do
+    case Parser.parse_block(rest) do
+      {:ok, body, rest} -> {:ok, [{:else, body}], rest}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_elif_else([{:keyword, _, "else"}, {:op, _, :colon} | rest]) do
+    case Parser.parse_inline_body(rest) do
+      {:ok, stmt, rest} -> {:ok, [{:else, [stmt]}], rest}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_elif_else(rest), do: {:ok, [], rest}
+
+  @spec parse_loop_else([Lexer.token()]) ::
+          {:ok, [Parser.ast_node()] | nil, [Lexer.token()]} | {:error, String.t()}
+  defp parse_loop_else([{:keyword, _, "else"}, {:op, _, :colon}, :newline, :indent | rest]) do
+    case Parser.parse_block(rest) do
+      {:ok, else_body, rest} -> {:ok, else_body, rest}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_loop_else(rest), do: {:ok, nil, rest}
+
+  @spec collect_for_vars([Lexer.token()], [String.t()]) ::
+          {:ok, [String.t()], [Lexer.token()]} | {:error, String.t()}
+  defp collect_for_vars([{:name, _, name}, {:keyword, _, "in"} | rest], acc) do
+    {:ok, Enum.reverse([name | acc]), rest}
+  end
+
+  defp collect_for_vars([{:name, _, name}, {:op, _, :comma} | rest], acc) do
+    collect_for_vars(rest, [name | acc])
+  end
+
+  defp collect_for_vars(tokens, _acc) do
+    {:error, "expected variable name in for loop at #{token_line(tokens)}"}
+  end
+
+  @spec parse_try_else([Lexer.token()]) ::
+          {:ok, [Parser.ast_node()] | nil, [Lexer.token()]} | {:error, String.t()}
+  defp parse_try_else([{:keyword, _, "else"}, {:op, _, :colon}, :newline, :indent | rest]) do
+    case Parser.parse_block(rest) do
+      {:ok, else_body, rest} -> {:ok, else_body, rest}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_try_else(rest), do: {:ok, nil, rest}
+
+  @spec parse_try_finally([Lexer.token()]) ::
+          {:ok, [Parser.ast_node()] | nil, [Lexer.token()]} | {:error, String.t()}
+  defp parse_try_finally([{:keyword, _, "finally"}, {:op, _, :colon}, :newline, :indent | rest]) do
+    case Parser.parse_block(rest) do
+      {:ok, finally_body, rest} -> {:ok, finally_body, rest}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_try_finally(rest), do: {:ok, nil, rest}
+
+  @spec parse_except_clauses([Lexer.token()], [except_clause()]) ::
+          {:ok, [except_clause()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_except_clauses(tokens, acc \\ [])
+
+  defp parse_except_clauses([{:keyword, _, "except"} | rest], acc) do
+    case rest do
+      [{:op, _, :colon}, :newline, :indent | rest] ->
+        case Parser.parse_block(rest) do
+          {:ok, handler_body, rest} ->
+            parse_except_clauses(rest, [{nil, nil, handler_body} | acc])
+
+          {:error, _} = error ->
+            error
+        end
+
+      [{:op, _, :lparen} | paren_rest] ->
+        case collect_except_names(paren_rest, []) do
+          {:ok, names, [{:keyword, _, "as"}, {:name, _, var_name} | after_as]} ->
+            with {:ok, after_as} <- expect_block_start(after_as, "except"),
+                 {:ok, handler_body, after_as} <- Parser.parse_block(after_as) do
+              parse_except_clauses(after_as, [{names, var_name, handler_body} | acc])
+            end
+
+          {:ok, names, after_paren} ->
+            with {:ok, after_paren} <- expect_block_start(after_paren, "except"),
+                 {:ok, handler_body, after_paren} <- Parser.parse_block(after_paren) do
+              parse_except_clauses(after_paren, [{names, nil, handler_body} | acc])
+            end
+
+          {:error, _} = error ->
+            error
+        end
+
+      [{:name, _, exc_name}, {:keyword, _, "as"}, {:name, _, var_name} | rest] ->
+        with {:ok, rest} <- expect_block_start(rest, "except"),
+             {:ok, handler_body, rest} <- Parser.parse_block(rest) do
+          parse_except_clauses(rest, [{exc_name, var_name, handler_body} | acc])
+        end
+
+      [{:name, _, exc_name} | rest] ->
+        with {:ok, rest} <- expect_block_start(rest, "except"),
+             {:ok, handler_body, rest} <- Parser.parse_block(rest) do
+          parse_except_clauses(rest, [{exc_name, nil, handler_body} | acc])
+        end
+
+      _ ->
+        {:error, "expected ':' or exception name after 'except' at #{token_line(rest)}"}
+    end
+  end
+
+  defp parse_except_clauses(rest, acc) do
+    {:ok, Enum.reverse(acc), rest}
+  end
+
+  @spec collect_except_names([Lexer.token()], [String.t()]) ::
+          {:ok, [String.t()], [Lexer.token()]} | {:error, String.t()}
+  defp collect_except_names([{:name, _, name}, {:op, _, :rparen} | rest], acc) do
+    {:ok, Enum.reverse([name | acc]), rest}
+  end
+
+  defp collect_except_names([{:name, _, name}, {:op, _, :comma} | rest], acc) do
+    collect_except_names(rest, [name | acc])
+  end
+
+  defp collect_except_names(tokens, _acc) do
+    {:error, "expected exception name in except tuple at #{token_line(tokens)}"}
+  end
+
+  @spec expect_block_start([Lexer.token()], String.t()) ::
+          {:ok, [Lexer.token()]} | {:error, String.t()}
+  defp expect_block_start([{:op, _, :colon}, :newline, :indent | rest], _context) do
+    {:ok, rest}
+  end
+
+  defp expect_block_start(tokens, context) do
+    {:error, "expected ':' after #{context} at #{token_line(tokens)}"}
+  end
+
+  @spec drop_newline([Lexer.token()]) :: [Lexer.token()]
+  defp drop_newline([:newline | rest]), do: rest
+  defp drop_newline(rest), do: rest
+
+  @spec token_line([Lexer.token()]) :: String.t()
+  defp token_line([{_, line, _} | _]), do: "line #{line}"
+  defp token_line(_), do: "end of input"
+end

--- a/lib/pyex/parser/definitions.ex
+++ b/lib/pyex/parser/definitions.ex
@@ -1,0 +1,269 @@
+defmodule Pyex.Parser.Definitions do
+  @moduledoc """
+  Definition-style statement parsing helpers for `Pyex.Parser`.
+
+  Keeps parsing for `def`, `class`, and `with` statements together so
+  block-oriented statement parsing stays cohesive without changing the
+  main parser entrypoints.
+  """
+
+  alias Pyex.{Lexer, Parser}
+
+  @typep parse_result :: {:ok, Parser.ast_node(), [Lexer.token()]} | {:error, String.t()}
+  @typep param :: Parser.param()
+  @typep base_class :: String.t() | {:dotted, String.t(), String.t()}
+
+  @doc """
+  Parses a function definition.
+  """
+  @spec parse_function_def([Lexer.token()]) :: parse_result()
+  def parse_function_def([{:name, line, name}, {:op, _, :lparen} | rest]) do
+    case parse_params(rest) do
+      {:ok, params, rest} ->
+        rest = skip_return_annotation(rest)
+
+        case rest do
+          [{:op, _, :colon}, :newline, :indent | rest] ->
+            case Parser.parse_block(rest) do
+              {:ok, body, rest} ->
+                {:ok, {:def, [line: line], [name, params, body]}, drop_newline(rest)}
+
+              {:error, _} = error ->
+                error
+            end
+
+          _ ->
+            {:error, "expected ':' after function definition on line #{line}"}
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  def parse_function_def(tokens) do
+    {:error, "expected function name at #{token_line(tokens)}"}
+  end
+
+  @doc """
+  Parses a `with` statement.
+  """
+  @spec parse_with([Lexer.token()], pos_integer()) :: parse_result()
+  def parse_with(rest, line) do
+    case Parser.parse_expression(rest) do
+      {:ok, expr,
+       [{:keyword, _, "as"}, {:name, _, name}, {:op, _, :colon}, :newline, :indent | rest]} ->
+        case Parser.parse_block(rest) do
+          {:ok, body, rest} ->
+            {:ok, {:with, [line: line], [expr, name, body]}, drop_newline(rest)}
+
+          {:error, _} = error ->
+            error
+        end
+
+      {:ok, expr, [{:op, _, :colon}, :newline, :indent | rest]} ->
+        case Parser.parse_block(rest) do
+          {:ok, body, rest} ->
+            {:ok, {:with, [line: line], [expr, nil, body]}, drop_newline(rest)}
+
+          {:error, _} = error ->
+            error
+        end
+
+      {:ok, _expr, _rest} ->
+        {:error, "expected ':' after with statement on line #{line}"}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Parses a class definition.
+  """
+  @spec parse_class_def([Lexer.token()]) :: parse_result()
+  def parse_class_def([{:name, line, name}, {:op, _, :lparen} | rest]) do
+    case parse_base_classes(rest) do
+      {:ok, bases, rest} ->
+        case rest do
+          [{:op, _, :colon}, :newline, :indent | rest] ->
+            case Parser.parse_block(rest) do
+              {:ok, body, rest} ->
+                {:ok, {:class, [line: line], [name, bases, body]}, drop_newline(rest)}
+
+              {:error, _} = error ->
+                error
+            end
+
+          _ ->
+            {:error, "expected ':' after class definition on line #{line}"}
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  def parse_class_def([{:name, line, name}, {:op, _, :colon}, :newline, :indent | rest]) do
+    case Parser.parse_block(rest) do
+      {:ok, body, rest} ->
+        {:ok, {:class, [line: line], [name, [], body]}, drop_newline(rest)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  def parse_class_def(tokens) do
+    {:error, "expected class name at #{token_line(tokens)}"}
+  end
+
+  @spec parse_base_classes([Lexer.token()]) ::
+          {:ok, [base_class()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_base_classes(tokens), do: parse_base_classes(tokens, [])
+
+  @spec parse_base_classes([Lexer.token()], [base_class()]) ::
+          {:ok, [base_class()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_base_classes([{:op, _, :rparen} | rest], acc), do: {:ok, Enum.reverse(acc), rest}
+
+  defp parse_base_classes([{:op, _, :comma} | rest], acc) do
+    parse_base_classes(rest, acc)
+  end
+
+  defp parse_base_classes([{:name, _, name}, {:op, _, :dot}, {:name, _, attr} | rest], acc) do
+    parse_base_classes(rest, [{:dotted, name, attr} | acc])
+  end
+
+  defp parse_base_classes([{:name, _, name} | rest], acc) do
+    parse_base_classes(rest, [name | acc])
+  end
+
+  defp parse_base_classes(tokens, _acc) do
+    {:error, "unexpected token in class bases at #{token_line(tokens)}"}
+  end
+
+  @spec parse_params([Lexer.token()]) :: {:ok, [param()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_params(tokens), do: parse_params(tokens, [])
+
+  @spec parse_params([Lexer.token()], [param()]) ::
+          {:ok, [param()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_params([{:op, _, :rparen} | rest], acc) do
+    {:ok, Enum.reverse(acc), rest}
+  end
+
+  defp parse_params([{:op, _, :comma} | rest], acc) do
+    parse_params(rest, acc)
+  end
+
+  defp parse_params([{:name, _, name}, {:op, _, :colon} | rest], acc) do
+    {type_str, rest} = collect_type_annotation(rest)
+
+    case rest do
+      [{:op, _, :assign} | rest] ->
+        with {:ok, default, rest} <- Parser.parse_expression(rest) do
+          parse_params(rest, [{name, default, type_str} | acc])
+        end
+
+      _ ->
+        parse_params(rest, [{name, nil, type_str} | acc])
+    end
+  end
+
+  defp parse_params([{:name, _, name}, {:op, _, :assign} | rest], acc) do
+    with {:ok, default, rest} <- Parser.parse_expression(rest) do
+      parse_params(rest, [{name, default} | acc])
+    end
+  end
+
+  defp parse_params([{:op, _, :double_star}, {:name, _, name} | rest], acc) do
+    parse_params(rest, [{"**" <> name, nil} | acc])
+  end
+
+  defp parse_params([{:op, _, :star}, {:name, _, name} | rest], acc) do
+    parse_params(rest, [{"*" <> name, nil} | acc])
+  end
+
+  defp parse_params([{:name, _, name} | rest], acc) do
+    parse_params(rest, [{name, nil} | acc])
+  end
+
+  defp parse_params(tokens, _acc) do
+    {:error, "unexpected token in parameter list at #{token_line(tokens)}"}
+  end
+
+  @spec skip_return_annotation([Lexer.token()]) :: [Lexer.token()]
+  defp skip_return_annotation([{:op, _, :minus}, {:op, _, :gt} | rest]) do
+    skip_type_annotation(rest)
+  end
+
+  defp skip_return_annotation(tokens), do: tokens
+
+  @spec collect_type_annotation([Lexer.token()]) :: {String.t(), [Lexer.token()]}
+  defp collect_type_annotation([{:name, _, name} | rest]) do
+    {subscript, rest} = collect_type_subscript(rest)
+    {name <> subscript, rest}
+  end
+
+  defp collect_type_annotation([{:keyword, _, "None"} | rest]), do: {"None", rest}
+  defp collect_type_annotation(tokens), do: {"", tokens}
+
+  @spec skip_type_annotation([Lexer.token()]) :: [Lexer.token()]
+  defp skip_type_annotation([{:name, _, _} | rest]), do: skip_type_subscript(rest)
+  defp skip_type_annotation([{:keyword, _, "None"} | rest]), do: rest
+  defp skip_type_annotation(tokens), do: tokens
+
+  @spec collect_type_subscript([Lexer.token()]) :: {String.t(), [Lexer.token()]}
+  defp collect_type_subscript([{:op, _, :lbracket} | rest]) do
+    {inner, rest} = collect_brackets(rest, 1, [])
+    {"[" <> inner <> "]", rest}
+  end
+
+  defp collect_type_subscript(tokens), do: {"", tokens}
+
+  @spec collect_brackets([Lexer.token()], non_neg_integer(), [String.t()]) ::
+          {String.t(), [Lexer.token()]}
+  defp collect_brackets(tokens, 0, acc), do: {acc |> Enum.reverse() |> Enum.join(), tokens}
+
+  defp collect_brackets([{:op, _, :lbracket} | rest], depth, acc),
+    do: collect_brackets(rest, depth + 1, ["[" | acc])
+
+  defp collect_brackets([{:op, _, :rbracket} | rest], 1, acc),
+    do: collect_brackets(rest, 0, acc)
+
+  defp collect_brackets([{:op, _, :rbracket} | rest], depth, acc),
+    do: collect_brackets(rest, depth - 1, ["]" | acc])
+
+  defp collect_brackets([{:op, _, :comma} | rest], depth, acc),
+    do: collect_brackets(rest, depth, [", " | acc])
+
+  defp collect_brackets([{:name, _, name} | rest], depth, acc),
+    do: collect_brackets(rest, depth, [name | acc])
+
+  defp collect_brackets([{:keyword, _, kw} | rest], depth, acc),
+    do: collect_brackets(rest, depth, [kw | acc])
+
+  defp collect_brackets([_ | rest], depth, acc),
+    do: collect_brackets(rest, depth, acc)
+
+  defp collect_brackets([], _depth, acc),
+    do: {acc |> Enum.reverse() |> Enum.join(), []}
+
+  @spec skip_type_subscript([Lexer.token()]) :: [Lexer.token()]
+  defp skip_type_subscript([{:op, _, :lbracket} | rest]), do: skip_brackets(rest, 1)
+  defp skip_type_subscript(tokens), do: tokens
+
+  @spec skip_brackets([Lexer.token()], non_neg_integer()) :: [Lexer.token()]
+  defp skip_brackets(tokens, 0), do: tokens
+  defp skip_brackets([{:op, _, :lbracket} | rest], depth), do: skip_brackets(rest, depth + 1)
+  defp skip_brackets([{:op, _, :rbracket} | rest], depth), do: skip_brackets(rest, depth - 1)
+  defp skip_brackets([_ | rest], depth), do: skip_brackets(rest, depth)
+  defp skip_brackets([], _depth), do: []
+
+  @spec drop_newline([Lexer.token()]) :: [Lexer.token()]
+  defp drop_newline([:newline | rest]), do: rest
+  defp drop_newline(rest), do: rest
+
+  @spec token_line([Lexer.token()]) :: String.t()
+  defp token_line([{_, line, _} | _]), do: "line #{line}"
+  defp token_line(_), do: "end of input"
+end

--- a/lib/pyex/parser/imports.ex
+++ b/lib/pyex/parser/imports.ex
@@ -1,0 +1,138 @@
+defmodule Pyex.Parser.Imports do
+  @moduledoc """
+  Import statement parsing helpers for `Pyex.Parser`.
+
+  Keeps `import` and `from ... import ...` parsing isolated from the
+  main parser so the top-level statement dispatcher stays smaller
+  without changing the public parser API.
+  """
+
+  alias Pyex.{Lexer, Parser}
+
+  @typep parse_result :: {:ok, Parser.ast_node(), [Lexer.token()]} | {:error, String.t()}
+  @typep import_spec :: {String.t(), String.t() | nil}
+
+  @doc """
+  Parses an `import ...` statement body.
+  """
+  @spec parse_import([Lexer.token()], pos_integer()) :: parse_result()
+  def parse_import([{:name, line, first} | rest], _line) do
+    {module_name, rest} = parse_dotted_name(first, rest)
+
+    {first_import, rest} = maybe_parse_alias(module_name, rest)
+
+    case rest do
+      [{:op, _, :comma} | rest] ->
+        case parse_import_list(rest, [first_import]) do
+          {:ok, imports, rest} ->
+            {:ok, {:import, [line: line], imports}, drop_newline(rest)}
+
+          {:error, _} = error ->
+            error
+        end
+
+      _ ->
+        {:ok, {:import, [line: line], [first_import]}, drop_newline(rest)}
+    end
+  end
+
+  def parse_import(tokens, line) do
+    {:error, "expected module name after 'import' on line #{line} at #{token_line(tokens)}"}
+  end
+
+  @doc """
+  Parses a `from ... import ...` statement body.
+  """
+  @spec parse_from_import([Lexer.token()], pos_integer()) :: parse_result()
+  def parse_from_import([{:name, _, first} | rest], line) do
+    {module_name, rest} = parse_dotted_name(first, rest)
+
+    case rest do
+      [{:keyword, _, "import"} | rest] ->
+        case parse_import_names(rest) do
+          {:ok, names, rest} ->
+            {:ok, {:from_import, [line: line], [module_name, names]}, drop_newline(rest)}
+
+          {:error, _} = error ->
+            error
+        end
+
+      _ ->
+        {:error, "expected 'import' after module name on line #{line} at #{token_line(rest)}"}
+    end
+  end
+
+  def parse_from_import(tokens, line) do
+    {:error, "expected module name after 'from' on line #{line} at #{token_line(tokens)}"}
+  end
+
+  @spec maybe_parse_alias(String.t(), [Lexer.token()]) :: {import_spec(), [Lexer.token()]}
+  defp maybe_parse_alias(module_name, [{:keyword, _, "as"}, {:name, _, alias_name} | rest]) do
+    {{module_name, alias_name}, rest}
+  end
+
+  defp maybe_parse_alias(module_name, rest) do
+    {{module_name, nil}, rest}
+  end
+
+  @spec parse_import_list([Lexer.token()], [import_spec()]) ::
+          {:ok, [import_spec()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_import_list([{:name, _, name} | rest], acc) do
+    {module_name, rest} = parse_dotted_name(name, rest)
+    {import_spec, rest} = maybe_parse_alias(module_name, rest)
+
+    case rest do
+      [{:op, _, :comma} | rest] ->
+        parse_import_list(rest, [import_spec | acc])
+
+      _ ->
+        {:ok, Enum.reverse([import_spec | acc]), rest}
+    end
+  end
+
+  defp parse_import_list(tokens, _acc) do
+    {:error, "expected module name after ',' at #{token_line(tokens)}"}
+  end
+
+  @spec parse_dotted_name(String.t(), [Lexer.token()]) :: {String.t(), [Lexer.token()]}
+  defp parse_dotted_name(acc, [{:op, _, :dot}, {:name, _, part} | rest]) do
+    parse_dotted_name(acc <> "." <> part, rest)
+  end
+
+  defp parse_dotted_name(acc, rest), do: {acc, rest}
+
+  @spec parse_import_names([Lexer.token()]) ::
+          {:ok, [import_spec()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_import_names(tokens), do: parse_import_names(tokens, [])
+
+  @spec parse_import_names([Lexer.token()], [import_spec()]) ::
+          {:ok, [import_spec()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_import_names(
+         [{:name, _, name}, {:keyword, _, "as"}, {:name, _, alias_name} | rest],
+         acc
+       ) do
+    case rest do
+      [{:op, _, :comma} | rest] -> parse_import_names(rest, [{name, alias_name} | acc])
+      _ -> {:ok, Enum.reverse([{name, alias_name} | acc]), rest}
+    end
+  end
+
+  defp parse_import_names([{:name, _, name} | rest], acc) do
+    case rest do
+      [{:op, _, :comma} | rest] -> parse_import_names(rest, [{name, nil} | acc])
+      _ -> {:ok, Enum.reverse([{name, nil} | acc]), rest}
+    end
+  end
+
+  defp parse_import_names(tokens, _acc) do
+    {:error, "expected name after 'import' at #{token_line(tokens)}"}
+  end
+
+  @spec drop_newline([Lexer.token()]) :: [Lexer.token()]
+  defp drop_newline([:newline | rest]), do: rest
+  defp drop_newline(rest), do: rest
+
+  @spec token_line([Lexer.token()]) :: String.t()
+  defp token_line([{_, line, _} | _]), do: "line #{line}"
+  defp token_line(_), do: "end of input"
+end

--- a/lib/pyex/parser/match.ex
+++ b/lib/pyex/parser/match.ex
@@ -1,0 +1,284 @@
+defmodule Pyex.Parser.Match do
+  @moduledoc """
+  Structural pattern matching parsing helpers for `Pyex.Parser`.
+
+  Keeps `match`/`case` parsing and pattern grammar isolated from the main
+  parser while preserving the existing parser entrypoints.
+  """
+
+  alias Pyex.{Lexer, Parser}
+
+  @typep match_pattern ::
+           {:match_wildcard, Parser.meta(), []}
+           | {:match_capture, Parser.meta(), [String.t()]}
+           | {:match_or, Parser.meta(), [match_pattern()]}
+           | {:match_sequence, Parser.meta(), [match_pattern()]}
+           | {:match_mapping, Parser.meta(), [{Parser.ast_node(), match_pattern()}]}
+           | {:match_class, Parser.meta(), [term()]}
+           | {:match_star, Parser.meta(), [String.t() | nil]}
+           | Parser.ast_node()
+
+  @typep match_case :: {match_pattern(), Parser.ast_node() | nil, [Parser.ast_node()]}
+
+  @doc """
+  Attempts to parse a `match` statement after the leading `match` name token.
+  Returns `:not_match` if the token stream should be treated as a normal name.
+  """
+  @spec try_match([Lexer.token()], pos_integer()) ::
+          {:ok, Parser.ast_node(), [Lexer.token()]} | :not_match
+  def try_match(tokens, line) do
+    with {:ok, subject, [{:op, _, :colon}, :newline, :indent | rest]} <-
+           Parser.parse_expression(tokens),
+         {:ok, cases, rest} <- parse_match_cases(rest) do
+      {:ok, {:match, [line: line], [subject, cases]}, drop_newline(rest)}
+    else
+      _ -> :not_match
+    end
+  end
+
+  @spec parse_match_cases([Lexer.token()], [match_case()]) ::
+          {:ok, [match_case()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_cases(tokens, acc \\ [])
+
+  defp parse_match_cases([{:name, _, "case"} | rest], acc) do
+    with {:ok, pattern, rest} <- parse_match_pattern(rest),
+         {:ok, guard, rest} <- parse_match_guard(rest),
+         {:ok, rest} <- Parser.expect_block_start(rest, "case"),
+         {:ok, body, rest} <- Parser.parse_block(rest) do
+      parse_match_cases(rest, [{pattern, guard, body} | acc])
+    end
+  end
+
+  defp parse_match_cases([:dedent | rest], acc), do: {:ok, Enum.reverse(acc), rest}
+  defp parse_match_cases([:newline | rest], acc), do: parse_match_cases(rest, acc)
+  defp parse_match_cases(rest, acc), do: {:ok, Enum.reverse(acc), rest}
+
+  @spec parse_match_guard([Lexer.token()]) ::
+          {:ok, Parser.ast_node() | nil, [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_guard([{:keyword, _, "if"} | rest]) do
+    with {:ok, guard_expr, rest} <- Parser.parse_expression(rest) do
+      {:ok, guard_expr, rest}
+    end
+  end
+
+  defp parse_match_guard(tokens), do: {:ok, nil, tokens}
+
+  @spec parse_match_pattern([Lexer.token()]) ::
+          {:ok, match_pattern(), [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_pattern(tokens) do
+    with {:ok, pattern, rest} <- parse_match_pattern_atom(tokens) do
+      parse_match_or(pattern, rest)
+    end
+  end
+
+  @spec parse_match_or(match_pattern(), [Lexer.token()]) ::
+          {:ok, match_pattern(), [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_or(left, [{:op, _, :pipe} | rest]) do
+    with {:ok, right, rest} <- parse_match_pattern_atom(rest) do
+      alts =
+        case left do
+          {:match_or, _, existing} -> existing ++ [right]
+          _ -> [left, right]
+        end
+
+      parse_match_or({:match_or, [line: Parser.node_line(left)], alts}, rest)
+    end
+  end
+
+  defp parse_match_or(pattern, rest), do: {:ok, pattern, rest}
+
+  @spec parse_match_pattern_atom([Lexer.token()]) ::
+          {:ok, match_pattern(), [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_pattern_atom([{:name, line, "_"} | rest]),
+    do: {:ok, {:match_wildcard, [line: line], []}, rest}
+
+  defp parse_match_pattern_atom([{:keyword, line, "None"} | rest]),
+    do: {:ok, {:lit, [line: line], [nil]}, rest}
+
+  defp parse_match_pattern_atom([{:keyword, line, "True"} | rest]),
+    do: {:ok, {:lit, [line: line], [true]}, rest}
+
+  defp parse_match_pattern_atom([{:keyword, line, "False"} | rest]),
+    do: {:ok, {:lit, [line: line], [false]}, rest}
+
+  defp parse_match_pattern_atom([{:integer, line, value} | rest]),
+    do: {:ok, {:lit, [line: line], [value]}, rest}
+
+  defp parse_match_pattern_atom([{:float, line, value} | rest]),
+    do: {:ok, {:lit, [line: line], [value]}, rest}
+
+  defp parse_match_pattern_atom([{:op, line, :minus}, {:integer, _, value} | rest]),
+    do: {:ok, {:lit, [line: line], [-value]}, rest}
+
+  defp parse_match_pattern_atom([{:op, line, :minus}, {:float, _, value} | rest]),
+    do: {:ok, {:lit, [line: line], [-value]}, rest}
+
+  defp parse_match_pattern_atom([{:string, line, value} | rest]),
+    do: {:ok, {:lit, [line: line], [value]}, rest}
+
+  defp parse_match_pattern_atom([{:fstring, line, parts} | rest]),
+    do: {:ok, {:fstring, [line: line], [parts]}, rest}
+
+  defp parse_match_pattern_atom([{:op, _, :star}, {:name, line, "_"} | rest]),
+    do: {:ok, {:match_star, [line: line], [nil]}, rest}
+
+  defp parse_match_pattern_atom([{:op, _, :star}, {:name, line, name} | rest]),
+    do: {:ok, {:match_star, [line: line], [name]}, rest}
+
+  defp parse_match_pattern_atom([{:op, line, :lbracket} | rest]) do
+    with {:ok, patterns, rest} <- parse_match_pattern_list(rest, []) do
+      {:ok, {:match_sequence, [line: line], patterns}, rest}
+    end
+  end
+
+  defp parse_match_pattern_atom([{:op, line, :lparen} | rest]) do
+    with {:ok, patterns, rest} <- parse_match_pattern_tuple(rest, []) do
+      {:ok, {:match_sequence, [line: line], patterns}, rest}
+    end
+  end
+
+  defp parse_match_pattern_atom([{:op, line, :lbrace} | rest]) do
+    with {:ok, pairs, rest} <- parse_match_mapping_entries(rest, []) do
+      {:ok, {:match_mapping, [line: line], pairs}, rest}
+    end
+  end
+
+  defp parse_match_pattern_atom([{:name, line, name}, {:op, _, :dot}, {:name, _, attr} | rest]) do
+    {:ok, {:getattr, [line: line], [{:var, [line: line], [name]}, attr]}, rest}
+  end
+
+  defp parse_match_pattern_atom([{:name, line, name}, {:op, _, :lparen} | rest]) do
+    with {:ok, pos_patterns, kw_patterns, rest} <- parse_match_class_args(rest, [], []) do
+      {:ok, {:match_class, [line: line], [name, pos_patterns, kw_patterns]}, rest}
+    end
+  end
+
+  defp parse_match_pattern_atom([{:name, line, name} | rest]) do
+    {:ok, {:match_capture, [line: line], [name]}, rest}
+  end
+
+  defp parse_match_pattern_atom(tokens),
+    do: {:error, "unexpected token in match pattern at #{token_line(tokens)}"}
+
+  @spec parse_match_pattern_list([Lexer.token()], [match_pattern()]) ::
+          {:ok, [match_pattern()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_pattern_list([{:op, _, :rbracket} | rest], acc),
+    do: {:ok, Enum.reverse(acc), rest}
+
+  defp parse_match_pattern_list(tokens, acc) do
+    with {:ok, pattern, rest} <- parse_match_pattern(tokens) do
+      case rest do
+        [{:op, _, :comma} | rest] -> parse_match_pattern_list(rest, [pattern | acc])
+        [{:op, _, :rbracket} | rest] -> {:ok, Enum.reverse([pattern | acc]), rest}
+        _ -> {:error, "expected ',' or ']' in match pattern list at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @spec parse_match_pattern_tuple([Lexer.token()], [match_pattern()]) ::
+          {:ok, [match_pattern()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_pattern_tuple([{:op, _, :rparen} | rest], acc),
+    do: {:ok, Enum.reverse(acc), rest}
+
+  defp parse_match_pattern_tuple(tokens, acc) do
+    with {:ok, pattern, rest} <- parse_match_pattern(tokens) do
+      case rest do
+        [{:op, _, :comma} | rest] -> parse_match_pattern_tuple(rest, [pattern | acc])
+        [{:op, _, :rparen} | rest] -> {:ok, Enum.reverse([pattern | acc]), rest}
+        _ -> {:error, "expected ',' or ')' in match pattern tuple at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @spec parse_match_mapping_entries([Lexer.token()], [{Parser.ast_node(), match_pattern()}]) ::
+          {:ok, [{Parser.ast_node(), match_pattern()}], [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_mapping_entries([{:op, _, :rbrace} | rest], acc),
+    do: {:ok, Enum.reverse(acc), rest}
+
+  defp parse_match_mapping_entries(tokens, acc) do
+    with {:ok, key, [{:op, _, :colon} | rest]} <- parse_match_mapping_key(tokens),
+         {:ok, value_pattern, rest} <- parse_match_pattern(rest) do
+      case rest do
+        [{:op, _, :comma} | rest] ->
+          parse_match_mapping_entries(rest, [{key, value_pattern} | acc])
+
+        [{:op, _, :rbrace} | rest] ->
+          {:ok, Enum.reverse([{key, value_pattern} | acc]), rest}
+
+        _ ->
+          {:error, "expected ',' or '}' in match mapping at #{token_line(rest)}"}
+      end
+    else
+      {:ok, _, rest} -> {:error, "expected ':' in match mapping at #{token_line(rest)}"}
+      {:error, _} = error -> error
+    end
+  end
+
+  @spec parse_match_mapping_key([Lexer.token()]) ::
+          {:ok, Parser.ast_node(), [Lexer.token()]} | {:error, String.t()}
+  defp parse_match_mapping_key([{:string, line, value} | rest]),
+    do: {:ok, {:lit, [line: line], [value]}, rest}
+
+  defp parse_match_mapping_key([{:integer, line, value} | rest]),
+    do: {:ok, {:lit, [line: line], [value]}, rest}
+
+  defp parse_match_mapping_key([{:float, line, value} | rest]),
+    do: {:ok, {:lit, [line: line], [value]}, rest}
+
+  defp parse_match_mapping_key([{:keyword, line, "None"} | rest]),
+    do: {:ok, {:lit, [line: line], [nil]}, rest}
+
+  defp parse_match_mapping_key([{:keyword, line, "True"} | rest]),
+    do: {:ok, {:lit, [line: line], [true]}, rest}
+
+  defp parse_match_mapping_key([{:keyword, line, "False"} | rest]),
+    do: {:ok, {:lit, [line: line], [false]}, rest}
+
+  defp parse_match_mapping_key(tokens),
+    do: {:error, "expected literal key in match mapping at #{token_line(tokens)}"}
+
+  @spec parse_match_class_args([Lexer.token()], [match_pattern()], [{String.t(), match_pattern()}]) ::
+          {:ok, [match_pattern()], [{String.t(), match_pattern()}], [Lexer.token()]}
+          | {:error, String.t()}
+  defp parse_match_class_args([{:op, _, :rparen} | rest], pos_acc, kw_acc) do
+    {:ok, Enum.reverse(pos_acc), Enum.reverse(kw_acc), rest}
+  end
+
+  defp parse_match_class_args([{:name, _, name}, {:op, _, :assign} | rest], pos_acc, kw_acc) do
+    with {:ok, pattern, rest} <- parse_match_pattern(rest) do
+      case rest do
+        [{:op, _, :comma} | rest] ->
+          parse_match_class_args(rest, pos_acc, [{name, pattern} | kw_acc])
+
+        [{:op, _, :rparen} | rest] ->
+          {:ok, Enum.reverse(pos_acc), Enum.reverse([{name, pattern} | kw_acc]), rest}
+
+        _ ->
+          {:error, "expected ',' or ')' in match class pattern at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  defp parse_match_class_args(tokens, pos_acc, kw_acc) do
+    with {:ok, pattern, rest} <- parse_match_pattern(tokens) do
+      case rest do
+        [{:op, _, :comma} | rest] ->
+          parse_match_class_args(rest, [pattern | pos_acc], kw_acc)
+
+        [{:op, _, :rparen} | rest] ->
+          {:ok, Enum.reverse([pattern | pos_acc]), Enum.reverse(kw_acc), rest}
+
+        _ ->
+          {:error, "expected ',' or ')' in match class pattern at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  @spec drop_newline([Lexer.token()]) :: [Lexer.token()]
+  defp drop_newline([:newline | rest]), do: rest
+  defp drop_newline(rest), do: rest
+
+  @spec token_line([Lexer.token()]) :: String.t()
+  defp token_line([{_, line, _} | _]), do: "line #{line}"
+  defp token_line(_), do: "end of input"
+end

--- a/lib/pyex/stdlib.ex
+++ b/lib/pyex/stdlib.ex
@@ -33,7 +33,8 @@ defmodule Pyex.Stdlib do
     "base64" => Pyex.Stdlib.Base64,
     "secrets" => Pyex.Stdlib.Secrets,
     "pandas" => Pyex.Stdlib.Pandas,
-    "yaml" => Pyex.Stdlib.Yaml
+    "yaml" => Pyex.Stdlib.Yaml,
+    "decimal" => Pyex.Stdlib.DecimalModule
   }
 
   @doc """

--- a/lib/pyex/stdlib/decimal_module.ex
+++ b/lib/pyex/stdlib/decimal_module.ex
@@ -1,0 +1,42 @@
+defmodule Pyex.Stdlib.DecimalModule do
+  @moduledoc """
+  Python `decimal` module.
+
+  Provides `Decimal` for arbitrary-precision decimal arithmetic.
+  Internally uses Elixir's `Decimal` library and wraps values in
+  `{:pyex_decimal, %Decimal{}}` tagged tuples.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "Decimal" => {:builtin, &decimal_new/1}
+    }
+  end
+
+  @spec decimal_new([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp decimal_new([val]) when is_binary(val) do
+    case parse_decimal(val) do
+      {:ok, decimal} -> {:pyex_decimal, decimal}
+      {:error, msg} -> {:exception, msg}
+    end
+  end
+
+  defp decimal_new([val]) when is_integer(val) do
+    {:pyex_decimal, Decimal.new(val)}
+  end
+
+  defp decimal_new([{:pyex_decimal, _} = d]) do
+    d
+  end
+
+  @spec parse_decimal(String.t()) :: {:ok, Decimal.t()} | {:error, String.t()}
+  defp parse_decimal(val) do
+    {:ok, Decimal.new(val)}
+  rescue
+    Decimal.Error -> {:error, "ValueError: invalid literal for Decimal(): '#{val}'"}
+  end
+end

--- a/test/pyex/builtins_test.exs
+++ b/test/pyex/builtins_test.exs
@@ -986,4 +986,237 @@ defmodule Pyex.BuiltinsTest do
       assert error.message =~ "__dict__"
     end
   end
+
+  describe "open() with keyword args" do
+    test "open(path, 'w', newline='') accepted without error" do
+      fs = Pyex.Filesystem.Memory.new()
+
+      result =
+        Pyex.run!(
+          """
+          f = open("out.csv", "w", newline="")
+          f.write("a,b\\n")
+          f.close()
+          """,
+          filesystem: fs
+        )
+
+      assert result == nil
+    end
+
+    test "open(file='path', mode='w') works" do
+      fs = Pyex.Filesystem.Memory.new()
+
+      result =
+        Pyex.run!(
+          """
+          f = open(file="out.txt", mode="w")
+          f.write("hello")
+          f.close()
+          """,
+          filesystem: fs
+        )
+
+      assert result == nil
+    end
+
+    test "open(path, mode='w') works" do
+      fs = Pyex.Filesystem.Memory.new()
+
+      result =
+        Pyex.run!(
+          """
+          f = open("out.txt", mode="w")
+          f.write("hello")
+          f.close()
+          """,
+          filesystem: fs
+        )
+
+      assert result == nil
+    end
+
+    test "open(path, 'w', encoding='utf-8') accepted" do
+      fs = Pyex.Filesystem.Memory.new()
+
+      result =
+        Pyex.run!(
+          """
+          f = open("out.txt", "w", encoding="utf-8")
+          f.write("hello")
+          f.close()
+          """,
+          filesystem: fs
+        )
+
+      assert result == nil
+    end
+
+    test "backward compat: open(path, 'r') still works" do
+      fs = Pyex.Filesystem.Memory.new(%{"test.txt" => "hello"})
+
+      result =
+        Pyex.run!(
+          """
+          f = open("test.txt", "r")
+          content = f.read()
+          f.close()
+          content
+          """,
+          filesystem: fs
+        )
+
+      assert result == "hello"
+    end
+
+    test "backward compat: open(path) defaults to read mode" do
+      fs = Pyex.Filesystem.Memory.new(%{"test.txt" => "world"})
+
+      result =
+        Pyex.run!(
+          """
+          f = open("test.txt")
+          content = f.read()
+          f.close()
+          content
+          """,
+          filesystem: fs
+        )
+
+      assert result == "world"
+    end
+
+    test "open with multiple kwargs" do
+      fs = Pyex.Filesystem.Memory.new()
+
+      result =
+        Pyex.run!(
+          """
+          f = open("out.csv", "w", newline="", encoding="utf-8")
+          f.write("x,y\\n")
+          f.close()
+          """,
+          filesystem: fs
+        )
+
+      assert result == nil
+    end
+
+    test "open in append mode with kwargs" do
+      fs = Pyex.Filesystem.Memory.new(%{"log.txt" => "line1\n"})
+
+      result =
+        Pyex.run!(
+          """
+          f = open("log.txt", "a", encoding="utf-8")
+          f.write("line2\\n")
+          f.close()
+          """,
+          filesystem: fs
+        )
+
+      assert result == nil
+    end
+
+    test "unexpected open kwarg raises TypeError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run(
+                 ~S|open("out.txt", "w", nope=1)|,
+                 filesystem: Pyex.Filesystem.Memory.new()
+               )
+
+      assert msg =~ "TypeError"
+      assert msg =~ "unexpected keyword argument 'nope'"
+    end
+
+    test "duplicate file positional and keyword raises TypeError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run(
+                 ~S|open("out.txt", file="other.txt")|,
+                 filesystem: Pyex.Filesystem.Memory.new()
+               )
+
+      assert msg =~ "TypeError"
+      assert msg =~ "given by name ('file') and position (1)"
+    end
+  end
+
+  describe "__file__ variable" do
+    test "__file__ returns path when file: option provided" do
+      result =
+        Pyex.run!(
+          "__file__",
+          file: "/tmp/my_script.py"
+        )
+
+      assert result == "/tmp/my_script.py"
+    end
+
+    test "os.path.dirname(__file__) works with file option" do
+      result =
+        Pyex.run!(
+          """
+          import os
+          os.path.dirname(__file__)
+          """,
+          file: "/tmp/scripts/my_script.py"
+        )
+
+      assert result == "/tmp/scripts"
+    end
+
+    test "__file__ raises NameError when not set" do
+      assert {:error, %Pyex.Error{message: msg}} = Pyex.run("__file__")
+      assert msg =~ "NameError"
+    end
+
+    test "__name__ defaults to __main__" do
+      assert Pyex.run!("__name__") == "__main__"
+    end
+
+    test "__name__ is __main__ even with file: option" do
+      result =
+        Pyex.run!(
+          "__name__",
+          file: "/tmp/script.py"
+        )
+
+      assert result == "__main__"
+    end
+
+    test "__file__ with relative path" do
+      result =
+        Pyex.run!(
+          "__file__",
+          file: "scripts/my_script.py"
+        )
+
+      assert result == "scripts/my_script.py"
+    end
+
+    test "if __name__ == '__main__' guard pattern" do
+      result =
+        Pyex.run!("""
+        result = "not main"
+        if __name__ == "__main__":
+            result = "is main"
+        result
+        """)
+
+      assert result == "is main"
+    end
+
+    test "os.path.basename(__file__)" do
+      result =
+        Pyex.run!(
+          """
+          import os
+          os.path.basename(__file__)
+          """,
+          file: "/home/user/projects/app.py"
+        )
+
+      assert result == "app.py"
+    end
+  end
 end

--- a/test/pyex/integration_test.exs
+++ b/test/pyex/integration_test.exs
@@ -1,0 +1,1173 @@
+defmodule Pyex.IntegrationTest do
+  @moduledoc """
+  Complex integration tests that exercise many features together.
+
+  Each test runs a realistic Python program that combines multiple
+  language features to verify correct interaction between subsystems.
+  """
+  use ExUnit.Case, async: true
+
+  # -------------------------------------------------------------------
+  # 1. Financial ledger: Decimal + defaultdict + f-string + classes + loops
+  # -------------------------------------------------------------------
+  describe "financial ledger" do
+    test "category totals with precise Decimal arithmetic and formatted report" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        from collections import defaultdict
+
+        class Transaction:
+            def __init__(self, category, amount, description):
+                self.category = category
+                self.amount = Decimal(amount)
+                self.description = description
+
+        transactions = [
+            Transaction("food", "19.99", "groceries"),
+            Transaction("food", "4.99", "coffee"),
+            Transaction("transport", "50.00", "gas"),
+            Transaction("food", "3.49", "snack"),
+            Transaction("transport", "2.50", "parking"),
+            Transaction("utilities", "120.00", "electric"),
+            Transaction("utilities", "45.99", "internet"),
+        ]
+
+        totals = defaultdict(lambda: Decimal("0"))
+        counts = defaultdict(lambda: 0)
+
+        for t in transactions:
+            totals[t.category] += t.amount
+            counts[t.category] += 1
+
+        lines = []
+        grand_total = Decimal("0")
+        for cat in sorted(totals.keys()):
+            total = totals[cat]
+            avg = total / counts[cat]
+            grand_total += total
+            lines.append(f"{cat:<12} {counts[cat]:>3} items  total: {str(total):>8}  avg: {str(avg)}")
+
+        lines.append(f"{'TOTAL':<12}            total: {str(grand_total):>8}")
+        "\\n".join(lines)
+        """)
+
+      assert result =~ "food"
+      assert result =~ "transport"
+      assert result =~ "utilities"
+      # Verify Decimal precision: 19.99 + 4.99 + 3.49 = 28.47 exactly
+      assert result =~ "28.47"
+      # transport: 50.00 + 2.50 = 52.50
+      assert result =~ "52.50"
+      # utilities: 120.00 + 45.99 = 165.99
+      assert result =~ "165.99"
+      # grand total: 28.47 + 52.50 + 165.99 = 246.96
+      assert result =~ "246.96"
+    end
+
+    test "transaction filtering and balance computation" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+
+        class Account:
+            def __init__(self, name):
+                self.name = name
+                self.balance = Decimal("0")
+                self.history = []
+
+            def deposit(self, amount):
+                self.balance += Decimal(amount)
+                self.history.append(("deposit", Decimal(amount)))
+
+            def withdraw(self, amount):
+                amt = Decimal(amount)
+                if amt > self.balance:
+                    return False
+                self.balance -= amt
+                self.history.append(("withdraw", amt))
+                return True
+
+        acct = Account("checking")
+        acct.deposit("1000.00")
+        acct.deposit("250.50")
+        acct.withdraw("75.25")
+        acct.withdraw("100.00")
+        acct.deposit("30.00")
+
+        deposits = [amt for typ, amt in acct.history if typ == "deposit"]
+        withdrawals = [amt for typ, amt in acct.history if typ == "withdraw"]
+
+        total_in = Decimal("0")
+        for d in deposits:
+            total_in += d
+
+        total_out = Decimal("0")
+        for w in withdrawals:
+            total_out += w
+
+        (str(acct.balance), str(total_in), str(total_out), len(acct.history))
+        """)
+
+      # balance = 1000.00 + 250.50 - 75.25 - 100.00 + 30.00 = 1105.25
+      assert result == {:tuple, ["1105.25", "1280.50", "175.25", 5]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 2. Data pipeline: comprehensions + sorting + string methods +
+  #    generators + dict operations + functional builtins
+  # -------------------------------------------------------------------
+  describe "data pipeline" do
+    test "word frequency analysis with sorting and filtering" do
+      result =
+        Pyex.run!("""
+        text = "the quick brown fox jumps over the lazy dog the fox the dog"
+        words = text.lower().split()
+
+        freq = {}
+        for w in words:
+            freq[w] = freq.get(w, 0) + 1
+
+        # Sort by frequency descending, then alphabetically
+        pairs = sorted(freq.items(), key=lambda p: (-p[1], p[0]))
+
+        # Top words with count > 1
+        top = [(w, c) for w, c in pairs if c > 1]
+
+        # Format as "word(count)" strings
+        formatted = [f"{w}({c})" for w, c in top]
+
+        ", ".join(formatted)
+        """)
+
+      assert result == "the(4), dog(2), fox(2)"
+    end
+
+    test "nested data transformation with comprehensions and unpacking" do
+      result =
+        Pyex.run!("""
+        students = [
+            {"name": "Alice", "grades": [90, 85, 92, 88]},
+            {"name": "Bob", "grades": [75, 80, 70, 85]},
+            {"name": "Carol", "grades": [95, 98, 92, 97]},
+            {"name": "Dave", "grades": [60, 65, 70, 55]},
+        ]
+
+        # Compute average, assign letter grade
+        def letter_grade(avg):
+            if avg >= 90:
+                return "A"
+            elif avg >= 80:
+                return "B"
+            elif avg >= 70:
+                return "C"
+            else:
+                return "F"
+
+        results = []
+        for s in students:
+            avg = sum(s["grades"]) / len(s["grades"])
+            lg = letter_grade(avg)
+            results.append((s["name"], avg, lg))
+
+        # Sort by average descending using sorted (not in-place sort)
+        results = sorted(results, key=lambda r: -r[1])
+
+        # Get names of passing students (C or above)
+        passing = [name for name, avg, lg in results if lg != "F"]
+
+        # Build summary
+        top_name, top_avg, top_grade = results[0]
+
+        (passing, f"{top_name}: {top_avg:.1f} ({top_grade})")
+        """)
+
+      assert result == {:tuple, [["Carol", "Alice", "Bob"], "Carol: 95.5 (A)"]}
+    end
+
+    test "generator pipeline with chained transformations" do
+      result =
+        Pyex.run!("""
+        def squares(n):
+            for i in range(n):
+                yield i * i
+
+        def evens(gen):
+            for x in gen:
+                if x % 2 == 0:
+                    yield x
+
+        def take(gen, n):
+            count = 0
+            for x in gen:
+                if count >= n:
+                    break
+                yield x
+                count += 1
+
+        # Pipeline: generate squares -> filter evens -> take first 5
+        pipeline = take(evens(squares(100)), 5)
+        list(pipeline)
+        """)
+
+      # squares: 0,1,4,9,16,25,36,49,64,81,...
+      # evens: 0,4,16,36,64,...
+      assert result == [0, 4, 16, 36, 64]
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 3. CSV/File report: open() + csv module + defaultdict + f-strings
+  # -------------------------------------------------------------------
+  describe "CSV report processing" do
+    test "read CSV, aggregate, and write formatted report" do
+      csv_data =
+        "name,department,salary\nAlice,Engineering,95000\nBob,Marketing,72000\nCarol,Engineering,105000\nDave,Marketing,68000\nEve,Engineering,88000\n"
+
+      fs = Pyex.Filesystem.Memory.new(%{"employees.csv" => csv_data})
+
+      result =
+        Pyex.run!(
+          """
+          import csv
+          from collections import defaultdict
+
+          # Read CSV
+          f = open("employees.csv", "r")
+          reader = csv.DictReader(f)
+          rows = list(reader)
+          f.close()
+
+          # Aggregate by department
+          dept_salaries = defaultdict(lambda: [])
+          for row in rows:
+              dept_salaries[row["department"]].append(int(row["salary"]))
+
+          # Build report
+          lines = []
+          for dept in sorted(dept_salaries.keys()):
+              salaries = dept_salaries[dept]
+              avg = sum(salaries) / len(salaries)
+              lines.append(f"{dept}: {len(salaries)} employees, avg ${avg:,.0f}")
+
+          # Write report
+          report = "\\n".join(lines)
+          out = open("report.txt", "w")
+          out.write(report)
+          out.close()
+
+          report
+          """,
+          filesystem: fs
+        )
+
+      assert result =~ "Engineering: 3 employees, avg $96,000"
+      assert result =~ "Marketing: 2 employees, avg $70,000"
+    end
+
+    test "parse and transform CSV data with list comprehensions" do
+      csv_data = "product,price,quantity\nWidget,9.99,100\nGadget,24.99,50\nGizmo,4.99,200\n"
+      fs = Pyex.Filesystem.Memory.new(%{"inventory.csv" => csv_data})
+
+      result =
+        Pyex.run!(
+          """
+          import csv
+
+          f = open("inventory.csv", "r")
+          reader = csv.DictReader(f)
+          items = list(reader)
+          f.close()
+
+          # Compute total value per item
+          valued = [(row["product"], float(row["price"]) * int(row["quantity"]))
+                    for row in items]
+
+          # Sort by value descending using sorted()
+          valued = sorted(valued, key=lambda x: -x[1])
+
+          # Format output
+          total = sum(v for _, v in valued)
+          top_product, top_value = valued[0]
+
+          (top_product, len(items), total)
+          """,
+          filesystem: fs
+        )
+
+      # Gadget: 24.99*50=1249.5, Widget: 9.99*100=999, Gizmo: 4.99*200=998
+      # Total: 3246.5, top = Gadget
+      assert result == {:tuple, ["Gadget", 3, 3246.5]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 4. Class hierarchy: inheritance + super + dunder + exceptions +
+  #    decorators
+  # -------------------------------------------------------------------
+  describe "class hierarchy" do
+    test "shape hierarchy with polymorphism and dunder methods" do
+      result =
+        Pyex.run!("""
+        import math
+
+        class Shape:
+            def __init__(self, name):
+                self.name = name
+
+            def area(self):
+                return 0
+
+            def __str__(self):
+                return f"{self.name}: area={self.area():.2f}"
+
+        class Circle(Shape):
+            def __init__(self, radius):
+                super().__init__("Circle")
+                self.radius = radius
+
+            def area(self):
+                return math.pi * self.radius ** 2
+
+        class Rectangle(Shape):
+            def __init__(self, width, height):
+                super().__init__("Rectangle")
+                self.width = width
+                self.height = height
+
+            def area(self):
+                return self.width * self.height
+
+        class Square(Rectangle):
+            def __init__(self, side):
+                super().__init__(side, side)
+                self.name = "Square"
+
+        shapes = [Circle(5), Rectangle(4, 6), Square(3)]
+
+        # Polymorphic area computation
+        total_area = sum(s.area() for s in shapes)
+
+        # String representations
+        labels = [str(s) for s in shapes]
+
+        # Type checking
+        checks = (
+            isinstance(shapes[2], Rectangle),
+            isinstance(shapes[2], Shape),
+            isinstance(shapes[0], Rectangle),
+        )
+
+        (labels, checks, total_area > 100)
+        """)
+
+      assert {:tuple, [labels, checks, area_check]} = result
+
+      assert length(labels) == 3
+      assert Enum.at(labels, 0) =~ "Circle: area="
+      assert Enum.at(labels, 1) =~ "Rectangle: area=24.00"
+      assert Enum.at(labels, 2) =~ "Square: area=9.00"
+      assert checks == {:tuple, [true, true, false]}
+      # pi*25 + 24 + 9 = ~111.54
+      assert area_check == true
+    end
+
+    test "exception hierarchy with try/except and custom exceptions" do
+      result =
+        Pyex.run!("""
+        class AppError(Exception):
+            pass
+
+        class ValidationError(AppError):
+            pass
+
+        class NotFoundError(AppError):
+            pass
+
+        def validate(value):
+            if not isinstance(value, int):
+                raise ValidationError("must be an integer")
+            if value < 0:
+                raise ValidationError("must be non-negative")
+            if value > 100:
+                raise NotFoundError("value out of range")
+            return value * 2
+
+        results = []
+        test_inputs = [42, -1, "hello", 200, 0]
+
+        for inp in test_inputs:
+            try:
+                r = validate(inp)
+                results.append(("ok", r))
+            except ValidationError as e:
+                results.append(("validation", str(e)))
+            except NotFoundError as e:
+                results.append(("not_found", str(e)))
+
+        results
+        """)
+
+      assert result == [
+               {:tuple, ["ok", 84]},
+               {:tuple, ["validation", "must be non-negative"]},
+               {:tuple, ["validation", "must be an integer"]},
+               {:tuple, ["not_found", "value out of range"]},
+               {:tuple, ["ok", 0]}
+             ]
+    end
+
+    test "decorator pattern with class-based call counting" do
+      result =
+        Pyex.run!("""
+        class CallCounter:
+            def __init__(self, func):
+                self.func = func
+                self.count = 0
+                self.last_result = None
+
+            def __call__(self, *args, **kwargs):
+                self.count += 1
+                self.last_result = self.func(*args, **kwargs)
+                return self.last_result
+
+        @CallCounter
+        def add(a, b):
+            return a + b
+
+        @CallCounter
+        def multiply(a, b):
+            return a * b
+
+        add(3, 4)
+        add(10, 20)
+        add(1, 1)
+        multiply(5, 6)
+
+        (add.count, add.last_result, multiply.count, multiply.last_result)
+        """)
+
+      assert result == {:tuple, [3, 2, 1, 30]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 5. Text processing: re + string methods + Counter + comprehensions
+  # -------------------------------------------------------------------
+  describe "text processing" do
+    test "log parsing with regex and Counter" do
+      result =
+        Pyex.run!("""
+        import re
+        from collections import Counter
+
+        logs = [
+            "2024-01-15 INFO  User login: alice",
+            "2024-01-15 ERROR Database connection failed",
+            "2024-01-15 INFO  User login: bob",
+            "2024-01-15 WARN  Disk usage at 85%",
+            "2024-01-16 ERROR Timeout on API call",
+            "2024-01-16 INFO  User login: alice",
+            "2024-01-16 INFO  User logout: bob",
+            "2024-01-16 ERROR Database connection failed",
+        ]
+
+        # Parse log levels
+        levels = []
+        for line in logs:
+            match = re.search(r"(INFO|ERROR|WARN)", line)
+            if match:
+                levels.append(match.group(1))
+
+        level_counts = Counter(levels)
+
+        # Extract unique users
+        users = set()
+        for line in logs:
+            match = re.search(r"User (?:login|logout): (\\w+)", line)
+            if match:
+                users.add(match.group(1))
+
+        # Count errors per day using a plain dict
+        error_days = {}
+        for line in logs:
+            if "ERROR" in line:
+                date = line[:10]
+                error_days[date] = error_days.get(date, 0) + 1
+
+        (level_counts["INFO"], level_counts["ERROR"], level_counts["WARN"],
+         sorted(list(users)), error_days)
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  4,
+                  3,
+                  1,
+                  ["alice", "bob"],
+                  %{"2024-01-15" => 1, "2024-01-16" => 2}
+                ]}
+    end
+
+    test "text template rendering with string operations" do
+      code = ~S"""
+      def render_template(template, context):
+          result = template
+          for key, value in context.items():
+              placeholder = "{{" + key + "}}"
+              result = result.replace(placeholder, str(value))
+          return result
+
+      template = "Dear {{name}},\nYour order #{{order_id}} of {{quantity}} items totaling ${{total}} has shipped."
+
+      context = {
+          "name": "Alice",
+          "order_id": 12345,
+          "quantity": 3,
+          "total": "29.97",
+      }
+
+      rendered = render_template(template, context)
+      lines = rendered.split("\n")
+
+      (lines[0], "shipped" in lines[1], lines[1].count("$"))
+      """
+
+      result = Pyex.run!(code)
+
+      assert result == {:tuple, ["Dear Alice,", true, 1]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 6. Algorithm implementations: recursion + closures + data structures
+  # -------------------------------------------------------------------
+  describe "algorithms" do
+    test "merge sort with recursion and list slicing" do
+      result =
+        Pyex.run!("""
+        def merge_sort(arr):
+            if len(arr) <= 1:
+                return arr
+            mid = len(arr) // 2
+            left = merge_sort(arr[:mid])
+            right = merge_sort(arr[mid:])
+            return merge(left, right)
+
+        def merge(left, right):
+            result = []
+            i = 0
+            j = 0
+            while i < len(left) and j < len(right):
+                if left[i] <= right[j]:
+                    result.append(left[i])
+                    i += 1
+                else:
+                    result.append(right[j])
+                    j += 1
+            while i < len(left):
+                result.append(left[i])
+                i += 1
+            while j < len(right):
+                result.append(right[j])
+                j += 1
+            return result
+
+        data = [38, 27, 43, 3, 9, 82, 10]
+        merge_sort(data)
+        """)
+
+      assert result == [3, 9, 10, 27, 38, 43, 82]
+    end
+
+    test "binary search with while loop and edge cases" do
+      result =
+        Pyex.run!("""
+        def binary_search(arr, target):
+            lo = 0
+            hi = len(arr) - 1
+            while lo <= hi:
+                mid = (lo + hi) // 2
+                if arr[mid] == target:
+                    return mid
+                elif arr[mid] < target:
+                    lo = mid + 1
+                else:
+                    hi = mid - 1
+            return -1
+
+        data = [2, 5, 8, 12, 16, 23, 38, 56, 72, 91]
+
+        results = []
+        for target in [23, 2, 91, 50, 8]:
+            results.append(binary_search(data, target))
+
+        results
+        """)
+
+      assert result == [5, 0, 9, -1, 2]
+    end
+
+    test "memoized fibonacci with closure and dict cache" do
+      result =
+        Pyex.run!("""
+        def memoize(func):
+            cache = {}
+            def wrapper(n):
+                if n not in cache:
+                    cache[n] = func(n)
+                return cache[n]
+            return wrapper
+
+        @memoize
+        def fib(n):
+            if n <= 1:
+                return n
+            return fib(n - 1) + fib(n - 2)
+
+        # Compute several fibonacci numbers
+        results = [fib(i) for i in range(15)]
+
+        (results, fib(10), fib(0), fib(1))
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377],
+                  55,
+                  0,
+                  1
+                ]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 7. Stateful processing: classes + closures + itertools + generators
+  # -------------------------------------------------------------------
+  describe "stateful processing" do
+    test "state machine with class and enum-like pattern" do
+      result =
+        Pyex.run!("""
+        class StateMachine:
+            def __init__(self):
+                self.state = "idle"
+                self.transitions = {
+                    ("idle", "start"): "running",
+                    ("running", "pause"): "paused",
+                    ("paused", "resume"): "running",
+                    ("running", "stop"): "stopped",
+                    ("paused", "stop"): "stopped",
+                }
+                self.history = []
+
+            def send(self, event):
+                key = (self.state, event)
+                if key in self.transitions:
+                    old = self.state
+                    self.state = self.transitions[key]
+                    self.history.append((old, event, self.state))
+                    return True
+                return False
+
+        sm = StateMachine()
+        events = ["start", "pause", "stop", "resume", "stop"]
+        outcomes = []
+
+        for event in events:
+            ok = sm.send(event)
+            outcomes.append((event, ok, sm.state))
+
+        final_state = sm.state
+        valid_transitions = len([ok for _, ok, _ in outcomes if ok])
+        history_len = len(sm.history)
+
+        (final_state, valid_transitions, history_len, outcomes[-1])
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  "stopped",
+                  3,
+                  3,
+                  {:tuple, ["stop", false, "stopped"]}
+                ]}
+    end
+
+    test "pipeline builder with closures and chaining" do
+      result =
+        Pyex.run!("""
+        def make_pipeline(*funcs):
+            def run(data):
+                result = data
+                for f in funcs:
+                    result = f(result)
+                return result
+            return run
+
+        # Define transformation functions
+        def double(x):
+            return [item * 2 for item in x]
+
+        def filter_big(x):
+            return [item for item in x if item > 10]
+
+        def sort_desc(x):
+            return sorted(x, reverse=True)
+
+        def take_three(x):
+            return x[:3]
+
+        pipeline = make_pipeline(double, filter_big, sort_desc, take_three)
+        data = [1, 8, 3, 12, 5, 9, 7, 15, 2]
+        pipeline(data)
+        """)
+
+      # double: [2, 16, 6, 24, 10, 18, 14, 30, 4]
+      # filter_big: [16, 24, 18, 14, 30]
+      # sort_desc: [30, 24, 18, 16, 14]
+      # take_three: [30, 24, 18]
+      assert result == [30, 24, 18]
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 8. JSON + data structures: json module + nested dicts + list ops
+  # -------------------------------------------------------------------
+  describe "JSON data processing" do
+    test "parse JSON, transform, and serialize" do
+      result =
+        Pyex.run!("""
+        import json
+
+        raw = '{"users": [{"name": "Alice", "age": 30, "active": true}, {"name": "Bob", "age": 25, "active": false}, {"name": "Carol", "age": 35, "active": true}]}'
+
+        data = json.loads(raw)
+
+        # Filter active users and transform
+        active = [
+            {"name": u["name"].upper(), "age": u["age"]}
+            for u in data["users"]
+            if u["active"]
+        ]
+
+        # Add computed field
+        avg_age = sum(u["age"] for u in active) / len(active)
+
+        output = {
+            "active_users": active,
+            "count": len(active),
+            "average_age": avg_age,
+        }
+
+        result_json = json.dumps(output)
+        parsed_back = json.loads(result_json)
+
+        (parsed_back["count"],
+         parsed_back["average_age"],
+         parsed_back["active_users"][0]["name"])
+        """)
+
+      assert result == {:tuple, [2, 32.5, "ALICE"]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 9. Math + itertools: combinations, permutations, functional patterns
+  # -------------------------------------------------------------------
+  describe "math and combinatorics" do
+    test "itertools combinations with filtering and aggregation" do
+      result =
+        Pyex.run!("""
+        from itertools import combinations, permutations
+
+        # Find all pairs from a list that sum to a target
+        numbers = [1, 3, 5, 7, 9, 11]
+        target = 12
+
+        pairs = [(a, b) for a, b in combinations(numbers, 2) if a + b == target]
+
+        # Count permutations of length 2 from first 4 numbers
+        perm_count = len(list(permutations(numbers[:4], 2)))
+
+        (sorted(pairs), perm_count)
+        """)
+
+      # pairs summing to 12: (1,11), (3,9), (5,7)
+      assert result ==
+               {:tuple,
+                [
+                  [{:tuple, [1, 11]}, {:tuple, [3, 9]}, {:tuple, [5, 7]}],
+                  12
+                ]}
+    end
+
+    test "mathematical computations with math module" do
+      result =
+        Pyex.run!("""
+        import math
+
+        # Compute stats manually
+        data = [2.5, 3.7, 1.2, 4.8, 3.3]
+
+        mean = sum(data) / len(data)
+
+        # Variance
+        variance = sum((x - mean) ** 2 for x in data) / len(data)
+        stddev = math.sqrt(variance)
+
+        # Geometric mean via logs
+        log_sum = sum(math.log(x) for x in data)
+        geo_mean = math.exp(log_sum / len(data))
+
+        # Round results
+        (round(mean, 2), round(stddev, 2), round(geo_mean, 2))
+        """)
+
+      # Banker's rounding: stddev ~1.1489 rounds to 1.15 or 1.2 depending on rounding mode
+      assert {:tuple, [mean, stddev, geo_mean]} = result
+      assert mean == 3.1
+      assert stddev >= 1.14 and stddev <= 1.2
+      assert geo_mean == 2.81
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 10. Complex string + dict + set operations
+  # -------------------------------------------------------------------
+  describe "complex data operations" do
+    test "set operations for data analysis" do
+      result =
+        Pyex.run!("""
+        enrolled_math = {"Alice", "Bob", "Carol", "Dave", "Eve"}
+        enrolled_science = {"Bob", "Carol", "Frank", "Grace"}
+        enrolled_english = {"Alice", "Carol", "Dave", "Grace", "Heidi"}
+
+        # Students in all three classes
+        all_three = enrolled_math & enrolled_science & enrolled_english
+
+        # Students in math OR science but NOT english
+        math_or_sci_not_eng = (enrolled_math | enrolled_science) - enrolled_english
+
+        # Students in exactly one class
+        only_math = enrolled_math - enrolled_science - enrolled_english
+        only_science = enrolled_science - enrolled_math - enrolled_english
+        only_english = enrolled_english - enrolled_math - enrolled_science
+
+        exactly_one = only_math | only_science | only_english
+
+        (sorted(list(all_three)),
+         sorted(list(math_or_sci_not_eng)),
+         sorted(list(exactly_one)))
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  ["Carol"],
+                  ["Bob", "Eve", "Frank"],
+                  ["Eve", "Frank", "Heidi"]
+                ]}
+    end
+
+    test "nested dict comprehension with complex transformation" do
+      result =
+        Pyex.run!("""
+        raw_scores = {
+            "team_a": [85, 90, 78, 92],
+            "team_b": [70, 88, 95, 80],
+            "team_c": [92, 88, 84, 96],
+        }
+
+        # Build summary dict with comprehension
+        summary = {
+            team: {
+                "min": min(scores),
+                "max": max(scores),
+                "avg": sum(scores) / len(scores),
+                "range": max(scores) - min(scores),
+            }
+            for team, scores in raw_scores.items()
+        }
+
+        # Find team with highest average
+        best_team = max(summary.keys(), key=lambda t: summary[t]["avg"])
+
+        # Get all teams with range < 15
+        consistent = sorted([t for t in summary if summary[t]["range"] < 15])
+
+        (best_team, summary[best_team]["avg"], consistent)
+        """)
+
+      assert result == {:tuple, ["team_c", 90.0, ["team_a", "team_c"]]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 11. Context managers + file I/O + with statement
+  # -------------------------------------------------------------------
+  describe "context managers" do
+    test "with statement for file read and processing" do
+      fs =
+        Pyex.Filesystem.Memory.new(%{
+          "data.txt" => "hello world\nfoo bar\nbaz qux\n"
+        })
+
+      result =
+        Pyex.run!(
+          """
+          with open("data.txt", "r") as f:
+              content = f.read()
+
+          # Process outside the with block
+          lines = content.strip().split("\\n")
+          words = []
+          for line in lines:
+              words.extend(line.split())
+
+          upper_words = [w.upper() for w in words if len(w) > 2]
+          sorted(upper_words)
+          """,
+          filesystem: fs
+        )
+
+      assert result == ["BAR", "BAZ", "FOO", "HELLO", "QUX", "WORLD"]
+    end
+
+    test "write file in context manager and read it back" do
+      fs = Pyex.Filesystem.Memory.new()
+
+      result =
+        Pyex.run!(
+          """
+          # Write data
+          with open("output.txt", "w") as f:
+              for i in range(5):
+                  f.write(f"Line {i + 1}: value={i * 10}\\n")
+
+          # Read it back
+          with open("output.txt", "r") as f:
+              content = f.read()
+
+          lines = content.strip().split("\\n")
+          (len(lines), lines[0], lines[-1])
+          """,
+          filesystem: fs
+        )
+
+      assert result == {:tuple, [5, "Line 1: value=0", "Line 5: value=40"]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 12. Hash + encoding: hashlib + base64 combined
+  # -------------------------------------------------------------------
+  describe "encoding and hashing" do
+    test "hash computation and base64 encoding" do
+      result =
+        Pyex.run!("""
+        import hashlib
+        import base64
+
+        message = "Hello, World!"
+
+        # SHA-256 hash
+        sha_hash = hashlib.sha256(message).hexdigest()
+
+        # Base64 encode/decode roundtrip
+        encoded = base64.b64encode(message)
+        decoded = base64.b64decode(encoded)
+
+        # MD5 for comparison
+        md5_hash = hashlib.md5(message).hexdigest()
+
+        (len(sha_hash) == 64,
+         decoded == message,
+         len(md5_hash) == 32,
+         sha_hash[:8])
+        """)
+
+      assert result == {:tuple, [true, true, true, "dffd6021"]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 13. Walrus operator + complex conditionals
+  # -------------------------------------------------------------------
+  describe "walrus operator in complex contexts" do
+    test "walrus in while loop for input processing simulation" do
+      result =
+        Pyex.run!("""
+        data = [5, 12, 3, 18, 7, 25, 1, 9]
+        idx = 0
+        big_values = []
+
+        while idx < len(data):
+            if (val := data[idx]) > 10:
+                big_values.append(val)
+            idx += 1
+
+        # Also use walrus in list comprehension filter
+        doubled_big = [y for x in data if (y := x * 2) > 20]
+
+        (big_values, doubled_big)
+        """)
+
+      assert result == {:tuple, [[12, 18, 25], [24, 36, 50]]}
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 14. Match/case with complex patterns
+  # -------------------------------------------------------------------
+  describe "match/case patterns" do
+    test "match with literal, list, and wildcard patterns" do
+      result =
+        Pyex.run!("""
+        def classify(value):
+            match value:
+                case 0:
+                    return "zero"
+                case 1:
+                    return "one"
+                case -1:
+                    return "neg one"
+                case "hello":
+                    return "greeting"
+                case "":
+                    return "empty string"
+                case [x]:
+                    return f"single: {x}"
+                case [x, y]:
+                    return f"pair: {x}, {y}"
+                case [x, y, z]:
+                    return f"triple: {x}, {y}, {z}"
+                case None:
+                    return "none"
+                case True:
+                    return "true"
+                case _:
+                    return "other"
+
+        results = [
+            classify(0),
+            classify(1),
+            classify(-1),
+            classify("hello"),
+            classify(""),
+            classify([99]),
+            classify([1, 2]),
+            classify([1, 2, 3]),
+            classify(None),
+            classify(42),
+        ]
+        results
+        """)
+
+      assert result == [
+               "zero",
+               "one",
+               "neg one",
+               "greeting",
+               "empty string",
+               "single: 99",
+               "pair: 1, 2",
+               "triple: 1, 2, 3",
+               "none",
+               "other"
+             ]
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 15. Datetime + string formatting end-to-end
+  # -------------------------------------------------------------------
+  describe "datetime processing" do
+    test "date parsing and arithmetic" do
+      result =
+        Pyex.run!("""
+        from datetime import datetime, timedelta
+
+        # Parse dates
+        start = datetime.fromisoformat("2024-01-15")
+        end = datetime.fromisoformat("2024-03-01")
+
+        # Compute difference
+        diff = end - start
+        days = diff.days
+
+        # Generate weekly checkpoints
+        checkpoints = []
+        current = start
+        week = timedelta(days=7)
+        while current < end:
+            checkpoints.append(str(current)[:10])
+            current = current + week
+
+        (days, len(checkpoints), checkpoints[0], checkpoints[-1])
+        """)
+
+      assert {:tuple, [days, count, first, _last]} = result
+      assert days == 46
+      assert count > 0
+      assert first == "2024-01-15"
+    end
+  end
+
+  # -------------------------------------------------------------------
+  # 16. Defaultdict + Decimal combined (single-level nesting)
+  # -------------------------------------------------------------------
+  describe "defaultdict with Decimal combined" do
+    test "expense tracker with categories and precise totals" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        from collections import defaultdict
+
+        expenses = [
+            ("2024-01", "rent", "1500.00"),
+            ("2024-01", "food", "423.50"),
+            ("2024-01", "food", "89.99"),
+            ("2024-02", "rent", "1500.00"),
+            ("2024-02", "food", "387.25"),
+            ("2024-02", "transport", "150.00"),
+            ("2024-01", "transport", "125.75"),
+        ]
+
+        # Track by category using compound keys "month:category"
+        totals = defaultdict(lambda: Decimal("0"))
+
+        for month, category, amount in expenses:
+            key = month + ":" + category
+            totals[key] += Decimal(amount)
+
+        # Compute monthly totals
+        jan_total = Decimal("0")
+        feb_total = Decimal("0")
+        for key in totals:
+            month = key.split(":")[0]
+            if month == "2024-01":
+                jan_total += totals[key]
+            elif month == "2024-02":
+                feb_total += totals[key]
+
+        jan_food = totals["2024-01:food"]
+
+        (str(jan_total), str(feb_total), str(jan_food),
+         str(jan_food == Decimal("513.49")))
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  "2139.24",
+                  "2037.25",
+                  "513.49",
+                  "True"
+                ]}
+    end
+  end
+end

--- a/test/pyex/interpreter_test.exs
+++ b/test/pyex/interpreter_test.exs
@@ -2427,4 +2427,249 @@ defmodule Pyex.InterpreterTest do
       assert Pyex.run!(code) == "hello"
     end
   end
+
+  describe "f-string format specs" do
+    test "float formatting with .2f" do
+      assert Pyex.run!("""
+             val = 3.14159
+             f"{val:.2f}"
+             """) == "3.14"
+    end
+
+    test "left-align string" do
+      assert Pyex.run!("""
+             f"{'ACCOUNT':<14}"
+             """) == "ACCOUNT       "
+    end
+
+    test "right-align with comma grouping and .2f" do
+      assert Pyex.run!("""
+             v = 1234567.891
+             f"{v:>18,.2f}"
+             """) == "      1,234,567.89"
+    end
+
+    test "right-align integer" do
+      assert Pyex.run!("""
+             count = 42
+             f"{count:>6}"
+             """) == "    42"
+    end
+
+    test "center with fill char" do
+      assert Pyex.run!("""
+             f"{'hi':*^10}"
+             """) == "****hi****"
+    end
+
+    test "subscript expression with format spec" do
+      assert Pyex.run!("""
+             info = {"count": 42}
+             f"{info['count']:>6}"
+             """) == "    42"
+    end
+
+    test "zero-padded integer" do
+      assert Pyex.run!("""
+             n = 7
+             f"{n:05d}"
+             """) == "00007"
+    end
+
+    test "mixed plain and formatted expressions" do
+      assert Pyex.run!("""
+             name = "Alice"
+             score = 95.5
+             f"{name} scored {score:.1f}"
+             """) == "Alice scored 95.5"
+    end
+
+    test "backward compat: f-strings without format specs still work" do
+      assert Pyex.run!("""
+             x = 42
+             f"value is {x}"
+             """) == "value is 42"
+    end
+
+    # --- Hex / Octal / Binary integer formatting ---
+
+    test "hex formatting lowercase :x" do
+      assert Pyex.run!(~s|f"{255:x}"|) == "ff"
+    end
+
+    test "hex formatting uppercase :X" do
+      assert Pyex.run!(~s|f"{255:X}"|) == "FF"
+    end
+
+    test "hex with alt form #x shows 0x prefix" do
+      assert Pyex.run!(~s|f"{255:#x}"|) == "0xff"
+    end
+
+    test "hex with alt form #X shows 0X prefix" do
+      assert Pyex.run!(~s|f"{255:#X}"|) == "0XFF"
+    end
+
+    test "octal formatting :o" do
+      assert Pyex.run!(~s|f"{255:o}"|) == "377"
+    end
+
+    test "octal with alt form #o" do
+      assert Pyex.run!(~s|f"{255:#o}"|) == "0o377"
+    end
+
+    test "binary formatting :b" do
+      assert Pyex.run!(~s|f"{10:b}"|) == "1010"
+    end
+
+    test "binary with alt form #b" do
+      assert Pyex.run!(~s|f"{10:#b}"|) == "0b1010"
+    end
+
+    test "hex of zero" do
+      assert Pyex.run!(~s|f"{0:x}"|) == "0"
+    end
+
+    test "hex of negative number" do
+      assert Pyex.run!(~s|f"{-42:x}"|) == "-2a"
+    end
+
+    test "hex negative with alt form" do
+      assert Pyex.run!(~s|f"{-42:#x}"|) == "-0x2a"
+    end
+
+    # --- Percentage formatting ---
+
+    test "percentage formatting :%" do
+      assert Pyex.run!(~s|f"{0.125:.1%}"|) == "12.5%"
+    end
+
+    test "percentage with default precision" do
+      assert Pyex.run!(~s|f"{0.5:%}"|) == "50.000000%"
+    end
+
+    test "percentage zero" do
+      assert Pyex.run!(~s|f"{0:.0%}"|) == "0%"
+    end
+
+    # --- Scientific notation ---
+
+    test "scientific notation lowercase :e" do
+      result = Pyex.run!(~s|f"{1234.5:.3e}"|)
+      assert result == "1.23e+03"
+    end
+
+    test "scientific notation uppercase :E" do
+      result = Pyex.run!(~s|f"{1234.5:.3E}"|)
+      assert result == "1.23E+03"
+    end
+
+    test "scientific notation default precision :e" do
+      result = Pyex.run!(~s|f"{1234.5:e}"|)
+      assert String.contains?(result, "e+")
+    end
+
+    # --- String formatting ---
+
+    test "string type :s" do
+      assert Pyex.run!(~s|f"{'hello':s}"|) == "hello"
+    end
+
+    test "string truncation with precision :.3s" do
+      assert Pyex.run!(~s|f"{'hello':.3s}"|) == "hel"
+    end
+
+    test "string left-aligned in width" do
+      assert Pyex.run!(~s|f"{'hi':<10s}"|) == "hi        "
+    end
+
+    # --- Underscore grouping ---
+
+    test "underscore grouping :_" do
+      assert Pyex.run!("""
+             f"{1000000:_}"
+             """) == "1_000_000"
+    end
+
+    # --- Comma grouping with integers ---
+
+    test "comma grouping with integer :," do
+      assert Pyex.run!("""
+             f"{1234567:,}"
+             """) == "1,234,567"
+    end
+
+    # --- Zero padding ---
+
+    test "zero padding float :08.2f" do
+      assert Pyex.run!("""
+             f"{3.14:08.2f}"
+             """) == "00003.14"
+    end
+
+    test "zero padding integer :06" do
+      assert Pyex.run!("""
+             f"{42:06}"
+             """) == "000042"
+    end
+
+    # --- Width without explicit alignment ---
+
+    test "width only on integer defaults to right-align" do
+      assert Pyex.run!(~s|f"{42:6}"|) == "    42"
+    end
+
+    test "width only on string defaults to left-align" do
+      assert Pyex.run!(~s|f"{'hi':10}"|) == "hi        "
+    end
+
+    # --- = alignment (pad after sign) ---
+
+    test "= alignment pads after sign" do
+      result = Pyex.run!(~s|f"{-42:=10d}"|)
+      assert result == "-       42"
+      assert String.length(result) == 10
+    end
+
+    # --- Edge cases ---
+
+    test "empty format spec is identity" do
+      assert Pyex.run!("""
+             x = 42
+             f"{x:}"
+             """) == "42"
+    end
+
+    test "format spec on expression result" do
+      assert Pyex.run!("""
+             f"{1 + 2:.2f}"
+             """) == "3.00"
+    end
+
+    test "multiple formatted expressions in one f-string" do
+      assert Pyex.run!("""
+             a = 3.14
+             b = 42
+             f"{a:.1f} and {b:05d}"
+             """) == "3.1 and 00042"
+    end
+
+    test "format spec with float default precision (.6f)" do
+      assert Pyex.run!(~s|f"{3.14:f}"|) == "3.140000"
+    end
+
+    test "invalid format type raises ValueError" do
+      assert {:error, %Pyex.Error{message: msg}} = Pyex.run(~s|f"{42:q}"|)
+      assert msg =~ "ValueError"
+    end
+
+    test "format :d on string raises ValueError" do
+      assert {:error, %Pyex.Error{message: msg}} = Pyex.run(~s|f"{'hi':d}"|)
+      assert msg =~ "ValueError"
+    end
+
+    test "format :f on string raises ValueError" do
+      assert {:error, %Pyex.Error{message: msg}} = Pyex.run(~s|f"{'hi':f}"|)
+      assert msg =~ "ValueError"
+    end
+  end
 end

--- a/test/pyex/lambda_test.exs
+++ b/test/pyex/lambda_test.exs
@@ -794,6 +794,41 @@ defmodule Pyex.LambdaTest do
     end
   end
 
+  describe "module globals" do
+    test "invoke defines __name__ as __main__" do
+      source = """
+      import fastapi
+      app = fastapi.FastAPI()
+
+      @app.get("/globals")
+      def globals():
+          return {"name": __name__}
+      """
+
+      assert {:ok, resp} = Lambda.invoke(source, %{method: "GET", path: "/globals"})
+      assert resp.status == 200
+      assert resp.body == %{"name" => "__main__"}
+    end
+
+    test "boot exposes __file__ when ctx.file is set" do
+      ctx = Pyex.Ctx.new(file: "/tmp/app.py")
+
+      source = """
+      import fastapi
+      app = fastapi.FastAPI()
+
+      @app.get("/globals")
+      def globals():
+          return {"name": __name__, "file": __file__}
+      """
+
+      assert {:ok, app} = Lambda.boot(source, ctx: ctx)
+      assert {:ok, resp, _app} = Lambda.handle(app, %{method: "GET", path: "/globals"})
+      assert resp.status == 200
+      assert resp.body == %{"name" => "__main__", "file" => "/tmp/app.py"}
+    end
+  end
+
   describe "pydantic body parameters" do
     test "POST handler with pydantic model auto-parses JSON body" do
       source = """

--- a/test/pyex/stdlib/collections_test.exs
+++ b/test/pyex/stdlib/collections_test.exs
@@ -302,4 +302,202 @@ defmodule Pyex.Stdlib.CollectionsTest do
       assert result == 10
     end
   end
+
+  describe "defaultdict with lambda factories" do
+    test "defaultdict(lambda: 0) with augmented assignment" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        d["a"] += 1
+        d["a"] += 1
+        d["b"] += 5
+        (d["a"], d["b"])
+        """)
+
+      assert result == {:tuple, [2, 5]}
+    end
+
+    test "defaultdict(lambda: dict) with nested subscript assignment" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: {"count": 0, "total": 0})
+        d["a"]["count"] += 1
+        d["a"]["total"] += 10
+        d["b"]["count"] += 3
+        (d["a"]["count"], d["a"]["total"], d["b"]["count"])
+        """)
+
+      assert result == {:tuple, [1, 10, 3]}
+    end
+
+    test "auto-insert: accessing missing key inserts default" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        x = d["a"]
+        len(d)
+        """)
+
+      assert result == 1
+    end
+
+    test "lambda factory preserved across multiple missing-key accesses" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: [])
+        d["a"].append(1)
+        d["b"].append(2)
+        d["b"].append(3)
+        (d["a"], d["b"])
+        """)
+
+      assert result == {:tuple, [[1], [2, 3]]}
+    end
+
+    test "defaultdict(lambda: 0) simple read of missing key returns 0" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        d["missing"]
+        """)
+
+      assert result == 0
+    end
+
+    test "defaultdict(lambda: '') returns empty string for missing key" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: "")
+        d["x"]
+        """)
+
+      assert result == ""
+    end
+
+    test "defaultdict preserves explicitly set keys" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        d["a"] = 99
+        d["a"]
+        """)
+
+      assert result == 99
+    end
+
+    test "defaultdict with lambda: 0 counting pattern" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        words = ["apple", "banana", "apple", "cherry", "banana", "apple"]
+        for w in words:
+            d[w] += 1
+        (d["apple"], d["banana"], d["cherry"])
+        """)
+
+      assert result == {:tuple, [3, 2, 1]}
+    end
+
+    test "defaultdict in operator does not auto-insert" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        d["a"] = 1
+        ("a" in d, "b" in d, len(d))
+        """)
+
+      assert result == {:tuple, [true, false, 1]}
+    end
+
+    test "defaultdict keys() returns only inserted keys" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        d["x"] += 1
+        d["y"] += 2
+        sorted(list(d.keys()))
+        """)
+
+      assert result == ["x", "y"]
+    end
+
+    test "defaultdict values() returns current values" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        d["a"] += 10
+        d["b"] += 20
+        sorted(list(d.values()))
+        """)
+
+      assert result == [10, 20]
+    end
+
+    test "defaultdict iteration yields keys" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        d["x"] = 1
+        d["y"] = 2
+        keys = []
+        for k in d:
+            keys.append(k)
+        sorted(keys)
+        """)
+
+      assert result == ["x", "y"]
+    end
+
+    test "defaultdict with lambda returning mutable default (each call independent)" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: [1, 2])
+        d["a"].append(3)
+        d["b"].append(4)
+        (d["a"], d["b"])
+        """)
+
+      assert result == {:tuple, [[1, 2, 3], [1, 2, 4]]}
+    end
+
+    test "defaultdict augmented assignment on existing key" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: 0)
+        d["a"] = 10
+        d["a"] += 5
+        d["a"]
+        """)
+
+      assert result == 15
+    end
+
+    test "defaultdict nested augmented: d['a']['x'] += 1 on existing outer key" do
+      result =
+        Pyex.run!("""
+        from collections import defaultdict
+        d = defaultdict(lambda: {"x": 0, "y": 0})
+        d["a"]["x"] += 1
+        d["a"]["x"] += 1
+        d["a"]["y"] += 10
+        (d["a"]["x"], d["a"]["y"])
+        """)
+
+      assert result == {:tuple, [2, 10]}
+    end
+  end
 end

--- a/test/pyex/stdlib/decimal_test.exs
+++ b/test/pyex/stdlib/decimal_test.exs
@@ -1,0 +1,708 @@
+defmodule Pyex.Stdlib.DecimalTest do
+  use ExUnit.Case, async: true
+
+  describe "Decimal constructor" do
+    test "Decimal from string" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("3.14"))
+        """)
+
+      assert result == "3.14"
+    end
+
+    test "Decimal from zero string" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("0"))
+        """)
+
+      assert result == "0"
+    end
+
+    test "Decimal from negative string" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("-1.5"))
+        """)
+
+      assert result == "-1.5"
+    end
+
+    test "Decimal from int" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal(5))
+        """)
+
+      assert result == "5"
+    end
+
+    test "invalid Decimal literal returns Python error" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               Decimal("abc")
+               """)
+
+      assert msg =~ "ValueError"
+      assert msg =~ "Decimal"
+    end
+  end
+
+  describe "Decimal arithmetic" do
+    test "Decimal + Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("1.1") + Decimal("2.2"))
+        """)
+
+      assert result == "3.3"
+    end
+
+    test "Decimal - Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("5.5") - Decimal("2.2"))
+        """)
+
+      assert result == "3.3"
+    end
+
+    test "Decimal * Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("2.5") * Decimal("4"))
+        """)
+
+      assert result == "10.0"
+    end
+
+    test "Decimal + int" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("3.14") + 1)
+        """)
+
+      assert result == "4.14"
+    end
+
+    test "int + Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(1 + Decimal("3.14"))
+        """)
+
+      assert result == "4.14"
+    end
+
+    test "Decimal += int" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        x = Decimal("10.5")
+        x += 1
+        str(x)
+        """)
+
+      assert result == "11.5"
+    end
+  end
+
+  describe "Decimal comparison" do
+    test "Decimal > Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        Decimal("3.14") > Decimal("2.71")
+        """)
+
+      assert result == true
+    end
+
+    test "Decimal == Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        Decimal("1.0") == Decimal("1.0")
+        """)
+
+      assert result == true
+    end
+
+    test "Decimal < 0" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        Decimal("-1.5") < 0
+        """)
+
+      assert result == true
+    end
+
+    test "Decimal > 0" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        Decimal("3.14") > 0
+        """)
+
+      assert result == true
+    end
+
+    test "Decimal == 0" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        Decimal("0") == 0
+        """)
+
+      assert result == true
+    end
+  end
+
+  describe "Decimal division" do
+    test "Decimal / Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("10") / Decimal("4"))
+        """)
+
+      assert result == "2.5"
+    end
+
+    test "Decimal / int" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("9") / 2)
+        """)
+
+      assert result == "4.5"
+    end
+
+    test "division by zero raises ZeroDivisionError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               Decimal("1") / Decimal("0")
+               """)
+
+      assert msg =~ "ZeroDivisionError"
+    end
+
+    test "division by zero int raises ZeroDivisionError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               Decimal("1") / 0
+               """)
+
+      assert msg =~ "ZeroDivisionError"
+    end
+  end
+
+  describe "Decimal negative arithmetic" do
+    test "Decimal subtraction yielding negative" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("1.5") - Decimal("3.0"))
+        """)
+
+      assert result == "-1.5"
+    end
+
+    test "negative Decimal + positive Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("-2.5") + Decimal("1.0"))
+        """)
+
+      assert result == "-1.5"
+    end
+
+    test "negative Decimal * positive Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("-3") * Decimal("4"))
+        """)
+
+      assert result == "-12"
+    end
+
+    test "negative Decimal * negative Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("-3") * Decimal("-4"))
+        """)
+
+      assert result == "12"
+    end
+  end
+
+  describe "Decimal extended comparisons" do
+    test "Decimal <= Decimal true" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("1.0") <= Decimal("1.0")
+             """) == true
+    end
+
+    test "Decimal <= Decimal strict" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("0.9") <= Decimal("1.0")
+             """) == true
+    end
+
+    test "Decimal >= Decimal true" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("2.0") >= Decimal("2.0")
+             """) == true
+    end
+
+    test "Decimal != Decimal" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("1.0") != Decimal("2.0")
+             """) == true
+    end
+
+    test "Decimal != Decimal same value" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("1.0") != Decimal("1.0")
+             """) == false
+    end
+
+    test "Decimal < int" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("0.5") < 1
+             """) == true
+    end
+
+    test "Decimal >= int" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("5") >= 5
+             """) == true
+    end
+  end
+
+  describe "Decimal copy constructor" do
+    test "Decimal from Decimal returns same value" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        a = Decimal("3.14")
+        b = Decimal(a)
+        str(b)
+        """)
+
+      assert result == "3.14"
+    end
+  end
+
+  describe "Decimal repr" do
+    test "repr of Decimal returns string form" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        repr(Decimal("3.14"))
+        """)
+
+      assert result == "3.14"
+    end
+
+    test "Decimal in list repr" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str([Decimal("3.14")])
+        """)
+
+      assert result == "[3.14]"
+    end
+  end
+
+  describe "Decimal truthiness" do
+    test "non-zero Decimal is truthy in if" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        x = Decimal("1.5")
+        "truthy" if x else "falsy"
+        """)
+
+      assert result == "truthy"
+    end
+
+    test "zero Decimal is falsy in if" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        x = Decimal("0")
+        "nonzero" if x else "zero"
+        """)
+
+      assert result == "zero"
+    end
+
+    test "negative Decimal is truthy in if" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        x = Decimal("-1")
+        "truthy" if x else "falsy"
+        """)
+
+      assert result == "truthy"
+    end
+
+    test "zero Decimal in while loop does not execute" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        x = Decimal("0")
+        ran = False
+        while x:
+            ran = True
+            break
+        ran
+        """)
+
+      assert result == false
+    end
+  end
+
+  describe "Decimal augmented assignment" do
+    test "Decimal -= Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        x = Decimal("10.5")
+        x -= Decimal("3.5")
+        str(x)
+        """)
+
+      assert result == "7.0"
+    end
+
+    test "Decimal *= int" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        x = Decimal("2.5")
+        x *= 3
+        str(x)
+        """)
+
+      assert result == "7.5"
+    end
+  end
+
+  describe "Decimal with f-string formatting" do
+    test "Decimal with .2f format spec" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        val = Decimal("3.14159")
+        f"{val:.2f}"
+        """)
+
+      assert result == "3.14"
+    end
+
+    test "Decimal .2f preserves large-value precision" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        val = Decimal("12345678901234567890.12")
+        f"{val:.2f}"
+        """)
+
+      assert result == "12345678901234567890.12"
+    end
+
+    test "Decimal .2f pads trailing zeros" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        val = Decimal("1")
+        f"{val:.2f}"
+        """)
+
+      assert result == "1.00"
+    end
+  end
+
+  describe "str(Decimal)" do
+    test "str of Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("3.14"))
+        """)
+
+      assert result == "3.14"
+    end
+
+    test "str of negative Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("-99.99"))
+        """)
+
+      assert result == "-99.99"
+    end
+
+    test "str of large Decimal" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("123456789.123456789"))
+        """)
+
+      assert result == "123456789.123456789"
+    end
+  end
+
+  describe "Decimal precision (avoids float errors)" do
+    test "0.1 + 0.2 == 0.3 with Decimal (unlike floats)" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("0.1") + Decimal("0.2") == Decimal("0.3")
+             """) == true
+    end
+
+    test "0.1 + 0.2 as float is NOT 0.3" do
+      assert Pyex.run!("0.1 + 0.2 == 0.3") == false
+    end
+
+    test "Decimal str of 0.1 + 0.2 is exactly 0.3" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("0.1") + Decimal("0.2"))
+        """)
+
+      assert result == "0.3"
+    end
+
+    test "Decimal subtraction precision: 1.0 - 0.9 == 0.1" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             Decimal("1.0") - Decimal("0.9") == Decimal("0.1")
+             """) == true
+    end
+
+    test "Decimal multiplication precision: 0.1 * 3 == 0.3" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("0.1") * Decimal("3"))
+        """)
+
+      assert result == "0.3"
+    end
+
+    test "Decimal division precision: 1 / 3 * 3" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("1") / Decimal("3") * Decimal("3"))
+        """)
+
+      # Decimal preserves the repeating-decimal behavior
+      assert result != nil
+    end
+
+    test "financial calculation: sum of line items" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        items = [Decimal("19.99"), Decimal("4.99"), Decimal("3.49")]
+        total = Decimal("0")
+        for item in items:
+            total += item
+        str(total)
+        """)
+
+      assert result == "28.47"
+    end
+  end
+
+  describe "Decimal type errors" do
+    test "Decimal + string raises TypeError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               Decimal("1") + "hello"
+               """)
+
+      assert msg =~ "TypeError"
+    end
+
+    test "Decimal * string raises TypeError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               Decimal("1") * "hello"
+               """)
+
+      assert msg =~ "TypeError"
+    end
+
+    test "Decimal + float raises TypeError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               Decimal("1") + 1.5
+               """)
+
+      assert msg =~ "TypeError"
+    end
+
+    test "float + Decimal raises TypeError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               1.5 + Decimal("1")
+               """)
+
+      assert msg =~ "TypeError"
+    end
+  end
+
+  describe "bool() with Decimal (regression)" do
+    test "bool(Decimal('0')) is false" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             bool(Decimal("0"))
+             """) == false
+    end
+
+    test "bool(Decimal('1')) is true" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             bool(Decimal("1"))
+             """) == true
+    end
+
+    test "bool(Decimal('-0')) is false" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             bool(Decimal("-0"))
+             """) == false
+    end
+
+    test "bool(Decimal('0.00')) is false" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             bool(Decimal("0.00"))
+             """) == false
+    end
+
+    test "bool(Decimal('0.001')) is true" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             bool(Decimal("0.001"))
+             """) == true
+    end
+  end
+
+  describe "Decimal edge cases" do
+    test "large Decimal arithmetic" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("999999999999999999.99") + Decimal("0.01"))
+        """)
+
+      assert result == "1000000000000000000.00"
+    end
+
+    test "very small Decimal arithmetic" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("0.000000001") + Decimal("0.000000001"))
+        """)
+
+      assert result == "2E-9" or result == "0.000000002"
+    end
+
+    test "repeating decimal from division preserves precision" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        s = str(Decimal("1") / Decimal("3"))
+        s[:5]
+        """)
+
+      assert result == "0.333"
+    end
+
+    test "division by zero raises ZeroDivisionError (int zero)" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               Decimal("5") / 0
+               """)
+
+      assert msg =~ "ZeroDivisionError"
+    end
+
+    test "not operator with Decimal" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             not Decimal("0")
+             """) == true
+    end
+
+    test "not operator with non-zero Decimal" do
+      assert Pyex.run!("""
+             from decimal import Decimal
+             not Decimal("1")
+             """) == false
+    end
+
+    test "Decimal in f-string without format spec" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        f"{Decimal('3.14')}"
+        """)
+
+      assert result == "3.14"
+    end
+
+    test "Decimal negative division" do
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal("-10") / Decimal("3"))
+        """)
+
+      # Should start with -3.333...
+      assert String.starts_with?(result, "-3.333")
+    end
+  end
+end


### PR DESCRIPTION
## Why

Pyex is approaching its first public pre-alpha, and the core parser/interpreter path needs to be easier to reason about and safer to evolve.

This change modularizes the largest execution modules and hardens several Python-facing semantics that surfaced during feature expansion. The goal is not full Python compatibility; the goal is a more trustworthy core for the supported subset.

## What changed

- split the parser into focused submodules for definitions, control flow, imports, comprehensions, and match parsing
- split the interpreter into focused submodules for assignments, calls, control flow, collections, protocols, invocation, and formatting
- added broader integration coverage around realistic multi-feature programs
- hardened runtime semantics for:
  - invalid `Decimal(...)` input staying inside Pyex as a Python error
  - Python-consistent numeric width alignment in f-strings
  - precision-preserving Decimal fixed-point formatting
  - `open()` keyword argument handling and validation
  - consistent `__name__` / `__file__` behavior across direct execution and Lambda execution

## Why this matters for pre-alpha

The main priority before a first public release is confidence in the core execution model:
- large core modules are now easier to review and extend
- high-risk runtime semantics are covered by targeted regressions
- sandbox boundaries are tighter
- execution behavior is more consistent across entrypoints

## Non-goals

- full CPython compatibility
- broad third-party library compatibility
- freezing a long-term stable public API

## Risk

This touches core interpreter and parser paths, so the main risk is semantic regression. The branch reduces that risk with focused regression coverage plus full test and dialyzer validation.

## Verification

- `mix format`
- `mix test`
- `mix dialyzer`