### PR TITLE
Harden network rule matching and validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,15 @@ jobs:
   test:
     name: Test (OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.elixir == '1.20.0-rc.2' }}
     strategy:
       matrix:
         include:
           - otp: "28.0"
             elixir: "1.19"
+            experimental: false
           - otp: "28.0"
             elixir: "1.20.0-rc.2"
+            experimental: true
 
     services:
       postgres:
@@ -69,10 +70,22 @@ jobs:
         run: mix format --check-formatted
 
       - name: Compile (warnings as errors)
+        id: compile
+        continue-on-error: ${{ matrix.experimental }}
         run: mix compile --warnings-as-errors
 
       - name: Run tests
+        id: test
+        if: ${{ !matrix.experimental || steps.compile.outcome == 'success' }}
+        continue-on-error: ${{ matrix.experimental }}
         run: mix test --include postgres
+
+      - name: Report experimental failure
+        if: ${{ always() && matrix.experimental && (steps.compile.outcome == 'failure' || steps.test.outcome == 'failure') }}
+        run: |
+          echo "Experimental Elixir ${{ matrix.elixir }} run failed, likely due to upstream dependency compatibility."
+          echo "Compile outcome: ${{ steps.compile.outcome }}"
+          echo "Test outcome: ${{ steps.test.outcome }}"
 
   dialyzer:
     name: Dialyzer
@@ -116,14 +129,15 @@ jobs:
   external-http:
     name: External HTTP Integration (OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.elixir == '1.20.0-rc.2' }}
     strategy:
       matrix:
         include:
           - otp: "28.0"
             elixir: "1.19"
+            experimental: false
           - otp: "28.0"
             elixir: "1.20.0-rc.2"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v4
@@ -151,4 +165,12 @@ jobs:
         run: mix deps.get
 
       - name: Run external HTTP integration tests
+        id: external_http
+        continue-on-error: ${{ matrix.experimental }}
         run: mix test --include external_http test/pyex/stdlib/requests_integration_test.exs
+
+      - name: Report experimental failure
+        if: ${{ always() && matrix.experimental && steps.external_http.outcome == 'failure' }}
+        run: |
+          echo "Experimental Elixir ${{ matrix.elixir }} external HTTP run failed, likely due to upstream dependency compatibility."
+          echo "Test outcome: ${{ steps.external_http.outcome }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     name: Test (OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }})
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.elixir == '1.20.0-rc.2' }}
     strategy:
       matrix:
         include:
@@ -115,6 +116,7 @@ jobs:
   external-http:
     name: External HTTP Integration (OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }})
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.elixir == '1.20.0-rc.2' }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         include:
           - otp: "28.0"
             elixir: "1.19"
+          - otp: "28.0"
+            elixir: "1.20.0-rc.2"
 
     services:
       postgres:
@@ -109,3 +111,42 @@ jobs:
 
       - name: Run Dialyzer
         run: mix dialyzer
+
+  external-http:
+    name: External HTTP Integration (OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - otp: "28.0"
+            elixir: "1.19"
+          - otp: "28.0"
+            elixir: "1.20.0-rc.2"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: deps
+          key: deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: _build
+          key: build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Run external HTTP integration tests
+        run: mix test --include external_http test/pyex/stdlib/requests_integration_test.exs

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Pyex.run(source, timeout_ms: 5_000)
 All network access is denied by default:
 
 ```elixir
-Pyex.run(source, network: [allowed_hosts: ["api.example.com"]])
+Pyex.run(source, network: [%{allowed_url_prefix: "https://api.example.com/"}])
 ```
 
 ### I/O capabilities

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -69,10 +69,10 @@ defmodule Pyex do
   - `:env` -- environment variables for `os.environ`
   - `:timeout_ms` -- compute time budget in milliseconds
   - `:network` -- network access policy for the `requests` module.
-    Accepts a keyword list with `:allowed_hosts` (exact hostname match),
-    `:allowed_url_prefixes`, `:allowed_methods` (default `["GET", "HEAD"]`),
-    or `:dangerously_allow_full_internet_access`. When omitted,
-    all network access is denied.
+    A list of rule maps, each with `:allowed_url_prefix` or
+    `:dangerously_allow_full_internet_access`, plus optional `:methods`
+    (default `["GET", "HEAD"]`) and `:headers` (injected into matching
+    requests). When omitted, all network access is denied.
   - `:capabilities` -- list of enabled I/O capabilities (e.g.
     `[:boto3, :sql]`). All capabilities are denied by default.
   - `:boto3` -- shorthand for adding `:boto3` to capabilities.

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -36,12 +36,16 @@ defmodule Pyex.Ctx do
           call: %{optional(String.t()) => float()}
         }
 
