### PR TITLE
Fix type comparisons against class objects

### DIFF
--- a/lib/pyex/interpreter/binary_ops.ex
+++ b/lib/pyex/interpreter/binary_ops.ex
@@ -350,6 +350,18 @@ defmodule Pyex.Interpreter.BinaryOps do
   defp dispatch(:eq, l, {:py_list, reversed, _}) when is_list(l),
     do: l == Enum.reverse(reversed)
 
+  defp dispatch(:eq, {:instance, {:class, "type", _, _}, attrs}, {:builtin_type, name, _}),
+    do: builtin_type_instance_name(attrs) == name
+
+  defp dispatch(:eq, {:builtin_type, name, _}, {:instance, {:class, "type", _, _}, attrs}),
+    do: name == builtin_type_instance_name(attrs)
+
+  defp dispatch(:eq, {:instance, {:class, "type", _, _}, attrs}, {:class, class_name, _, _}),
+    do: builtin_type_instance_name(attrs) == class_name
+
+  defp dispatch(:eq, {:class, class_name, _, _}, {:instance, {:class, "type", _, _}, attrs}),
+    do: class_name == builtin_type_instance_name(attrs)
+
   defp dispatch(:eq, l, r), do: l == r
 
   defp dispatch(:neq, {:py_list, lr, _}, {:py_list, rr, _}),
@@ -360,6 +372,18 @@ defmodule Pyex.Interpreter.BinaryOps do
 
   defp dispatch(:neq, l, {:py_list, reversed, _}) when is_list(l),
     do: l != Enum.reverse(reversed)
+
+  defp dispatch(:neq, {:instance, {:class, "type", _, _}, attrs}, {:builtin_type, name, _}),
+    do: builtin_type_instance_name(attrs) != name
+
+  defp dispatch(:neq, {:builtin_type, name, _}, {:instance, {:class, "type", _, _}, attrs}),
+    do: name != builtin_type_instance_name(attrs)
+
+  defp dispatch(:neq, {:instance, {:class, "type", _, _}, attrs}, {:class, class_name, _, _}),
+    do: builtin_type_instance_name(attrs) != class_name
+
+  defp dispatch(:neq, {:class, class_name, _, _}, {:instance, {:class, "type", _, _}, attrs}),
+    do: class_name != builtin_type_instance_name(attrs)
 
   defp dispatch(:neq, l, r), do: l != r
 
@@ -400,7 +424,32 @@ defmodule Pyex.Interpreter.BinaryOps do
 
   # -- identity -------------------------------------------------------
 
+  defp dispatch(:is, {:instance, {:class, "type", _, _}, attrs}, {:builtin_type, name, _}),
+    do: builtin_type_instance_name(attrs) == name
+
+  defp dispatch(:is, {:builtin_type, name, _}, {:instance, {:class, "type", _, _}, attrs}),
+    do: name == builtin_type_instance_name(attrs)
+
+  defp dispatch(:is, {:instance, {:class, "type", _, _}, attrs}, {:class, class_name, _, _}),
+    do: builtin_type_instance_name(attrs) == class_name
+
+  defp dispatch(:is, {:class, class_name, _, _}, {:instance, {:class, "type", _, _}, attrs}),
+    do: class_name == builtin_type_instance_name(attrs)
+
   defp dispatch(:is, l, r), do: l === r
+
+  defp dispatch(:is_not, {:instance, {:class, "type", _, _}, attrs}, {:builtin_type, name, _}),
+    do: builtin_type_instance_name(attrs) != name
+
+  defp dispatch(:is_not, {:builtin_type, name, _}, {:instance, {:class, "type", _, _}, attrs}),
+    do: name != builtin_type_instance_name(attrs)
+
+  defp dispatch(:is_not, {:instance, {:class, "type", _, _}, attrs}, {:class, class_name, _, _}),
+    do: builtin_type_instance_name(attrs) != class_name
+
+  defp dispatch(:is_not, {:class, class_name, _, _}, {:instance, {:class, "type", _, _}, attrs}),
+    do: class_name != builtin_type_instance_name(attrs)
+
   defp dispatch(:is_not, l, r), do: l !== r
 
   # -- not_in ---------------------------------------------------------
@@ -479,6 +528,10 @@ defmodule Pyex.Interpreter.BinaryOps do
 
   defp dispatch(:rshift, l, r),
     do: type_error(">>", l, r)