-  @type network_config :: %{
-          allowed_hosts: [String.t()],
-          allowed_url_prefixes: [String.t()],
-          allowed_methods: [String.t()],
-          dangerously_allow_full_internet_access: boolean()
+  @type network_rule :: %{
+          optional(:allowed_url_prefix) => String.t(),
+          optional(:dangerously_allow_full_internet_access) => true,
+          optional(:methods) => [String.t()] | :all,
+          optional(:headers) => %{optional(String.t()) => String.t()}
         }
+
+  @type network_config :: [network_rule()] | nil
+
+  @url_prefix_pattern ~r/\A([a-z][a-z0-9+\-.]*:\/\/)([^\/?#]*)(.*)\z/i
 
   @type capability :: :boto3 | :sql | atom()
 
@@ -117,18 +121,38 @@ defmodule Pyex.Ctx do
     per-function call counts with timing. Results are stored in the
     returned context's `profile` field. Default `false`.
   - `:network` -- network access policy for the `requests` module.
-    A keyword list or map with:
-    - `:allowed_hosts` -- list of hostnames that are permitted (exact match,
-      compared against `URI.parse(url).host`)
-    - `:allowed_url_prefixes` -- list of URL prefixes that are permitted
-      (use trailing slash to prevent subdomain bypass)
-    - `:allowed_methods` -- list of HTTP methods allowed (default `["GET", "HEAD"]`)
-    - `:dangerously_allow_full_internet_access` -- `true` to allow all
-      URLs and methods (use with caution)
 
-    A request is allowed if its URL matches any `:allowed_hosts` entry
-    **or** any `:allowed_url_prefixes` entry. When `nil` (the default),
+    A list of rule maps. Each rule may contain:
+    - `:allowed_url_prefix` -- URL prefix that is permitted
+      (use trailing slash to prevent subdomain bypass)
+    - `:dangerously_allow_full_internet_access` -- `true` to match any URL
+    - `:methods` -- list of HTTP methods allowed (default `["GET", "HEAD"]`)
+    - `:headers` -- map of headers to inject into matching requests.
+      Injected headers override any headers set by the Python code,
+      and are not visible to the sandboxed code.
+
+    Each rule must have either `:allowed_url_prefix` or
+    `:dangerously_allow_full_internet_access`. A request is allowed if
+    it matches any rule (URL prefix + method). When `nil` (the default),
     all network access is denied.
+
+    ## Examples
+
+        # Prefix rules with credential injection
+        network: [
+          %{allowed_url_prefix: "https://api.openai.com/v1/",
+            methods: ["POST"],
+            headers: %{"authorization" => "Bearer sk-..."}},
+          %{allowed_url_prefix: "https://httpbin.org/"}
+        ]
+
+        # GET everything, POST to a specific API with injected auth
+        network: [
+          %{dangerously_allow_full_internet_access: true, methods: ["GET"]},
+          %{allowed_url_prefix: "https://api.openai.com/v1/",
+            methods: ["POST"],
+            headers: %{"authorization" => "Bearer sk-..."}}
+        ]
   - `:capabilities` -- a list of atoms naming enabled I/O capabilities.
     Known capabilities: `:boto3` (S3 operations), `:sql` (database
     queries). All capabilities are denied by default.
@@ -220,109 +244,186 @@ defmodule Pyex.Ctx do
     MapSet.new(explicit ++ shorthand)
   end
 
-  @spec normalize_network(keyword() | map() | nil) :: network_config() | nil
+  @spec normalize_network(term()) :: network_config()
   defp normalize_network(nil), do: nil
+  defp normalize_network([]), do: []
 
-  defp normalize_network(opts) when is_list(opts) do
-    normalize_network(Map.new(opts))
+  defp normalize_network(rules) when is_list(rules) do
+    if Keyword.keyword?(rules) do
+      raise ArgumentError,
+            "network must be a list of rule maps, not a keyword list. " <>
+              "Use network: [%{allowed_url_prefix: \"https://api.example.com/\"}]"
+    end
+
+    Enum.map(rules, &normalize_rule/1)
   end
 
-  defp normalize_network(opts) when is_map(opts) do
-    %{
-      allowed_hosts:
-        Map.get(opts, :allowed_hosts, [])
-        |> Enum.map(&(&1 |> to_string() |> String.downcase())),
-      allowed_url_prefixes: Map.get(opts, :allowed_url_prefixes, []) |> Enum.map(&to_string/1),
-      allowed_methods:
-        Map.get(opts, :allowed_methods, ["GET", "HEAD"])
-        |> Enum.map(&(&1 |> to_string() |> String.upcase())),
-      dangerously_allow_full_internet_access:
-        Map.get(opts, :dangerously_allow_full_internet_access, false) == true
-    }
+  defp normalize_network(%{}), do: raise_invalid_network_config()
+
+  defp normalize_network(_), do: raise_invalid_network_config()
+
+  @spec raise_invalid_network_config() :: no_return()
+  defp raise_invalid_network_config do
+    raise ArgumentError,
+          "network must be a list of rule maps. " <>
+            "Use network: [%{allowed_url_prefix: \"https://api.example.com/\"}]"
+  end
+
+  @spec normalize_rule(term()) :: network_rule()
+  defp normalize_rule(%{} = rule) do
+    has_prefix = Map.has_key?(rule, :allowed_url_prefix)
+    has_dangerous = Map.get(rule, :dangerously_allow_full_internet_access, false) == true
+
+    unless has_prefix or has_dangerous do
+      raise ArgumentError,
+            "network rule must have :allowed_url_prefix or :dangerously_allow_full_internet_access"
+    end
+
+    methods =
+      case Map.get(rule, :methods, ["GET", "HEAD"]) do
+        :all ->
+          :all
+
+        list when is_list(list) ->
+          Enum.map(list, &(&1 |> to_string() |> String.upcase()))
+
+        _ ->
+          raise ArgumentError, "network rule :methods must be a list of strings or :all"
+      end
+
+    headers =
+      case Map.get(rule, :headers, %{}) do
+        %{} = headers ->
+          Map.new(headers, fn {k, v} -> {String.downcase(to_string(k)), to_string(v)} end)
+
+        _ ->
+          raise ArgumentError, "network rule :headers must be a map"
+      end
+
+    base = %{methods: methods, headers: headers}
+
+    if has_prefix do
+      Map.put(base, :allowed_url_prefix, normalize_allowed_url_prefix(rule.allowed_url_prefix))
+    else
+      Map.put(base, :dangerously_allow_full_internet_access, true)
+    end
+  end
+
+  defp normalize_rule(_) do
+    raise ArgumentError, "each network rule must be a map"
+  end
+
+  @spec normalize_allowed_url_prefix(term()) :: String.t()
+  defp normalize_allowed_url_prefix(prefix) when is_binary(prefix) and prefix != "", do: prefix
+
+  defp normalize_allowed_url_prefix(_) do
+    raise ArgumentError, "network rule :allowed_url_prefix must be a non-empty string"
   end
 
   @doc """
   Checks whether a network request is allowed by the current policy.
 
-  Returns `:ok` if the request is permitted, or `{:denied, reason}` with
-  a descriptive error message when the request violates the policy.
+  Returns `{:ok, inject_headers}` if the request is permitted (where
+  `inject_headers` is a list of `{name, value}` tuples to merge into
+  the request), or `{:denied, reason}` with a descriptive error message.
   """
-  @spec check_network_access(t(), String.t(), String.t()) :: :ok | {:denied, String.t()}
+  @spec check_network_access(t(), String.t(), String.t()) ::
+          {:ok, [{String.t(), String.t()}]} | {:denied, String.t()}
   def check_network_access(%__MODULE__{network: nil}, _method, _url) do
     {:denied,
      "NetworkError: network access is disabled. " <>
        "Configure the :network option to allow HTTP requests"}
   end
 
-  def check_network_access(
-        %__MODULE__{network: %{dangerously_allow_full_internet_access: true}},
-        _method,
-        _url
-      ) do
-    :ok
+  def check_network_access(%__MODULE__{network: []}, _method, _url) do
+    {:denied,
+     "NetworkError: no network rules configured. " <>
+       "Add rules to the :network option to allow HTTP requests"}
   end
 
-  def check_network_access(%__MODULE__{network: config}, method, url) do
+  def check_network_access(%__MODULE__{network: rules}, method, url) do
     method_upper = String.upcase(method)
 
-    with :ok <- check_method(config.allowed_methods, method_upper),
-         :ok <- check_url_allowed(config.allowed_hosts, config.allowed_url_prefixes, url) do
-      :ok
+    case find_matching_rules(rules, method_upper, url) do
+      {:ok, headers} -> {:ok, headers}
+      :no_match -> {:denied, build_denial_message(rules, method_upper, url)}
     end
   end
 
-  @spec check_method([String.t()], String.t()) :: :ok | {:denied, String.t()}
-  defp check_method(allowed, method) do
-    if method in allowed do
-      :ok
+  @spec find_matching_rules([network_rule()], String.t(), String.t()) ::
+          {:ok, [{String.t(), String.t()}]} | :no_match
+  defp find_matching_rules(rules, method, url) do
+    rules
+    |> Enum.filter(&(rule_matches_url?(&1, url) and rule_allows_method?(&1, method)))
+    |> merge_matching_rule_headers()
+  end
+
+  @spec merge_matching_rule_headers([network_rule()]) ::
+          {:ok, [{String.t(), String.t()}]} | :no_match
+  defp merge_matching_rule_headers([]), do: :no_match
+
+  defp merge_matching_rule_headers(rules) do
+    headers =
+      rules
+      |> Enum.with_index()
+      |> Enum.sort_by(fn {rule, index} -> {rule_specificity(rule), index} end)
+      |> Enum.reduce(%{}, fn {rule, _index}, acc ->
+        Map.merge(acc, Map.get(rule, :headers, %{}))
+      end)
+
+    {:ok, Enum.to_list(headers)}
+  end
+
+  @spec rule_allows_method?(network_rule(), String.t()) :: boolean()
+  defp rule_allows_method?(%{methods: :all}, _method), do: true
+  defp rule_allows_method?(%{methods: methods}, method), do: method in methods
+
+  @spec rule_matches_url?(network_rule(), String.t()) :: boolean()
+  defp rule_matches_url?(%{dangerously_allow_full_internet_access: true}, _url), do: true
+
+  defp rule_matches_url?(%{allowed_url_prefix: prefix}, url),
+    do: String.starts_with?(normalize_url_prefix(url), normalize_url_prefix(prefix))
+
+  defp rule_matches_url?(_, _url), do: false
+
+  @spec rule_specificity(network_rule()) :: non_neg_integer()
+  defp rule_specificity(%{allowed_url_prefix: prefix}), do: byte_size(prefix)
+  defp rule_specificity(%{dangerously_allow_full_internet_access: true}), do: 0
+
+  @spec normalize_url_prefix(String.t()) :: String.t()
+  defp normalize_url_prefix(url) do
+    case Regex.run(@url_prefix_pattern, url, capture: :all_but_first) do
+      [scheme, authority, rest] -> String.downcase(scheme) <> String.downcase(authority) <> rest
+      _ -> url
+    end
+  end
+
+  @spec build_denial_message([network_rule()], String.t(), String.t()) :: String.t()
+  defp build_denial_message(rules, method, url) do
+    url_matched_rules = Enum.filter(rules, &rule_matches_url?(&1, url))
+
+    if url_matched_rules != [] do
+      has_all = Enum.any?(url_matched_rules, &(&1.methods == :all))
+
+      allowed =
+        if has_all,
+          do: ["*"],
+          else: url_matched_rules |> Enum.flat_map(& &1.methods) |> Enum.uniq()
+
+      "NetworkError: HTTP method #{method} is not allowed. " <>
+        "Allowed methods: #{Enum.join(allowed, ", ")}"
     else
-      {:denied,
-       "NetworkError: HTTP method #{method} is not allowed. " <>
-         "Allowed methods: #{Enum.join(allowed, ", ")}"}
-    end
-  end
+      prefixes =
+        rules
+        |> Enum.filter(&Map.has_key?(&1, :allowed_url_prefix))
+        |> Enum.map(& &1.allowed_url_prefix)
 
-  @spec check_url_allowed([String.t()], [String.t()], String.t()) ::
-          :ok | {:denied, String.t()}
-  defp check_url_allowed([], [], _url) do
-    {:denied,
-     "NetworkError: no allowed hosts or URL prefixes configured. " <>
-       "Add hosts to :allowed_hosts or URL prefixes to :allowed_url_prefixes"}
-  end
-
-  defp check_url_allowed(hosts, prefixes, url) do
-    host_match = hosts != [] and url_matches_host?(hosts, url)
-    prefix_match = prefixes != [] and Enum.any?(prefixes, &String.starts_with?(url, &1))
-
-    if host_match or prefix_match do
-      :ok
-    else
-      parts =
-        []
-        |> then(fn acc ->
-          if hosts != [], do: ["allowed hosts: #{Enum.join(hosts, ", ")}" | acc], else: acc
-        end)
-        |> then(fn acc ->
-          if prefixes != [],
-            do: ["allowed prefixes: #{Enum.join(prefixes, ", ")}" | acc],
-            else: acc
-        end)
-        |> Enum.reverse()
-        |> Enum.join("; ")
-
-      {:denied, "NetworkError: URL is not allowed. #{String.capitalize(parts)}"}
-    end
-  end
-
-  @spec url_matches_host?([String.t()], String.t()) :: boolean()
-  defp url_matches_host?(allowed_hosts, url) do
-    case URI.parse(url) do
-      %URI{host: host} when is_binary(host) ->
-        normalized = String.downcase(host)
-        Enum.any?(allowed_hosts, &(&1 == normalized))
-
-      _ ->
-        false
+      if prefixes == [] do
+        "NetworkError: URL is not allowed"
+      else
+        "NetworkError: URL is not allowed. " <>
+          "Allowed prefixes: #{Enum.join(prefixes, ", ")}"
+      end
     end
   end
 

--- a/lib/pyex/stdlib/boto3.ex
+++ b/lib/pyex/stdlib/boto3.ex
@@ -89,7 +89,7 @@ defmodule Pyex.Stdlib.Boto3 do
 
   defp check_endpoint_network(ctx, url) do
     case Pyex.Ctx.check_network_access(ctx, "GET", url) do
-      :ok -> :ok
+      {:ok, _headers} -> :ok
       {:denied, reason} -> {:exception, reason}
     end
   end

--- a/lib/pyex/stdlib/requests.ex
+++ b/lib/pyex/stdlib/requests.ex
@@ -80,11 +80,8 @@ defmodule Pyex.Stdlib.Requests do
           %{optional(String.t()) => Pyex.Interpreter.pyvalue()}
         ) :: {:io_call, (Pyex.Env.t(), Pyex.Ctx.t() -> {term(), Pyex.Env.t(), Pyex.Ctx.t()})}
   defp do_request(method, url, kwargs) do
-    headers = build_headers(kwargs)
+    user_headers = build_headers(kwargs)
     method_str = method |> Atom.to_string() |> String.upcase()
-
-    req_opts =
-      [headers: headers, method: method, url: url, redirect: false] ++ body_opts(kwargs)
 
     {:io_call,
      fn env, ctx ->
@@ -92,7 +89,13 @@ defmodule Pyex.Stdlib.Requests do
          {:denied, reason} ->
            {{:exception, reason}, env, ctx}
 
-         :ok ->
+         {:ok, inject_headers} ->
+           # Injected headers override user-provided ones (host config wins)
+           headers = merge_headers(user_headers, inject_headers)
+
+           req_opts =
+             [headers: headers, method: method, url: url, redirect: false] ++ body_opts(kwargs)
+
            start_mono = System.monotonic_time()
            telemetry_meta = %{method: method_str, url: url}
 
@@ -132,6 +135,18 @@ defmodule Pyex.Stdlib.Requests do
            {result, env, ctx}
        end
      end}
+  end
+
+  @spec merge_headers([{String.t(), String.t()}], [{String.t(), String.t()}]) :: [
+          {String.t(), String.t()}
+        ]
+  defp merge_headers(user_headers, []), do: user_headers
+
+  defp merge_headers(user_headers, inject_headers) do
+    inject_keys = MapSet.new(inject_headers, fn {k, _} -> String.downcase(k) end)
+
+    filtered = Enum.reject(user_headers, fn {k, _} -> String.downcase(k) in inject_keys end)
+    filtered ++ inject_headers
   end
 
   @spec body_opts(%{optional(String.t()) => Pyex.Interpreter.pyvalue()}) :: keyword()

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Pyex.MixProject do
       {:yaml_elixir, "~> 2.12", only: :test},
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:ex_doc, "~> 0.35", only: :dev, runtime: false},
-      {:explorer, "~> 0.10", optional: true},
+      {:explorer, "~> 0.11.1", optional: true},
       {:stream_data, "~> 1.1", only: :test},
       {:bypass, "~> 2.1", only: :test},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/test/pyex/ctx_test.exs
+++ b/test/pyex/ctx_test.exs
@@ -8,6 +8,39 @@ defmodule Pyex.CtxTest do
       ctx = Ctx.new()
       assert ctx.output_buffer == []
     end
+
+    test "rejects legacy keyword-list network config" do
+      assert_raise ArgumentError, ~r/network must be a list of rule maps/, fn ->
+        Ctx.new(network: [dangerously_allow_full_internet_access: true])
+      end
+    end
+
+    test "rejects legacy map network config" do
+      assert_raise ArgumentError, ~r/network must be a list of rule maps/, fn ->
+        Ctx.new(network: %{dangerously_allow_full_internet_access: true})
+      end
+    end
+
+    test "rejects nil allowed_url_prefix" do
+      assert_raise ArgumentError, ~r/allowed_url_prefix must be a non-empty string/, fn ->
+        Ctx.new(network: [%{allowed_url_prefix: nil}])
+      end
+    end
+
+    test "rejects empty allowed_url_prefix" do
+      assert_raise ArgumentError, ~r/allowed_url_prefix must be a non-empty string/, fn ->
+        Ctx.new(network: [%{allowed_url_prefix: ""}])
+      end
+    end
+  end
+
+  describe "check_network_access/3" do
+    test "matches scheme and host case-insensitively" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com/v1/"}])
+
+      assert {:ok, []} =
+               Ctx.check_network_access(ctx, "GET", "HTTPS://API.EXAMPLE.COM/v1/chat")
+    end
   end
 
   describe "record/3" do

--- a/test/pyex/readme_test.exs
+++ b/test/pyex/readme_test.exs
@@ -148,14 +148,14 @@ defmodule Pyex.ReadmeTest do
       assert msg =~ "network access is disabled"
     end
 
-    test "allowed_hosts permits matching host" do
+    test "allowed_url_prefix permits matching prefix" do
       assert {:error, %Error{message: msg}} =
                Pyex.run(
                  """
                  import requests
                  requests.get("http://other.com")
                  """,
-                 network: [allowed_hosts: ["api.example.com"]]
+                 network: [%{allowed_url_prefix: "https://api.example.com/"}]
                )
 
       assert msg =~ "URL is not allowed"

--- a/test/pyex/stdlib/boto3_test.exs
+++ b/test/pyex/stdlib/boto3_test.exs
@@ -589,8 +589,7 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.Ctx.new(
           boto3: true,
           network: [
-            allowed_hosts: ["example.com"],
-            allowed_methods: ["GET", "PUT", "DELETE"]
+            %{allowed_url_prefix: "http://example.com/", methods: ["GET", "PUT", "DELETE"]}
           ]
         )
 
@@ -616,8 +615,7 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.Ctx.new(
           boto3: true,
           network: [
-            allowed_hosts: ["localhost"],
-            allowed_methods: ["GET", "PUT", "DELETE"]
+            %{allowed_url_prefix: "http://localhost:", methods: ["GET", "PUT", "DELETE"]}
           ]
         )
 

--- a/test/pyex/stdlib/requests_integration_test.exs
+++ b/test/pyex/stdlib/requests_integration_test.exs
@@ -1,0 +1,160 @@
+defmodule Pyex.Stdlib.RequestsIntegrationTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+
+  alias Pyex.Error
+
+  @moduletag :external_http
+  @moduletag timeout: 30_000
+
+  describe "real HTTP endpoints" do
+    test "GETs a real JSON endpoint with a prefix rule" do
+      result =
+        Pyex.run!(
+          """
+          import requests
+
+          response = requests.get("https://postman-echo.com/get?source=pyex")
+          data = response.json()
+          [
+              response.status_code,
+              response.ok,
+              "content-type" in response.headers,
+              data["args"]["source"],
+              data["headers"]["host"],
+              data["url"]
+          ]
+          """,
+          network: [%{allowed_url_prefix: "https://postman-echo.com/get"}]
+        )
+
+      assert result == [
+               200,
+               true,
+               true,
+               "pyex",
+               "postman-echo.com",
+               "https://postman-echo.com/get?source=pyex"
+             ]
+    end
+
+    test "denies a live request when the prefix rule does not match" do
+      assert {:error, %Error{message: message}} =
+               Pyex.run(
+                 """
+                 import requests
+                 requests.get("https://postman-echo.com/get?blocked=1")
+                 """,
+                 network: [%{allowed_url_prefix: "https://example.com/"}]
+               )
+
+      assert message =~ "NetworkError: URL is not allowed"
+      assert message =~ "https://example.com/"
+    end
+
+    test "POSTs to a real endpoint with injected headers" do
+      result =
+        Pyex.run!(
+          """
+          import requests
+
+          response = requests.post(
+              "https://postman-echo.com/post",
+              json={"message": "hello"},
+              headers={"X-User-Header": "from-python"}
+          )
+          data = response.json()
+          [
+              response.status_code,
+              response.ok,
+              response.headers["content-type"][0],
+              data["json"]["message"],
+              data["headers"]["x-pyex-token"],
+              data["headers"]["x-user-header"],
+              data["headers"]["content-type"],
+              data["url"]
+          ]
+          """,
+          network: [
+            %{
+              allowed_url_prefix: "https://postman-echo.com/post",
+              methods: ["POST"],
+              headers: %{"x-pyex-token" => "integration-secret"}
+            }
+          ]
+        )
+
+      assert result == [
+               200,
+               true,
+               "application/json; charset=utf-8",
+               "hello",
+               "integration-secret",
+               "from-python",
+               "application/json",
+               "https://postman-echo.com/post"
+             ]
+    end
+
+    test "config-injected headers win over Python headers on a live endpoint" do
+      result =
+        Pyex.run!(
+          """
+          import requests
+
+          response = requests.post(
+              "https://postman-echo.com/post",
+              json={"message": "hello"},
+              headers={
+                  "X-Pyex-Token": "from-python",
+                  "X-User-Header": "still-present"
+              }
+          )
+          data = response.json()
+          [
+              response.status_code,
+              response.ok,
+              response.headers["content-type"][0],
+              data["headers"]["x-pyex-token"],
+              data["headers"]["x-user-header"],
+              data["data"]["message"],
+              data["url"]
+          ]
+          """,
+          network: [
+            %{dangerously_allow_full_internet_access: true, methods: ["POST"]},
+            %{
+              allowed_url_prefix: "https://postman-echo.com/post",
+              methods: ["POST"],
+              headers: %{"x-pyex-token" => "from-config"}
+            }
+          ]
+        )
+
+      assert result == [
+               200,
+               true,
+               "application/json; charset=utf-8",
+               "from-config",
+               "still-present",
+               "hello",
+               "https://postman-echo.com/post"
+             ]
+    end
+
+    test "handles a live non-2xx response without crashing" do
+      result =
+        Pyex.run!(
+          """
+          import requests
+
+          response = requests.get("https://postman-echo.com/status/418")
+          [response.status_code, response.ok, response.text, response.json()["status"]]
+          """,
+          network: [%{allowed_url_prefix: "https://postman-echo.com/status/"}]
+        )
+
+      assert result == [418, false, ~s({"status":418}), 418]
+    end
+  end
+end

--- a/test/pyex/stdlib/requests_test.exs
+++ b/test/pyex/stdlib/requests_test.exs
@@ -1,7 +1,7 @@
 defmodule Pyex.Stdlib.RequestsTest do
   use ExUnit.Case
 
-  @network [dangerously_allow_full_internet_access: true]
+  @network [%{dangerously_allow_full_internet_access: true, methods: :all}]
 
   setup do
     bypass = Bypass.open()
@@ -416,7 +416,7 @@ defmodule Pyex.Stdlib.RequestsTest do
           response = requests.get("http://localhost:#{port}/api/data")
           response.status_code
           """,
-          network: [allowed_url_prefixes: ["http://localhost:#{port}/api/"]]
+          network: [%{allowed_url_prefix: "http://localhost:#{port}/api/"}]
         )
 
       assert result == 200
@@ -435,7 +435,7 @@ defmodule Pyex.Stdlib.RequestsTest do
           import requests
           requests.get("http://localhost:#{port}/secret")
           """,
-          network: [allowed_url_prefixes: ["https://api.example.com"]]
+          network: [%{allowed_url_prefix: "https://api.example.com/"}]
         )
       end
     end
@@ -455,7 +455,7 @@ defmodule Pyex.Stdlib.RequestsTest do
           response = requests.get("http://localhost:#{port}/data")
           response.status_code
           """,
-          network: [allowed_url_prefixes: [prefix]]
+          network: [%{allowed_url_prefix: prefix}]
         )
 
       assert result == 200
@@ -466,12 +466,12 @@ defmodule Pyex.Stdlib.RequestsTest do
           import requests
           requests.post("http://localhost:#{port}/data", json={})
           """,
-          network: [allowed_url_prefixes: [prefix]]
+          network: [%{allowed_url_prefix: prefix}]
         )
       end
     end
 
-    test "custom allowed_methods", %{bypass: bypass} do
+    test "custom methods per prefix", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/api/data", fn conn ->
         {:ok, _body, conn} = Plug.Conn.read_body(conn)
         Plug.Conn.resp(conn, 201, "created")
@@ -487,15 +487,44 @@ defmodule Pyex.Stdlib.RequestsTest do
           response.status_code
           """,
           network: [
-            allowed_url_prefixes: ["http://localhost:#{port}/"],
-            allowed_methods: ["GET", "HEAD", "POST"]
+            %{allowed_url_prefix: "http://localhost:#{port}/", methods: ["GET", "HEAD", "POST"]}
           ]
         )
 
       assert result == 201
     end
 
-    test "dangerously_allow_full_internet_access allows everything", %{bypass: bypass} do
+    test "dangerously_allow_full_internet_access defaults to GET/HEAD", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/data", fn conn ->
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/data")
+          response.status_code
+          """,
+          network: [%{dangerously_allow_full_internet_access: true}]
+        )
+
+      assert result == 200
+
+      assert_raise RuntimeError, ~r/NetworkError.*HTTP method DELETE is not allowed/, fn ->
+        Pyex.run!(
+          """
+          import requests
+          requests.delete("http://localhost:#{port}/data")
+          """,
+          network: [%{dangerously_allow_full_internet_access: true}]
+        )
+      end
+    end
+
+    test "dangerously_allow_full_internet_access with methods: :all", %{bypass: bypass} do
       Bypass.expect_once(bypass, "DELETE", "/api/item/1", fn conn ->
         Plug.Conn.resp(conn, 204, "")
       end)