+
+  @spec builtin_type_instance_name(map()) :: String.t() | nil
+  defp builtin_type_instance_name(%{"__name__" => name}) when is_binary(name), do: name
+  defp builtin_type_instance_name(_), do: nil
 
   # -------------------------------------------------------------------
   # Private helpers

--- a/test/pyex/builtins_test.exs
+++ b/test/pyex/builtins_test.exs
@@ -305,6 +305,97 @@ defmodule Pyex.BuiltinsTest do
       {:instance, _, %{"__name__" => name}} = Pyex.run!("type({})")
       assert name == "dict"
     end
+
+    test "builtin type comparisons match builtin type objects" do
+      result =
+        Pyex.run!("""
+        x_dict = {"a": 1}
+        x_list = [1, 2]
+        x_str = "hello"
+        x_int = 42
+        x_float = 3.14
+        x_bool = True
+        x_tuple = (1, 2)
+        x_set = {1, 2}
+
+        (
+            type(x_dict) == dict,
+            type(x_dict) != dict,
+            dict == type(x_dict),
+            type(x_list) == list,
+            type(x_str) == str,
+            type(x_int) == int,
+            type(x_float) == float,
+            type(x_bool) == bool,
+            type(x_tuple) == tuple,
+            type(x_set) == set,
+            type(x_dict) == list,
+            type(x_bool) == int
+        )
+        """)
+
+      assert result ==
+               {:tuple,
+                [true, false, true, true, true, true, true, true, true, true, false, false]}
+    end
+
+    test "builtin exact type checks work with is and is not" do
+      result =
+        Pyex.run!("""
+        x_dict = {"a": 1}
+        x_list = [1, 2]
+        x_str = "hello"
+        x_int = 42
+        x_float = 3.14
+        x_bool = True
+        x_tuple = (1, 2)
+        x_set = {1, 2}
+
+        (
+            type(x_dict) is dict,
+            type(x_dict) is not dict,
+            type(x_list) is list,
+            type(x_str) is str,
+            type(x_int) is int,
+            type(x_float) is float,
+            type(x_bool) is bool,
+            type(x_tuple) is tuple,
+            type(x_set) is set,
+            type(x_dict) is list,
+            type(x_dict) is not list
+        )
+        """)
+
+      assert result ==
+               {:tuple, [true, false, true, true, true, true, true, true, true, false, true]}
+    end
+
+    test "user-defined class comparisons match exact type semantics" do
+      result =
+        Pyex.run!("""
+        class Foo:
+            pass
+
+        class Bar:
+            pass
+
+        x = Foo()
+
+        (
+            type(x) == Foo,
+            type(x) != Foo,
+            Foo == type(x),
+            type(x) is Foo,
+            type(x) is not Foo,
+            type(x) == Bar,
+            type(x) != Bar,
+            type(x) is Bar,
+            type(x) is not Bar
+        )
+        """)
+
+      assert result == {:tuple, [true, false, true, true, false, false, true, false, true]}
+    end
   end
 
   describe "abs()" do
@@ -528,6 +619,24 @@ defmodule Pyex.BuiltinsTest do
     test "isinstance with builtin type set" do
       assert Pyex.run!("isinstance({1, 2}, set)") == true
       assert Pyex.run!("isinstance([1, 2], set)") == false
+    end
+
+    test "isinstance works for all builtin collection and scalar types" do
+      result =
+        Pyex.run!("""
+        (
+            isinstance({"a": 1}, dict),
+            isinstance([1, 2], list),
+            isinstance("hello", str),
+            isinstance(42, int),
+            isinstance(3.14, float),
+            isinstance(True, bool),
+            isinstance((1, 2), tuple),
+            isinstance({1, 2}, set)
+        )
+        """)
+
+      assert result == {:tuple, [true, true, true, true, true, true, true, true]}
     end
 
     test "isinstance with tuple of types" do


### PR DESCRIPTION
## Summary
- make `type(...)` compare correctly against builtin type objects and user-defined classes for `==`, `!=`, `is`, and `is not`
- add regression coverage for exact-type checks across builtin scalar/collection types plus user-defined classes
- keep `isinstance(...)` coverage alongside the new type-comparison cases

## Verification
- mix test test/pyex/builtins_test.exs