@@ -509,10 +538,40 @@ defmodule Pyex.Stdlib.RequestsTest do
           response = requests.delete("http://localhost:#{port}/api/item/1")
           response.status_code
           """,
-          network: [dangerously_allow_full_internet_access: true]
+          network: [%{dangerously_allow_full_internet_access: true, methods: :all}]
         )
 
       assert result == 204
+    end
+
+    test "dangerously_allow_full_internet_access with method restriction", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/data", fn conn ->
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.get("http://localhost:#{port}/data")
+          response.status_code
+          """,
+          network: [%{dangerously_allow_full_internet_access: true, methods: ["GET"]}]
+        )
+
+      assert result == 200
+
+      assert_raise RuntimeError, ~r/NetworkError.*HTTP method POST is not allowed/, fn ->
+        Pyex.run!(
+          """
+          import requests
+          requests.post("http://localhost:#{port}/data", json={})
+          """,
+          network: [%{dangerously_allow_full_internet_access: true, methods: ["GET"]}]
+        )
+      end
     end
 
     test "multiple prefixes work", %{bypass: bypass} do
@@ -530,10 +589,8 @@ defmodule Pyex.Stdlib.RequestsTest do
           response.text
           """,
           network: [
-            allowed_url_prefixes: [
-              "http://localhost:#{port}/v1/",
-              "http://localhost:#{port}/v2/"
-            ]
+            %{allowed_url_prefix: "http://localhost:#{port}/v1/"},
+            %{allowed_url_prefix: "http://localhost:#{port}/v2/"}
           ]
         )
 
@@ -554,14 +611,14 @@ defmodule Pyex.Stdlib.RequestsTest do
           response = requests.head("http://localhost:#{port}/ping")
           response.status_code
           """,
-          network: [allowed_url_prefixes: ["http://localhost:#{port}/"]]
+          network: [%{allowed_url_prefix: "http://localhost:#{port}/"}]
         )
 
       assert result == 200
     end
 
-    test "empty config denies all URLs" do
-      assert_raise RuntimeError, ~r/NetworkError.*no allowed hosts or URL prefixes/, fn ->
+    test "empty rules list denies all URLs" do
+      assert_raise RuntimeError, ~r/NetworkError.*no network rules/, fn ->
         Pyex.run!(
           """
           import requests
@@ -571,148 +628,245 @@ defmodule Pyex.Stdlib.RequestsTest do
         )
       end
     end
-  end
 
-  describe "network access control: allowed_hosts" do
-    test "allows request to matching host", %{bypass: bypass} do
-      Bypass.expect_once(bypass, "GET", "/data", fn conn ->
-        Plug.Conn.resp(conn, 200, "ok")
+    test "mixed rules: dangerous GET + prefix POST with headers", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/public", fn conn ->
+        Plug.Conn.resp(conn, 200, "public data")
+      end)
+
+      Bypass.expect_once(bypass, "POST", "/api/data", fn conn ->
+        [auth] = Plug.Conn.get_req_header(conn, "authorization")
+        assert auth == "Bearer test-key"
+        Plug.Conn.resp(conn, 201, "created")
       end)
 
       port = bypass.port
 
-      result =
-        Pyex.run!(
-          """
-          import requests
-          response = requests.get("http://localhost:#{port}/data")
-          response.status_code
-          """,
-          network: [allowed_hosts: ["localhost"]]
-        )
-
-      assert result == 200
-    end
-
-    test "denies request to non-matching host" do
-      assert_raise RuntimeError, ~r/NetworkError.*URL is not allowed/, fn ->
-        Pyex.run!(
-          """
-          import requests
-          requests.get("http://evil.com/data")
-          """,
-          network: [allowed_hosts: ["api.example.com"]]
-        )
-      end
-    end
-
-    test "rejects subdomains (exact match only)" do
-      assert_raise RuntimeError, ~r/NetworkError.*URL is not allowed/, fn ->
-        Pyex.run!(
-          """
-          import requests
-          requests.get("http://evil.api.example.com/data")
-          """,
-          network: [allowed_hosts: ["api.example.com"]]
-        )
-      end
-    end
-
-    test "host matching is case-insensitive" do
-      assert_raise RuntimeError, ~r/NetworkError.*URL is not allowed/, fn ->
-        Pyex.run!(
-          """
-          import requests
-          requests.get("http://evil.com/data")
-          """,
-          network: [allowed_hosts: ["API.EXAMPLE.COM"]]
-        )
-      end
-    end
-
-    test "multiple allowed hosts", %{bypass: bypass} do
-      Bypass.expect_once(bypass, "GET", "/data", fn conn ->
-        Plug.Conn.resp(conn, 200, "ok")
-      end)
-
-      port = bypass.port
-
-      result =
-        Pyex.run!(
-          """
-          import requests
-          response = requests.get("http://localhost:#{port}/data")
-          response.status_code
-          """,
-          network: [allowed_hosts: ["api.example.com", "localhost"]]
-        )
-
-      assert result == 200
-    end
-
-    test "allowed_methods still applies with allowed_hosts", %{bypass: bypass} do
-      port = bypass.port
-
-      assert_raise RuntimeError, ~r/NetworkError.*HTTP method POST is not allowed/, fn ->
-        Pyex.run!(
-          """
-          import requests
-          requests.post("http://localhost:#{port}/data", json={})
-          """,
-          network: [allowed_hosts: ["localhost"]]
-        )
-      end
-    end
-
-    test "allowed_hosts and allowed_url_prefixes work together", %{bypass: bypass} do
-      Bypass.expect_once(bypass, "GET", "/api/v1/data", fn conn ->
-        Plug.Conn.resp(conn, 200, "from prefix")
-      end)
-
-      Bypass.expect_once(bypass, "GET", "/other", fn conn ->
-        Plug.Conn.resp(conn, 200, "from host")
-      end)
-
-      port = bypass.port
-
-      opts = [
-        network: [
-          allowed_hosts: ["localhost"],
-          allowed_url_prefixes: ["http://localhost:#{port}/api/"]
-        ]
+      network = [
+        %{dangerously_allow_full_internet_access: true, methods: ["GET"]},
+        %{
+          allowed_url_prefix: "http://localhost:#{port}/api/",
+          methods: ["POST"],
+          headers: %{"authorization" => "Bearer test-key"}
+        }
       ]
 
       r1 =
         Pyex.run!(
           """
           import requests
-          requests.get("http://localhost:#{port}/api/v1/data").text
+          requests.get("http://localhost:#{port}/public").text
           """,
-          opts
+          network: network
         )
+
+      assert r1 == "public data"
 
       r2 =
         Pyex.run!(
           """
           import requests
-          requests.get("http://localhost:#{port}/other").text
+          requests.post("http://localhost:#{port}/api/data", json={}).status_code
           """,
-          opts
+          network: network
         )
 
-      assert r1 == "from prefix"
-      assert r2 == "from host"
+      assert r2 == 201
     end
+  end
 
-    test "prevents api.example.com.evil.com subdomain attack" do
-      assert_raise RuntimeError, ~r/NetworkError.*URL is not allowed/, fn ->
+  describe "credential injection" do
+    test "specific matching rule injects headers even when broader rule also matches", %{
+      bypass: bypass
+    } do
+      Bypass.expect_once(bypass, "POST", "/v1/chat", fn conn ->
+        [auth] = Plug.Conn.get_req_header(conn, "authorization")
+        assert auth == "Bearer injected"
+
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
         Pyex.run!(
           """
           import requests
-          requests.get("https://api.example.com.evil.com/data")
+          response = requests.post("http://localhost:#{port}/v1/chat", json={})
+          response.status_code
           """,
-          network: [allowed_hosts: ["api.example.com"]]
+          network: [
+            %{dangerously_allow_full_internet_access: true, methods: :all},
+            %{
+              allowed_url_prefix: "http://localhost:#{port}/v1/",
+              methods: ["POST"],
+              headers: %{"authorization" => "Bearer injected"}
+            }
+          ]
         )
+
+      assert result == 200
+    end
+
+    test "injects headers from network rule", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/v1/chat", fn conn ->
+        [auth] = Plug.Conn.get_req_header(conn, "authorization")
+        assert auth == "Bearer sk-injected"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, ~s({"result": "ok"}))
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.post("http://localhost:#{port}/v1/chat", json={"prompt": "hi"})
+          response.json()["result"]
+          """,
+          network: [
+            %{
+              allowed_url_prefix: "http://localhost:#{port}/v1/",
+              methods: ["POST"],
+              headers: %{"authorization" => "Bearer sk-injected"}
+            }
+          ]
+        )
+
+      assert result == "ok"
+    end
+
+    test "injected headers override user-provided headers", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/v1/chat", fn conn ->
+        [auth] = Plug.Conn.get_req_header(conn, "authorization")
+        # The injected header wins, not the Python-provided one
+        assert auth == "Bearer sk-from-config"
+
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.post(
+              "http://localhost:#{port}/v1/chat",
+              json={},
+              headers={"Authorization": "Bearer sk-from-python"}
+          )
+          response.status_code
+          """,
+          network: [
+            %{
+              allowed_url_prefix: "http://localhost:#{port}/v1/",
+              methods: ["POST"],
+              headers: %{"authorization" => "Bearer sk-from-config"}
+            }
+          ]
+        )
+
+      assert result == 200
+    end
+
+    test "multiple injected headers", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/v1/chat", fn conn ->
+        [key] = Plug.Conn.get_req_header(conn, "x-api-key")
+        [version] = Plug.Conn.get_req_header(conn, "anthropic-version")
+        assert key == "sk-ant-test"
+        assert version == "2024-10-22"
+
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.post("http://localhost:#{port}/v1/chat", json={})
+          response.status_code
+          """,
+          network: [
+            %{
+              allowed_url_prefix: "http://localhost:#{port}/v1/",
+              methods: ["POST"],
+              headers: %{
+                "x-api-key" => "sk-ant-test",
+                "anthropic-version" => "2024-10-22"
+              }
+            }
+          ]
+        )
+
+      assert result == 200
+    end
+
+    test "no headers injected for plain prefix rules", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/data", fn conn ->
+        assert Plug.Conn.get_req_header(conn, "authorization") == []
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          requests.get("http://localhost:#{port}/data").status_code
+          """,
+          network: [%{allowed_url_prefix: "http://localhost:#{port}/"}]
+        )
+
+      assert result == 200
+    end
+
+    test "user headers preserved alongside injected headers", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/v1/chat", fn conn ->
+        [auth] = Plug.Conn.get_req_header(conn, "authorization")
+        [custom] = Plug.Conn.get_req_header(conn, "x-custom")
+        assert auth == "Bearer sk-injected"
+        assert custom == "user-value"
+
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.post(
+              "http://localhost:#{port}/v1/chat",
+              json={},
+              headers={"X-Custom": "user-value"}
+          )
+          response.status_code
+          """,
+          network: [
+            %{
+              allowed_url_prefix: "http://localhost:#{port}/v1/",
+              methods: ["POST"],
+              headers: %{"authorization" => "Bearer sk-injected"}
+            }
+          ]
+        )
+
+      assert result == 200
+    end
+  end
+
+  describe "normalize_network validation" do
+    test "raises on rule without prefix or dangerous flag" do
+      assert_raise ArgumentError, ~r/must have :allowed_url_prefix/, fn ->
+        Pyex.run!("1 + 1", network: [%{methods: ["GET"]}])
       end
     end
   end

--- a/test/pyex_test.exs
+++ b/test/pyex_test.exs
@@ -3,7 +3,7 @@ defmodule PyexTest do
 
   alias Pyex.Error
 
-  @network [dangerously_allow_full_internet_access: true]
+  @network [%{dangerously_allow_full_internet_access: true, methods: :all}]
 
   describe "end-to-end: two functions doing math" do
     test "define add and multiply, compose them" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.start(exclude: [:postgres, :r2])
+ExUnit.start(exclude: [:postgres, :r2, :external_http])
 
 if System.get_env("PYEX_TRACE") == "1" do
   trace = Pyex.Trace.attach()


### PR DESCRIPTION
## Summary
- switch network access to explicit rule maps with per-rule methods and optional injected headers
- harden rule normalization and matching so invalid prefixes are rejected, URL matching is case-insensitive for scheme/host, and specific matching rules can override broader ones
- add regression coverage for credential injection, rule validation, and the updated requests/boto3/readme behavior
- add opt-in live HTTP integration tests for `requests` covering real payloads, header precedence, denial behavior, and non-2xx responses
- run the new external HTTP suite in CI, expand the test matrix to include Elixir `1.20.0-rc.2`, and treat the RC jobs as informational while `explorer` catches up
- align the optional `explorer` dependency spec with the currently locked `0.11.1` release

## Verification
- mix test
- mix dialyzer
- mix test --include external_http test/pyex/stdlib/requests_integration_test.exs