### PR TITLE
Make boto3 AWS config host-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Initial release.
 
 ### Sandbox
 
-- Compute budget via `timeout_ms`
+- Compute budget via `timeout`
 - Network access policy (deny-by-default, allowlist hosts/prefixes)
 - Capability gates for SQL and S3 (deny-by-default)
 - Pluggable filesystem backends (Memory, S3)

--- a/README.md
+++ b/README.md
@@ -109,8 +109,17 @@ SQL and S3 require explicit opt-in:
 
 ```elixir
 Pyex.run(source, sql: true, env: %{"DATABASE_URL" => "postgres://..."})
-Pyex.run(source, boto3: true)
+Pyex.run(source,
+  boto3: true,
+  aws: [
+    region: "us-east-1",
+    access_key_id: "...",
+    secret_access_key: "..."
+  ])
 ```
+
+`boto3` uses host-provided AWS configuration. Sandboxed Python code
+cannot supply credentials or override the S3 endpoint.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ what it can access.
 ### Compute budget
 
 ```elixir
-Pyex.run(source, timeout_ms: 5_000)
+Pyex.run(source, timeout: 5_000)
 # => {:error, %Pyex.Error{kind: :timeout}}
 ```
 

--- a/bench/generators.exs
+++ b/bench/generators.exs
@@ -1,7 +1,7 @@
 alias Pyex.Ctx
 
 ctx = %{
-  Ctx.new(timeout_ms: 200)
+  Ctx.new(timeout: 200)
   | compute: 0.0,
     compute_started_at: System.monotonic_time()
 }

--- a/bench/golden_cross_bench.exs
+++ b/bench/golden_cross_bench.exs
@@ -141,7 +141,7 @@ IO.puts("=== Golden Cross Benchmark ===\n")
 for n <- [300, 1000] do
   prices = GoldenCrossBench.generate_prices(n)
   modules = GoldenCrossBench.platform_module(prices)
-  opts = [timeout_ms: 30_000, modules: modules]
+  opts = [timeout: 30_000, modules: modules]
   runs = if n <= 300, do: 20, else: 10
 
   IO.puts("#{n} price points (#{runs} runs):")

--- a/bench/math_oracle_bench.exs
+++ b/bench/math_oracle_bench.exs
@@ -117,7 +117,7 @@ defmodule MathOracleBench do
     csv = build_csv(row_count)
     fs = Memory.new()
     {:ok, fs} = Memory.write(fs, "data.csv", csv, :write)
-    opts = [filesystem: fs, timeout_ms: 5000]
+    opts = [filesystem: fs, timeout: 5000]
     source = python_source(row_count)
 
     # warm up

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -31,7 +31,7 @@ defmodule Pyex do
 
       Pyex.run(source,
         env: %{"API_KEY" => "sk-..."},
-        timeout_ms: 5_000,
+        timeout: 5_000,
         modules: %{"mylib" => %{"greet" => {:builtin, fn [n] -> "hi \#{n}" end}}})
 
   See `run/2` for the full list of options.
@@ -67,7 +67,7 @@ defmodule Pyex do
   - `:modules` -- custom Python modules available via `import`
   - `:filesystem` -- a filesystem backend struct (module derived automatically)
   - `:env` -- environment variables for `os.environ`
-  - `:timeout_ms` -- compute time budget in milliseconds
+  - `:timeout` -- compute time budget in milliseconds
   - `:network` -- network access policy for the `requests` module.
     A list of rule maps, each with `:allowed_url_prefix` or
     `:dangerously_allow_full_internet_access`, plus optional `:methods`

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -73,6 +73,10 @@ defmodule Pyex do
     `:dangerously_allow_full_internet_access`, plus optional `:methods`
     (default `["GET", "HEAD"]`) and `:headers` (injected into matching
     requests). When omitted, all network access is denied.
+  - `:aws` -- host-owned AWS configuration for `boto3`. Accepts
+    `:region`, `:access_key_id`, `:secret_access_key`, and optional
+    `:session_token` / `:endpoint_url`. Python code cannot override
+    these values.
   - `:capabilities` -- list of enabled I/O capabilities (e.g.
     `[:boto3, :sql]`). All capabilities are denied by default.
   - `:boto3` -- shorthand for adding `:boto3` to capabilities.

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -45,7 +45,22 @@ defmodule Pyex.Ctx do
 
   @type network_config :: [network_rule()] | nil
 
+  @type aws_config :: %{
+          required(:region) => String.t(),
+          required(:access_key_id) => String.t(),
+          required(:secret_access_key) => String.t(),
+          optional(:session_token) => String.t(),
+          optional(:endpoint_url) => String.t()
+        }
+
   @url_prefix_pattern ~r/\A([a-z][a-z0-9+\-.]*:\/\/)([^\/?#]*)(.*)\z/i
+
+  @network_rule_keys [
+    :allowed_url_prefix,
+    :dangerously_allow_full_internet_access,
+    :methods,
+    :headers
+  ]
 
   @type capability :: :boto3 | :sql | atom()
 
@@ -67,6 +82,7 @@ defmodule Pyex.Ctx do
           iterators: %{optional(non_neg_integer()) => [term()] | term()},
           next_iterator_id: non_neg_integer(),
           network: network_config() | nil,
+          aws: aws_config() | nil,
           capabilities: MapSet.t(capability()),
           exception_instance: term(),
           current_line: non_neg_integer() | nil,
@@ -97,6 +113,7 @@ defmodule Pyex.Ctx do
             iterators: %{},
             next_iterator_id: 0,
             network: nil,
+            aws: nil,
             capabilities: MapSet.new(),
             exception_instance: nil,
             current_line: nil,
@@ -153,6 +170,18 @@ defmodule Pyex.Ctx do
             methods: ["POST"],
             headers: %{"authorization" => "Bearer sk-..."}}
         ]
+  - `:aws` -- host-owned AWS configuration for the `boto3` module.
+
+    Accepts a keyword list or map with:
+    - `:region` -- AWS region used for S3 requests
+    - `:access_key_id` -- AWS access key id
+    - `:secret_access_key` -- AWS secret access key
+    - `:session_token` -- optional temporary credential token
+    - `:endpoint_url` -- optional fixed custom S3-compatible endpoint
+
+    Sandboxed Python code cannot override these values. Configure
+    `:boto3` to enable S3 operations and `:aws` to choose the identity
+    and endpoint they use.
   - `:capabilities` -- a list of atoms naming enabled I/O capabilities.
     Known capabilities: `:boto3` (S3 operations), `:sql` (database
     queries). All capabilities are denied by default.
@@ -166,6 +195,7 @@ defmodule Pyex.Ctx do
     :timeout_ms,
     :profile,
     :network,
+    :aws,
     :capabilities,
     :boto3,
     :sql,
@@ -198,6 +228,7 @@ defmodule Pyex.Ctx do
         else: nil
 
     network = normalize_network(Keyword.get(opts, :network))
+    aws = normalize_aws(Keyword.get(opts, :aws))
     capabilities = normalize_capabilities(opts)
     file = Keyword.get(opts, :file)
 
@@ -210,6 +241,7 @@ defmodule Pyex.Ctx do
       compute_started_at: System.monotonic_time(),
       profile: profile,
       network: network,
+      aws: aws,
       capabilities: capabilities,
       file: file
     }
@@ -244,6 +276,72 @@ defmodule Pyex.Ctx do
     MapSet.new(explicit ++ shorthand)
   end
 
+  @spec normalize_aws(keyword() | map() | nil) :: aws_config() | nil
+  defp normalize_aws(nil), do: nil
+
+  defp normalize_aws(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      opts |> Map.new() |> normalize_aws()
+    else
+      raise_invalid_aws_config()
+    end
+  end
+
+  defp normalize_aws(%{} = opts) do
+    validate_aws_keys!(opts)
+
+    aws = %{
+      region: fetch_required_aws_string!(opts, :region),
+      access_key_id: fetch_required_aws_string!(opts, :access_key_id),
+      secret_access_key: fetch_required_aws_string!(opts, :secret_access_key)
+    }
+
+    aws
+    |> put_optional_aws_string(opts, :session_token)
+    |> put_optional_aws_string(opts, :endpoint_url)
+  end
+
+  defp normalize_aws(_), do: raise_invalid_aws_config()
+
+  @aws_config_keys [:region, :access_key_id, :secret_access_key, :session_token, :endpoint_url]
+
+  @spec raise_invalid_aws_config() :: no_return()
+  defp raise_invalid_aws_config do
+    raise ArgumentError,
+          "aws must be a keyword list or map. " <>
+            "Use aws: [region: \"us-east-1\", access_key_id: \"...\", secret_access_key: \"...\"]"
+  end
+
+  @spec validate_aws_keys!(map()) :: :ok
+  defp validate_aws_keys!(opts) do
+    unknown = Map.keys(opts) -- @aws_config_keys
+
+    if unknown != [] do
+      raise ArgumentError,
+            "unknown keys #{inspect(unknown)} in aws config. " <>
+              "Valid keys: #{inspect(@aws_config_keys)}"
+    end
+
+    :ok
+  end
+
+  @spec fetch_required_aws_string!(map(), atom()) :: String.t()
+  defp fetch_required_aws_string!(opts, key) do
+    case Map.get(opts, key) do
+      value when is_binary(value) and value != "" -> value
+      _ -> raise ArgumentError, "aws #{inspect(key)} must be a non-empty string"
+    end
+  end
+
+  @spec put_optional_aws_string(aws_config(), map(), atom()) :: aws_config()
+  defp put_optional_aws_string(aws, opts, key) do
+    case Map.get(opts, key) do
+      nil -> aws
+      value when is_binary(value) and value != "" -> Map.put(aws, key, value)
+      _ -> raise ArgumentError, "aws #{inspect(key)} must be a non-empty string"
+    end
+  end
+
   @spec normalize_network(term()) :: network_config()
   defp normalize_network(nil), do: nil
   defp normalize_network([]), do: []
@@ -271,6 +369,8 @@ defmodule Pyex.Ctx do
 
   @spec normalize_rule(term()) :: network_rule()
   defp normalize_rule(%{} = rule) do
+    validate_rule_keys!(rule)
+
     has_prefix = Map.has_key?(rule, :allowed_url_prefix)
     has_dangerous = Map.get(rule, :dangerously_allow_full_internet_access, false) == true
 
@@ -311,6 +411,19 @@ defmodule Pyex.Ctx do
 
   defp normalize_rule(_) do
     raise ArgumentError, "each network rule must be a map"
+  end
+
+  @spec validate_rule_keys!(map()) :: :ok
+  defp validate_rule_keys!(rule) do
+    unknown = Map.keys(rule) -- @network_rule_keys
+
+    if unknown != [] do
+      raise ArgumentError,
+            "unknown keys #{inspect(unknown)} in network rule. " <>
+              "Valid keys: #{inspect(@network_rule_keys)}"
+    end
+
+    :ok
   end
 
   @spec normalize_allowed_url_prefix(term()) :: String.t()

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -12,7 +12,7 @@ defmodule Pyex.Ctx do
 
       Pyex.run(source,
         env: %{"KEY" => "val"},
-        timeout_ms: 5_000,
+        timeout: 5_000,
         modules: %{"mylib" => %{...}})
 
   Use `Ctx.new/1` when you need to share a context across
@@ -132,7 +132,7 @@ defmodule Pyex.Ctx do
   - `:modules` -- custom Python modules available via `import`. A map from
     module name strings to either a `%{String.t() => pyvalue()}` map or a
     module implementing `Pyex.Stdlib.Module`.
-  - `:timeout_ms` -- maximum *compute* time in milliseconds (nil = no limit).
+  - `:timeout` -- maximum *compute* time in milliseconds (nil = no limit).
     I/O time (HTTP requests, SQL queries) does not count against the budget.
   - `:profile` -- when `true`, collects per-line execution counts and
     per-function call counts with timing. Results are stored in the
@@ -192,7 +192,7 @@ defmodule Pyex.Ctx do
     :filesystem,
     :env,
     :modules,
-    :timeout_ms,
+    :timeout,
     :profile,
     :network,
     :aws,
@@ -217,7 +217,7 @@ defmodule Pyex.Ctx do
     modules = Keyword.get(opts, :modules, %{}) |> normalize_modules()
 
     timeout =
-      case Keyword.get(opts, :timeout_ms) do
+      case Keyword.get(opts, :timeout) do
         nil -> nil
         ms when is_integer(ms) -> ms
       end

--- a/lib/pyex/entropy.ex
+++ b/lib/pyex/entropy.ex
@@ -1,0 +1,230 @@
+defmodule Pyex.Entropy do
+  @moduledoc """
+  Shannon entropy primitives for binary analysis and secret detection.
+  """
+
+  @type hit :: %{
+          offset: non_neg_integer(),
+          entropy: float(),
+          window: binary(),
+          matcher: atom() | nil
+        }
+
+  @default_window_size 64
+  @default_threshold 5.8
+
+  @builtin_matchers %{
+    aws_access_key: ~r/AKIA[0-9A-Z]{16}/,
+    aws_secret_key:
+      ~r/(?i)aws(.{0,20})?(secret|access)?(.{0,20})?(key)?\s*[:=]\s*["']?[A-Za-z0-9\/+=]{40}["']?/,
+    google_api_key: ~r/AIza[0-9A-Za-z\-_]{35}/,
+    azure_storage_connection_string:
+      ~r/DefaultEndpointsProtocol=https;AccountName=[^;]+;AccountKey=[A-Za-z0-9+\/=]+;EndpointSuffix=core\.windows\.net/,
+    github_token: ~r/ghp_[A-Za-z0-9]{36}/,
+    github_fine_grained: ~r/github_pat_[A-Za-z0-9_]{82}/,
+    openai_key: ~r/sk-(?!(?:ant-|or-v1-))(?:proj-)?[A-Za-z0-9_-]{20,}/,
+    anthropic_key: ~r/sk-ant-[A-Za-z0-9_-]{20,}/,
+    openrouter_key: ~r/sk-or-v1-[A-Za-z0-9_-]{20,}/,
+    groq_key: ~r/gsk_[A-Za-z0-9]{20,}/,
+    huggingface_token: ~r/hf_[A-Za-z0-9]{30,}/,
+    stripe_live: ~r/sk_live_[A-Za-z0-9]{24,}/,
+    stripe_test: ~r/sk_test_[A-Za-z0-9]{24,}/,
+    slack_token: ~r/xox[bpors]-[A-Za-z0-9\-]{10,}/,
+    private_key: ~r/-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----/,
+    generic_secret: ~r/(?i)(secret|password|token|api_key|apikey)\s*[:=]\s*["'][^\s"']{8,}["']/
+  }
+
+  @doc """
+  Computes the Shannon entropy of a binary in bits per byte.
+
+  ## Examples
+
+      iex> Pyex.Entropy.shannon("aaaa")
+      0.0
+
+      iex> Pyex.Entropy.shannon("abcd")
+      2.0
+
+  """
+  @spec shannon(binary()) :: float()
+  def shannon(<<>>), do: 0.0
+
+  def shannon(binary) when is_binary(binary) do
+    size = byte_size(binary)
+
+    binary
+    |> byte_freqs()
+    |> entropy_from_freqs(size)
+  end
+
+  @doc """
+  Returns the builtin matcher map. Useful for inspection or selective inclusion.
+
+  ## Examples
+
+      iex> Map.has_key?(Pyex.Entropy.builtin_matchers(), :openai_key)
+      true
+
+  """
+  @spec builtin_matchers() :: %{atom() => Regex.t()}
+  def builtin_matchers, do: @builtin_matchers
+
+  @doc """
+  Scans a binary with a sliding window and optional regex matchers.
+
+  Returns a list of `%{offset, entropy, window, matcher}` maps. A hit fires
+  when *either* condition is met:
+
+    * window entropy >= threshold
+    * a matcher regex matches the window
+
+  When both match, the hit includes the matcher name. When only entropy
+  triggers, `matcher` is `nil`.
+
+  ## Options
+
+    * `:window_size` - sliding window in bytes (default: #{@default_window_size})
+    * `:threshold` - minimum entropy in bits to report (default: #{@default_threshold})
+    * `:matchers` - `%{atom() => Regex.t()}` of named patterns (default: `%{}`)
+    * `:builtins` - include builtin matchers (default: `false`)
+
+  ## Examples
+
+      iex> token = "tok_" <> String.duplicate("a", 24)
+      iex> input = ~s(config = {api_key: ") <> token <> ~s("})
+      iex> matchers = %{custom_token: ~r/tok_[A-Za-z0-9]{24,}/}
+      iex> hits = Pyex.Entropy.scan(input, matchers: matchers, threshold: 99.0, window_size: 256)
+      iex> Enum.any?(hits, &(&1.matcher == :custom_token))
+      true
+
+  """
+  @spec scan(binary(), keyword()) :: [hit()]
+  def scan(binary, opts \\ []) when is_binary(binary) do
+    window_size = normalize_window_size!(Keyword.get(opts, :window_size, @default_window_size))
+    threshold = normalize_threshold!(Keyword.get(opts, :threshold, @default_threshold))
+    user_matchers = normalize_matchers!(Keyword.get(opts, :matchers, %{}))
+    builtins = if Keyword.get(opts, :builtins, false), do: @builtin_matchers, else: %{}
+    matchers = Map.merge(builtins, user_matchers)
+
+    case byte_size(binary) do
+      0 -> []
+      size when size < window_size -> collect_single(binary, threshold, matchers)
+      _size -> do_scan(binary, window_size, threshold, matchers)
+    end
+  end
+
+  # -- Private --
+
+  defp do_scan(binary, window_size, threshold, matchers) do
+    size = byte_size(binary)
+
+    init_freqs =
+      for <<byte <- binary_part(binary, 0, window_size)>>, reduce: %{} do
+        acc -> Map.update(acc, byte, 1, &(&1 + 1))
+      end
+
+    {_freqs, hits} =
+      1..(size - window_size)//1
+      |> Enum.reduce(
+        {init_freqs, collect(binary, 0, init_freqs, window_size, threshold, matchers)},
+        fn offset, {freqs, hits} ->
+          entering = :binary.at(binary, offset + window_size - 1)
+          leaving = :binary.at(binary, offset - 1)
+
+          freqs =
+            freqs
+            |> Map.update(entering, 1, &(&1 + 1))
+            |> decrement_or_remove(leaving)
+
+          {freqs, collect(binary, offset, freqs, window_size, threshold, matchers) ++ hits}
+        end
+      )
+
+    hits
+    |> Enum.reverse()
+    |> dedupe()
+  end
+
+  defp collect_single(binary, threshold, matchers) do
+    collect(binary, 0, byte_freqs(binary), byte_size(binary), threshold, matchers)
+  end
+
+  defp collect(binary, offset, freqs, window_size, threshold, matchers) do
+    window = binary_part(binary, offset, window_size)
+    h = entropy_from_freqs(freqs, window_size)
+    matched = find_matchers(window, matchers)
+
+    cond do
+      matched != [] ->
+        Enum.map(matched, fn name ->
+          %{offset: offset, entropy: h, window: window, matcher: name}
+        end)
+
+      h >= threshold ->
+        [%{offset: offset, entropy: h, window: window, matcher: nil}]
+
+      true ->
+        []
+    end
+  end
+
+  defp find_matchers(_window, matchers) when map_size(matchers) == 0, do: []
+
+  defp find_matchers(window, matchers) do
+    for {name, regex} <- matchers, Regex.match?(regex, window), do: name
+  end
+
+  defp dedupe(hits) do
+    # collapse overlapping windows that matched the same pattern
+    hits
+    |> Enum.reduce({[], nil}, fn hit, {acc, prev} ->
+      if prev && hit.matcher && hit.matcher == prev.matcher &&
+           hit.offset - prev.offset < byte_size(prev.window) do
+        {acc, prev}
+      else
+        {[hit | acc], hit}
+      end
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+
+  defp byte_freqs(binary) do
+    for <<byte <- binary>>, reduce: %{} do
+      acc -> Map.update(acc, byte, 1, &(&1 + 1))
+    end
+  end
+
+  defp entropy_from_freqs(freqs, total) do
+    Enum.reduce(freqs, 0.0, fn {_byte, count}, acc ->
+      p = count / total
+      acc - p * :math.log2(p)
+    end)
+  end
+
+  defp decrement_or_remove(freqs, byte) do
+    case freqs[byte] do
+      1 -> Map.delete(freqs, byte)
+      n -> Map.put(freqs, byte, n - 1)
+    end
+  end
+
+  defp normalize_window_size!(window_size) when is_integer(window_size) and window_size > 0,
+    do: window_size
+
+  defp normalize_window_size!(_window_size) do
+    raise ArgumentError, "window_size must be a positive integer"
+  end
+
+  defp normalize_threshold!(threshold) when is_number(threshold), do: threshold * 1.0
+
+  defp normalize_threshold!(_threshold) do
+    raise ArgumentError, "threshold must be a number"
+  end
+
+  defp normalize_matchers!(matchers) when is_map(matchers), do: matchers
+
+  defp normalize_matchers!(_matchers) do
+    raise ArgumentError, "matchers must be a map"
+  end
+end

--- a/lib/pyex/stdlib/boto3.ex
+++ b/lib/pyex/stdlib/boto3.ex
@@ -23,7 +23,17 @@ defmodule Pyex.Stdlib.Boto3 do
 
   ## Testing with a local endpoint
 
-      s3 = boto3.client('s3', endpoint_url='http://localhost:9000')
+      ctx = Pyex.Ctx.new(
+        boto3: true,
+        aws: [
+          region: "us-east-1",
+          access_key_id: "test",
+          secret_access_key: "test",
+          endpoint_url: "http://localhost:9000"
+        ]
+      )
+
+      Pyex.run(source, ctx)
   """
 
   @behaviour Pyex.Stdlib.Module
@@ -55,52 +65,64 @@ defmodule Pyex.Stdlib.Boto3 do
     {:exception, "TypeError: boto3.client() requires a service name string"}
   end
 
-  @typep s3_config :: %{
-           region: String.t(),
-           endpoint_url: String.t() | nil,
-           signing_opts: keyword() | nil
-         }
-
   @spec build_s3_client(%{optional(String.t()) => Pyex.Interpreter.pyvalue()}) ::
           Pyex.Interpreter.pyvalue()
-  defp build_s3_client(kwargs) do
-    region = Map.get(kwargs, "region_name", "us-east-1")
-    endpoint_url = Map.get(kwargs, "endpoint_url")
-    access_key = Map.get(kwargs, "aws_access_key_id")
-    secret_key = Map.get(kwargs, "aws_secret_access_key")
-
-    signing_opts = build_signing_opts(region, access_key, secret_key)
-
-    config = %{region: region, endpoint_url: endpoint_url, signing_opts: signing_opts}
-
+  defp build_s3_client(%{} = kwargs) when map_size(kwargs) == 0 do
     %{
       "__boto3_s3_client__" => true,
-      "__region__" => region,
-      "__endpoint_url__" => endpoint_url,
-      "put_object" => {:builtin_kw, &s3_put_object(config, &1, &2)},
-      "get_object" => {:builtin_kw, &s3_get_object(config, &1, &2)},
-      "delete_object" => {:builtin_kw, &s3_delete_object(config, &1, &2)},
-      "list_objects_v2" => {:builtin_kw, &s3_list_objects_v2(config, &1, &2)}
+      "put_object" => {:builtin_kw, &s3_put_object/2},
+      "get_object" => {:builtin_kw, &s3_get_object/2},
+      "delete_object" => {:builtin_kw, &s3_delete_object/2},
+      "list_objects_v2" => {:builtin_kw, &s3_list_objects_v2/2}
     }
   end
 
-  @spec check_endpoint_network(Pyex.Ctx.t(), String.t()) :: :ok | {:exception, String.t()}
-  defp check_endpoint_network(%Pyex.Ctx{network: nil}, _url), do: :ok
+  defp build_s3_client(_kwargs) do
+    {:exception,
+     "PermissionError: boto3.client('s3') options must be configured by the host via the :aws option"}
+  end
 
-  defp check_endpoint_network(ctx, url) do
-    case Pyex.Ctx.check_network_access(ctx, "GET", url) do
-      {:ok, _headers} -> :ok
-      {:denied, reason} -> {:exception, reason}
+  @spec s3_config(Pyex.Ctx.t()) :: {:ok, Pyex.Ctx.aws_config()} | {:error, String.t()}
+  defp s3_config(%Pyex.Ctx{aws: nil}) do
+    {:error,
+     "PermissionError: boto3 is enabled but no AWS configuration is available. " <>
+       "Configure the :aws option"}
+  end
+
+  defp s3_config(%Pyex.Ctx{aws: config}), do: {:ok, config}
+
+  @spec check_endpoint_network(Pyex.Ctx.t(), Pyex.Ctx.aws_config(), String.t(), String.t()) ::
+          :ok | {:exception, String.t()}
+  defp check_endpoint_network(ctx, config, method, url) do
+    case {Map.get(config, :endpoint_url), ctx.network} do
+      {nil, _network} ->
+        :ok
+
+      {_endpoint, nil} ->
+        :ok
+
+      {_endpoint, _network} ->
+        case Pyex.Ctx.check_network_access(ctx, method, url) do
+          {:ok, _headers} -> :ok
+          {:denied, reason} -> {:exception, reason}
+        end
     end
   end
 
-  @spec build_signing_opts(String.t(), String.t() | nil, String.t() | nil) :: keyword() | nil
-  defp build_signing_opts(region, access_key, secret_key)
-       when is_binary(access_key) and is_binary(secret_key) do
-    [service: :s3, region: region, access_key_id: access_key, secret_access_key: secret_key]
-  end
+  @spec build_signing_opts(Pyex.Ctx.aws_config()) :: keyword()
+  defp build_signing_opts(config) do
+    opts = [
+      service: :s3,
+      region: config.region,
+      access_key_id: config.access_key_id,
+      secret_access_key: config.secret_access_key
+    ]
 
-  defp build_signing_opts(_region, _access_key, _secret_key), do: nil
+    case Map.get(config, :session_token) do
+      nil -> opts
+      token -> Keyword.put(opts, :token, token)
+    end
+  end
 
   @spec object_url(String.t(), String.t(), String.t(), String.t() | nil) :: String.t()
   defp object_url(bucket, key, region, nil) do
@@ -122,14 +144,13 @@ defmodule Pyex.Stdlib.Boto3 do
     "#{base}/#{bucket}/"
   end
 
-  @spec signing_req_opts(keyword() | nil) :: keyword()
-  defp signing_req_opts(nil), do: []
-  defp signing_req_opts(opts), do: [aws_sigv4: opts]
+  @spec signing_req_opts(Pyex.Ctx.aws_config()) :: keyword()
+  defp signing_req_opts(config), do: [aws_sigv4: build_signing_opts(config)]
 
-  @spec s3_put_object(s3_config(), [Pyex.Interpreter.pyvalue()], %{
+  @spec s3_put_object([Pyex.Interpreter.pyvalue()], %{
           optional(String.t()) => Pyex.Interpreter.pyvalue()
         }) :: s3_result()
-  defp s3_put_object(config, _args, kwargs) do
+  defp s3_put_object(_args, kwargs) do
     bucket = Map.get(kwargs, "Bucket")
     key = Map.get(kwargs, "Key")
     body = Map.get(kwargs, "Body", "")
@@ -143,46 +164,52 @@ defmodule Pyex.Stdlib.Boto3 do
         {:exception, "ParamValidationError: Missing required parameter: 'Key'"}
 
       true ->
-        url = object_url(bucket, key, config.region, config.endpoint_url)
         body_bytes = if is_binary(body), do: body, else: to_string(body)
 
-        headers =
-          if is_binary(content_type),
-            do: [{"content-type", content_type}],
-            else: []
-
-        req_opts =
-          [body: body_bytes, headers: headers] ++ signing_req_opts(config.signing_opts)
-
         Pyex.Ctx.guarded_io_call(:boto3, fn env, ctx ->
-          case check_endpoint_network(ctx, url) do
-            {:exception, _} = err ->
-              {err, env, ctx}
+          case s3_config(ctx) do
+            {:error, reason} ->
+              {{:exception, reason}, env, ctx}
 
-            :ok ->
-              result =
-                case Req.put(url, req_opts) do
-                  {:ok, %{status: status}} when status in [200, 201] ->
-                    %{"ResponseMetadata" => %{"HTTPStatusCode" => status}}
+            {:ok, config} ->
+              url = object_url(bucket, key, config.region, Map.get(config, :endpoint_url))
 
-                  {:ok, %{status: status, body: resp_body}} ->
-                    {:exception,
-                     "ClientError: S3 PutObject failed (#{status}): #{inspect(resp_body)}"}
+              case check_endpoint_network(ctx, config, "PUT", url) do
+                {:exception, _} = err ->
+                  {err, env, ctx}
 
-                  {:error, reason} ->
-                    {:exception, "ClientError: #{inspect(reason)}"}
-                end
+                :ok ->
+                  headers =
+                    if is_binary(content_type),
+                      do: [{"content-type", content_type}],
+                      else: []
 
-              {result, env, ctx}
+                  req_opts = [body: body_bytes, headers: headers] ++ signing_req_opts(config)
+
+                  result =
+                    case Req.put(url, req_opts) do
+                      {:ok, %{status: status}} when status in [200, 201] ->
+                        %{"ResponseMetadata" => %{"HTTPStatusCode" => status}}
+
+                      {:ok, %{status: status, body: resp_body}} ->
+                        {:exception,
+                         "ClientError: S3 PutObject failed (#{status}): #{inspect(resp_body)}"}
+
+                      {:error, reason} ->
+                        {:exception, "ClientError: #{inspect(reason)}"}
+                    end
+
+                  {result, env, ctx}
+              end
           end
         end)
     end
   end
 
-  @spec s3_get_object(s3_config(), [Pyex.Interpreter.pyvalue()], %{
+  @spec s3_get_object([Pyex.Interpreter.pyvalue()], %{
           optional(String.t()) => Pyex.Interpreter.pyvalue()
         }) :: s3_result()
-  defp s3_get_object(config, _args, kwargs) do
+  defp s3_get_object(_args, kwargs) do
     bucket = Map.get(kwargs, "Bucket")
     key = Map.get(kwargs, "Key")
 
@@ -194,56 +221,63 @@ defmodule Pyex.Stdlib.Boto3 do
         {:exception, "ParamValidationError: Missing required parameter: 'Key'"}
 
       true ->
-        url = object_url(bucket, key, config.region, config.endpoint_url)
-        req_opts = [decode_body: false] ++ signing_req_opts(config.signing_opts)
-
         Pyex.Ctx.guarded_io_call(:boto3, fn env, ctx ->
-          case check_endpoint_network(ctx, url) do
-            {:exception, _} = err ->
-              {err, env, ctx}
+          case s3_config(ctx) do
+            {:error, reason} ->
+              {{:exception, reason}, env, ctx}
 
-            :ok ->
-              result =
-                case Req.get(url, req_opts) do
-                  {:ok, %{status: 200, body: body, headers: headers}} ->
-                    body_str = body
+            {:ok, config} ->
+              url = object_url(bucket, key, config.region, Map.get(config, :endpoint_url))
 
-                    body_obj = %{
-                      "read" => {:builtin, fn [] -> body_str end},
-                      "__body_bytes__" => body_str
-                    }
+              case check_endpoint_network(ctx, config, "GET", url) do
+                {:exception, _} = err ->
+                  {err, env, ctx}
 
-                    content_type = extract_header(headers, "content-type")
+                :ok ->
+                  req_opts = [decode_body: false] ++ signing_req_opts(config)
 
-                    %{
-                      "Body" => body_obj,
-                      "ContentLength" => byte_size(body_str),
-                      "ContentType" => content_type,
-                      "ResponseMetadata" => %{"HTTPStatusCode" => 200}
-                    }
+                  result =
+                    case Req.get(url, req_opts) do
+                      {:ok, %{status: 200, body: body, headers: headers}} ->
+                        body_str = body
 
-                  {:ok, %{status: 404}} ->
-                    {:exception,
-                     "ClientError: An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist."}
+                        body_obj = %{
+                          "read" => {:builtin, fn [] -> body_str end},
+                          "__body_bytes__" => body_str
+                        }
 
-                  {:ok, %{status: status, body: resp_body}} ->
-                    {:exception,
-                     "ClientError: S3 GetObject failed (#{status}): #{inspect(resp_body)}"}
+                        content_type = extract_header(headers, "content-type")
 
-                  {:error, reason} ->
-                    {:exception, "ClientError: #{inspect(reason)}"}
-                end
+                        %{
+                          "Body" => body_obj,
+                          "ContentLength" => byte_size(body_str),
+                          "ContentType" => content_type,
+                          "ResponseMetadata" => %{"HTTPStatusCode" => 200}
+                        }
 
-              {result, env, ctx}
+                      {:ok, %{status: 404}} ->
+                        {:exception,
+                         "ClientError: An error occurred (NoSuchKey) when calling the GetObject operation: The specified key does not exist."}
+
+                      {:ok, %{status: status, body: resp_body}} ->
+                        {:exception,
+                         "ClientError: S3 GetObject failed (#{status}): #{inspect(resp_body)}"}
+
+                      {:error, reason} ->
+                        {:exception, "ClientError: #{inspect(reason)}"}
+                    end
+
+                  {result, env, ctx}
+              end
           end
         end)
     end
   end
 
-  @spec s3_delete_object(s3_config(), [Pyex.Interpreter.pyvalue()], %{
+  @spec s3_delete_object([Pyex.Interpreter.pyvalue()], %{
           optional(String.t()) => Pyex.Interpreter.pyvalue()
         }) :: s3_result()
-  defp s3_delete_object(config, _args, kwargs) do
+  defp s3_delete_object(_args, kwargs) do
     bucket = Map.get(kwargs, "Bucket")
     key = Map.get(kwargs, "Key")
 
@@ -255,75 +289,89 @@ defmodule Pyex.Stdlib.Boto3 do
         {:exception, "ParamValidationError: Missing required parameter: 'Key'"}
 
       true ->
-        url = object_url(bucket, key, config.region, config.endpoint_url)
-        req_opts = signing_req_opts(config.signing_opts)
-
         Pyex.Ctx.guarded_io_call(:boto3, fn env, ctx ->
-          case check_endpoint_network(ctx, url) do
-            {:exception, _} = err ->
-              {err, env, ctx}
+          case s3_config(ctx) do
+            {:error, reason} ->
+              {{:exception, reason}, env, ctx}
 
-            :ok ->
-              result =
-                case Req.delete(url, req_opts) do
-                  {:ok, %{status: status}} when status in [200, 204] ->
-                    %{"ResponseMetadata" => %{"HTTPStatusCode" => status}}
+            {:ok, config} ->
+              url = object_url(bucket, key, config.region, Map.get(config, :endpoint_url))
 
-                  {:ok, %{status: status, body: resp_body}} ->
-                    {:exception,
-                     "ClientError: S3 DeleteObject failed (#{status}): #{inspect(resp_body)}"}
+              case check_endpoint_network(ctx, config, "DELETE", url) do
+                {:exception, _} = err ->
+                  {err, env, ctx}
 
-                  {:error, reason} ->
-                    {:exception, "ClientError: #{inspect(reason)}"}
-                end
+                :ok ->
+                  req_opts = signing_req_opts(config)
 
-              {result, env, ctx}
+                  result =
+                    case Req.delete(url, req_opts) do
+                      {:ok, %{status: status}} when status in [200, 204] ->
+                        %{"ResponseMetadata" => %{"HTTPStatusCode" => status}}
+
+                      {:ok, %{status: status, body: resp_body}} ->
+                        {:exception,
+                         "ClientError: S3 DeleteObject failed (#{status}): #{inspect(resp_body)}"}
+
+                      {:error, reason} ->
+                        {:exception, "ClientError: #{inspect(reason)}"}
+                    end
+
+                  {result, env, ctx}
+              end
           end
         end)
     end
   end
 
-  @spec s3_list_objects_v2(s3_config(), [Pyex.Interpreter.pyvalue()], %{
+  @spec s3_list_objects_v2([Pyex.Interpreter.pyvalue()], %{
           optional(String.t()) => Pyex.Interpreter.pyvalue()
         }) :: s3_result()
-  defp s3_list_objects_v2(config, _args, kwargs) do
+  defp s3_list_objects_v2(_args, kwargs) do
     bucket = Map.get(kwargs, "Bucket")
     prefix = Map.get(kwargs, "Prefix", "")
 
     if not is_binary(bucket) do
       {:exception, "ParamValidationError: Missing required parameter: 'Bucket'"}
     else
-      base = bucket_url(bucket, config.region, config.endpoint_url)
-      url = "#{base}?list-type=2&prefix=#{URI.encode(prefix)}"
-      req_opts = signing_req_opts(config.signing_opts)
-
       Pyex.Ctx.guarded_io_call(:boto3, fn env, ctx ->
-        case check_endpoint_network(ctx, url) do
-          {:exception, _} = err ->
-            {err, env, ctx}
+        case s3_config(ctx) do
+          {:error, reason} ->
+            {{:exception, reason}, env, ctx}
 
-          :ok ->
-            result =
-              case Req.get(url, req_opts) do
-                {:ok, %{status: 200, body: body}} ->
-                  contents = parse_list_response(body, prefix)
+          {:ok, config} ->
+            base = bucket_url(bucket, config.region, Map.get(config, :endpoint_url))
+            url = "#{base}?list-type=2&prefix=#{URI.encode(prefix)}"
 
-                  %{
-                    "Contents" => contents,
-                    "KeyCount" => length(contents),
-                    "Prefix" => prefix,
-                    "ResponseMetadata" => %{"HTTPStatusCode" => 200}
-                  }
+            case check_endpoint_network(ctx, config, "GET", url) do
+              {:exception, _} = err ->
+                {err, env, ctx}
 
-                {:ok, %{status: status, body: resp_body}} ->
-                  {:exception,
-                   "ClientError: S3 ListObjectsV2 failed (#{status}): #{inspect(resp_body)}"}
+              :ok ->
+                req_opts = signing_req_opts(config)
 
-                {:error, reason} ->
-                  {:exception, "ClientError: #{inspect(reason)}"}
-              end
+                result =
+                  case Req.get(url, req_opts) do
+                    {:ok, %{status: 200, body: body}} ->
+                      contents = parse_list_response(body, prefix)
 
-            {result, env, ctx}
+                      %{
+                        "Contents" => contents,
+                        "KeyCount" => length(contents),
+                        "Prefix" => prefix,
+                        "ResponseMetadata" => %{"HTTPStatusCode" => 200}
+                      }
+
+                    {:ok, %{status: status, body: resp_body}} ->
+                      {:exception,
+                       "ClientError: S3 ListObjectsV2 failed (#{status}): #{inspect(resp_body)}"}
+
+                    {:error, reason} ->
+                      {:exception, "ClientError: #{inspect(reason)}"}
+                  end
+
+                {result, env, ctx}
+            end
         end
       end)
     end

--- a/test/pyex/capabilities_test.exs
+++ b/test/pyex/capabilities_test.exs
@@ -6,7 +6,7 @@ defmodule Pyex.CapabilitiesTest do
       {:error, error} =
         Pyex.run("""
         import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3 = boto3.client('s3')
         s3.put_object(Bucket='bucket', Key='key.txt', Body='data')
         """)
 
@@ -24,7 +24,7 @@ defmodule Pyex.CapabilitiesTest do
         {:error, error} =
           Pyex.run("""
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+          s3 = boto3.client('s3')
           s3.#{op}
           """)
 
@@ -37,7 +37,7 @@ defmodule Pyex.CapabilitiesTest do
       result =
         Pyex.run!("""
         import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3 = boto3.client('s3')
         'put_object' in s3
         """)
 

--- a/test/pyex/ctx_test.exs
+++ b/test/pyex/ctx_test.exs
@@ -32,6 +32,37 @@ defmodule Pyex.CtxTest do
         Ctx.new(network: [%{allowed_url_prefix: ""}])
       end
     end
+
+    test "rejects unknown network rule keys" do
+      assert_raise ArgumentError, ~r/unknown keys \[:method\] in network rule/, fn ->
+        Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com/", method: ["POST"]}])
+      end
+    end
+
+    test "rejects string-keyed network rules" do
+      assert_raise ArgumentError, ~r/unknown keys \["allowed_url_prefix"\] in network rule/, fn ->
+        Ctx.new(network: [%{"allowed_url_prefix" => "https://api.example.com/"}])
+      end
+    end
+
+    test "rejects aws config without required keys" do
+      assert_raise ArgumentError, ~r/aws :access_key_id must be a non-empty string/, fn ->
+        Ctx.new(aws: [region: "us-east-1", secret_access_key: "secret"])
+      end
+    end
+
+    test "rejects unknown aws config keys" do
+      assert_raise ArgumentError, ~r/unknown keys \[:endpoint\] in aws config/, fn ->
+        Ctx.new(
+          aws: [
+            region: "us-east-1",
+            access_key_id: "access",
+            secret_access_key: "secret",
+            endpoint: "http://localhost:9000"
+          ]
+        )
+      end
+    end
   end
 
   describe "check_network_access/3" do

--- a/test/pyex/ctx_test.exs
+++ b/test/pyex/ctx_test.exs
@@ -101,13 +101,13 @@ defmodule Pyex.CtxTest do
       assert Ctx.check_deadline(ctx) == :ok
     end
 
-    test "timeout is set from timeout_ms" do
-      ctx = Ctx.new(timeout_ms: 5000)
+    test "timeout is set from timeout" do
+      ctx = Ctx.new(timeout: 5000)
       assert ctx.timeout == 5000
     end
 
     test "check_deadline returns :ok within budget" do
-      ctx = Ctx.new(timeout_ms: 5000)
+      ctx = Ctx.new(timeout: 5000)
       assert Ctx.check_deadline(ctx) == :ok
     end
 
@@ -122,7 +122,7 @@ defmodule Pyex.CtxTest do
     end
 
     test "pause_compute and resume_compute exclude I/O time" do
-      ctx = Ctx.new(timeout_ms: 5000)
+      ctx = Ctx.new(timeout: 5000)
       paused = Ctx.pause_compute(ctx)
       assert paused.compute_started_at == nil
       assert paused.compute > 0 or true
@@ -131,14 +131,14 @@ defmodule Pyex.CtxTest do
     end
 
     test "compute_time tracks accumulated compute time" do
-      ctx = Ctx.new(timeout_ms: 5000)
+      ctx = Ctx.new(timeout: 5000)
       Process.sleep(5)
       ms = Ctx.compute_time(ctx)
       assert ms >= 0
     end
 
     test "while True loop is killed by timeout" do
-      ctx = Ctx.new(timeout_ms: 50)
+      ctx = Ctx.new(timeout: 50)
 
       code = """
       x = 0
@@ -151,7 +151,7 @@ defmodule Pyex.CtxTest do
     end
 
     test "for loop is killed by timeout" do
-      ctx = Ctx.new(timeout_ms: 50)
+      ctx = Ctx.new(timeout: 50)
 
       code = """
       x = 0
@@ -164,7 +164,7 @@ defmodule Pyex.CtxTest do
     end
 
     test "normal program completes within timeout" do
-      ctx = Ctx.new(timeout_ms: 5000)
+      ctx = Ctx.new(timeout: 5000)
 
       code = """
       total = 0

--- a/test/pyex/differential_fuzz_test.exs
+++ b/test/pyex/differential_fuzz_test.exs
@@ -47,7 +47,7 @@ defmodule Pyex.DifferentialFuzzTest do
   end
 
   defp run_pyex(code) do
-    case Pyex.run(code, Pyex.Ctx.new(timeout_ms: 2_000)) do
+    case Pyex.run(code, Pyex.Ctx.new(timeout: 2_000)) do
       {:ok, _, ctx} -> {:ok, ctx |> Pyex.output() |> IO.iodata_to_binary() |> String.trim()}
       {:error, err} -> {:error, err.exception_type || err.kind}
     end

--- a/test/pyex/entropy_test.exs
+++ b/test/pyex/entropy_test.exs
@@ -1,0 +1,79 @@
+defmodule Pyex.EntropyTest do
+  use ExUnit.Case, async: true
+
+  doctest Pyex.Entropy
+
+  alias Pyex.Entropy
+
+  describe "shannon/1" do
+    test "returns expected values for simple inputs" do
+      assert Entropy.shannon("aaaa") == 0.0
+      assert Entropy.shannon("abcd") == 2.0
+      assert Entropy.shannon(<<>>) == 0.0
+    end
+  end
+
+  describe "builtin_matchers/0" do
+    test "includes major cloud and llm providers" do
+      keys = Entropy.builtin_matchers() |> Map.keys() |> MapSet.new()
+
+      for key <- [
+            :aws_access_key,
+            :aws_secret_key,
+            :google_api_key,
+            :azure_storage_connection_string,
+            :openai_key,
+            :anthropic_key,
+            :openrouter_key,
+            :groq_key,
+            :huggingface_token
+          ] do
+        assert MapSet.member?(keys, key)
+      end
+    end
+  end
+
+  describe "scan/2" do
+    test "detects high-entropy input smaller than the window" do
+      input = :binary.list_to_bin(Enum.to_list(0..15))
+
+      assert [%{offset: 0, matcher: nil, window: ^input}] =
+               Entropy.scan(input, window_size: 64, threshold: 3.5)
+    end
+
+    test "detects provider secrets with builtin matchers" do
+      samples = [
+        {:aws_access_key, "AKIA" <> String.duplicate("A", 16)},
+        {:aws_secret_key, ~s(aws_secret_access_key=") <> String.duplicate("A", 40) <> ~s(")},
+        {:google_api_key, "AIza" <> String.duplicate("A", 35)},
+        {:azure_storage_connection_string,
+         "DefaultEndpointsProtocol=https;AccountName=demo;AccountKey=" <>
+           Base.encode64(String.duplicate("a", 24)) <> ";EndpointSuffix=core.windows.net"},
+        {:openai_key, "sk-proj-" <> String.duplicate("a", 24)},
+        {:anthropic_key, "sk-ant-" <> String.duplicate("a", 24)},
+        {:openrouter_key, "sk-or-v1-" <> String.duplicate("a", 24)},
+        {:groq_key, "gsk_" <> String.duplicate("A", 24)},
+        {:huggingface_token, "hf_" <> String.duplicate("A", 30)}
+      ]
+
+      Enum.each(samples, fn {matcher, sample} ->
+        assert Enum.any?(
+                 Entropy.scan(sample, builtins: true, threshold: 99.0, window_size: 256),
+                 &(&1.matcher == matcher)
+               )
+      end)
+    end
+
+    test "rejects invalid window sizes" do
+      assert_raise ArgumentError, ~r/window_size must be a positive integer/, fn ->
+        Entropy.scan("abc", window_size: 0)
+      end
+    end
+
+    test "rejects invalid matcher collections" do
+      assert_raise ArgumentError, ~r/matchers must be a map/, fn ->
+        Entropy.scan("abc", matchers: [:not_a_map])
+      end
+    end
+  end
+end

--- a/test/pyex/error_test.exs
+++ b/test/pyex/error_test.exs
@@ -221,7 +221,7 @@ defmodule Pyex.ErrorTest do
     end
 
     test "timeout error returns structured error" do
-      ctx = Pyex.Ctx.new(timeout_ms: 50)
+      ctx = Pyex.Ctx.new(timeout: 50)
       {:error, %Error{} = err} = Pyex.run("while True:\n    x = 1", ctx)
       assert err.kind == :timeout
     end

--- a/test/pyex/property_test.exs
+++ b/test/pyex/property_test.exs
@@ -11,7 +11,7 @@ defmodule Pyex.PropertyTest do
 
   alias Pyex.{Lexer, Parser, Builtins, Interpreter, Ctx}
 
-  @timeout_ctx Ctx.new(timeout_ms: 200)
+  @timeout_ctx Ctx.new(timeout: 200)
 
   defp fresh_ctx do
     %{@timeout_ctx | compute: 0.0, compute_started_at: System.monotonic_time()}

--- a/test/pyex/readme_test.exs
+++ b/test/pyex/readme_test.exs
@@ -132,7 +132,7 @@ defmodule Pyex.ReadmeTest do
                  while True:
                      x = 1
                  """,
-                 timeout_ms: 50
+                 timeout: 50
                )
     end
   end
@@ -203,7 +203,7 @@ defmodule Pyex.ReadmeTest do
 
     test "timeout error" do
       assert {:error, %Error{kind: :timeout}} =
-               Pyex.run("while True:\n    x = 1", timeout_ms: 50)
+               Pyex.run("while True:\n    x = 1", timeout: 50)
     end
 
     test "import error" do

--- a/test/pyex/stdlib/boto3_test.exs
+++ b/test/pyex/stdlib/boto3_test.exs
@@ -6,17 +6,32 @@ defmodule Pyex.Stdlib.Boto3Test do
     {:ok, bypass: bypass, port: bypass.port}
   end
 
+  defp aws_config(port) do
+    [
+      region: "us-east-1",
+      access_key_id: "test-access-key",
+      secret_access_key: "test-secret-key",
+      endpoint_url: "http://localhost:#{port}"
+    ]
+  end
+
+  defp boto3_opts(port), do: [boto3: true, aws: aws_config(port)]
+
+  defp boto3_ctx(port, extra_opts \\ []) do
+    Pyex.Ctx.new([boto3: true, aws: aws_config(port)] ++ extra_opts)
+  end
+
   describe "boto3.client" do
     test "creates an s3 client with expected methods", %{port: port} do
       result =
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           methods = ['put_object' in s3, 'get_object' in s3, 'delete_object' in s3, 'list_objects_v2' in s3]
           methods
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == [true, true, true, true]
@@ -26,7 +41,7 @@ defmodule Pyex.Stdlib.Boto3Test do
       {:error, error} =
         Pyex.run("""
         import boto3
-        s3 = boto3.client('dynamodb', endpoint_url='http://localhost:9999')
+        s3 = boto3.client('dynamodb')
         """)
 
       assert error.message =~ "unsupported service 'dynamodb'"
@@ -40,6 +55,19 @@ defmodule Pyex.Stdlib.Boto3Test do
         """)
 
       assert error.message =~ "requires a service name string"
+    end
+
+    test "rejects Python-supplied client configuration" do
+      {:error, error} =
+        Pyex.run(
+          """
+          import boto3
+          boto3.client('s3', endpoint_url='http://localhost:9999')
+          """,
+          boto3: true
+        )
+
+      assert error.message =~ "must be configured by the host via the :aws option"
     end
   end
 
@@ -55,11 +83,11 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           resp = s3.put_object(Bucket='my-bucket', Key='hello.txt', Body='world')
           resp['ResponseMetadata']['HTTPStatusCode']
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == 200
@@ -76,11 +104,11 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           resp = s3.put_object(Bucket='bucket', Key='data.json', Body='{}', ContentType='application/json')
           resp['ResponseMetadata']['HTTPStatusCode']
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == 200
@@ -90,7 +118,7 @@ defmodule Pyex.Stdlib.Boto3Test do
       {:error, error} =
         Pyex.run("""
         import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3 = boto3.client('s3')
         s3.put_object(Key='hello.txt', Body='world')
         """)
 
@@ -101,7 +129,7 @@ defmodule Pyex.Stdlib.Boto3Test do
       {:error, error} =
         Pyex.run("""
         import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3 = boto3.client('s3')
         s3.put_object(Bucket='my-bucket', Body='world')
         """)
 
@@ -117,10 +145,10 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           s3.put_object(Bucket='bucket', Key='key.txt', Body='data')
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert error.message =~ "S3 PutObject failed (500)"
@@ -139,11 +167,11 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           obj = s3.get_object(Bucket='my-bucket', Key='hello.txt')
           obj['Body'].read()
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == "world"
@@ -160,11 +188,11 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           obj = s3.get_object(Bucket='bucket', Key='data.json')
           [obj['ContentLength'], obj['ResponseMetadata']['HTTPStatusCode']]
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       [content_length, status] = result
@@ -181,10 +209,10 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           s3.get_object(Bucket='bucket', Key='missing.txt')
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert error.message =~ "NoSuchKey"
@@ -194,7 +222,7 @@ defmodule Pyex.Stdlib.Boto3Test do
       {:error, error} =
         Pyex.run("""
         import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3 = boto3.client('s3')
         s3.get_object(Key='hello.txt')
         """)
 
@@ -213,12 +241,12 @@ defmodule Pyex.Stdlib.Boto3Test do
           """
           import boto3
           import json
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           obj = s3.get_object(Bucket='bucket', Key='data.json')
           data = json.loads(obj['Body'].read())
           [data['name'], data['age']]
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == ["Alice", 30]
@@ -235,11 +263,11 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           resp = s3.delete_object(Bucket='bucket', Key='old.txt')
           resp['ResponseMetadata']['HTTPStatusCode']
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == 204
@@ -249,7 +277,7 @@ defmodule Pyex.Stdlib.Boto3Test do
       {:error, error} =
         Pyex.run("""
         import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3 = boto3.client('s3')
         s3.delete_object(Bucket='my-bucket')
         """)
 
@@ -265,10 +293,10 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           s3.delete_object(Bucket='bucket', Key='key.txt')
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert error.message =~ "S3 DeleteObject failed (403)"
@@ -298,12 +326,12 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           resp = s3.list_objects_v2(Bucket='bucket')
           keys = [item['Key'] for item in resp['Contents']]
           [keys, resp['KeyCount']]
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       [keys, count] = result
@@ -331,11 +359,11 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           resp = s3.list_objects_v2(Bucket='bucket', Prefix='data/')
           [item['Key'] for item in resp['Contents']]
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == ["data/a.csv", "data/b.csv"]
@@ -355,11 +383,11 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           resp = s3.list_objects_v2(Bucket='empty-bucket')
           [resp['Contents'], resp['KeyCount']]
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == [[], 0]
@@ -369,7 +397,7 @@ defmodule Pyex.Stdlib.Boto3Test do
       {:error, error} =
         Pyex.run("""
         import boto3
-        s3 = boto3.client('s3', endpoint_url='http://localhost:9999')
+        s3 = boto3.client('s3')
         s3.list_objects_v2()
         """)
 
@@ -407,12 +435,12 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           s3.put_object(Bucket='store', Key='docs/readme.md', Body='# Hello World')
           obj = s3.get_object(Bucket='store', Key='docs/readme.md')
           obj['Body'].read()
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == "# Hello World"
@@ -450,14 +478,14 @@ defmodule Pyex.Stdlib.Boto3Test do
           """
           import boto3
           import json
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           user = {"name": "Alice", "age": 30, "active": True}
           s3.put_object(Bucket='data', Key='records/user.json', Body=json.dumps(user))
           obj = s3.get_object(Bucket='data', Key='records/user.json')
           parsed = json.loads(obj['Body'].read())
           [parsed['name'], parsed['age'], parsed['active']]
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == ["Alice", 30, true]
@@ -512,14 +540,14 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run!(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           s3.put_object(Bucket='bucket', Key='a.txt', Body='aaa')
           s3.put_object(Bucket='bucket', Key='b.txt', Body='bbb')
           s3.put_object(Bucket='bucket', Key='c.txt', Body='ccc')
           resp = s3.list_objects_v2(Bucket='bucket')
           resp['KeyCount']
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == 3
@@ -566,7 +594,7 @@ defmodule Pyex.Stdlib.Boto3Test do
               age: int
               active: bool
 
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           user = User(name='Alice', age=30, active=True)
           s3.put_object(Bucket='models', Key='users/1.json', Body=json.dumps(user.model_dump()))
           obj = s3.get_object(Bucket='models', Key='users/1.json')
@@ -574,7 +602,7 @@ defmodule Pyex.Stdlib.Boto3Test do
           loaded = User(**data)
           [loaded.name, loaded.age, loaded.active]
           """,
-          boto3: true
+          boto3_opts(port)
         )
 
       assert result == ["Alice", 30, true]
@@ -584,10 +612,23 @@ defmodule Pyex.Stdlib.Boto3Test do
   end
 
   describe "SSRF protection" do
+    test "operations require host AWS config" do
+      {:error, error} =
+        Pyex.run(
+          """
+          import boto3
+          s3 = boto3.client('s3')
+          s3.put_object(Bucket='bucket', Key='test.txt', Body='hello')
+          """,
+          boto3: true
+        )
+
+      assert error.message =~ "no AWS configuration is available"
+    end
+
     test "boto3 operations check network policy when set", %{port: port} do
       ctx =
-        Pyex.Ctx.new(
-          boto3: true,
+        boto3_ctx(port,
           network: [
             %{allowed_url_prefix: "http://example.com/", methods: ["GET", "PUT", "DELETE"]}
           ]
@@ -597,7 +638,7 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           s3.put_object(Bucket='bucket', Key='test.txt', Body='hello')
           """,
           ctx
@@ -612,8 +653,7 @@ defmodule Pyex.Stdlib.Boto3Test do
       end)
 
       ctx =
-        Pyex.Ctx.new(
-          boto3: true,
+        boto3_ctx(port,
           network: [
             %{allowed_url_prefix: "http://localhost:", methods: ["GET", "PUT", "DELETE"]}
           ]
@@ -623,7 +663,7 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           s3.put_object(Bucket='bucket', Key='test.txt', Body='hello')
           """,
           ctx
@@ -641,13 +681,34 @@ defmodule Pyex.Stdlib.Boto3Test do
         Pyex.run(
           """
           import boto3
-          s3 = boto3.client('s3', endpoint_url='http://localhost:#{port}')
+          s3 = boto3.client('s3')
           s3.put_object(Bucket='bucket', Key='test.txt', Body='hello')
           """,
-          Pyex.Ctx.new(boto3: true)
+          boto3_ctx(port)
         )
 
       assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
+    end
+
+    test "network method restrictions apply to custom endpoints", %{port: port} do
+      ctx =
+        boto3_ctx(port,
+          network: [
+            %{allowed_url_prefix: "http://localhost:", methods: ["GET"]}
+          ]
+        )
+
+      {:error, error} =
+        Pyex.run(
+          """
+          import boto3
+          s3 = boto3.client('s3')
+          s3.put_object(Bucket='bucket', Key='test.txt', Body='hello')
+          """,
+          ctx
+        )
+
+      assert error.message =~ "HTTP method PUT is not allowed"
     end
   end
 end

--- a/test/pyex/stdlib/pandas_test.exs
+++ b/test/pyex/stdlib/pandas_test.exs
@@ -231,7 +231,7 @@ defmodule Pyex.Stdlib.PandasTest do
       platform: platform,
       expected_signals: expected_signals
     } do
-      opts = [timeout_ms: 20_000, modules: %{"platform" => platform}]
+      opts = [timeout: 20_000, modules: %{"platform" => platform}]
 
       naive_code = """
       import platform
@@ -268,7 +268,7 @@ defmodule Pyex.Stdlib.PandasTest do
       platform: platform,
       expected_signals: expected_signals
     } do
-      opts = [timeout_ms: 20_000, modules: %{"platform" => platform}]
+      opts = [timeout: 20_000, modules: %{"platform" => platform}]
 
       pandas_code = """
       import pandas as pd
@@ -293,7 +293,7 @@ defmodule Pyex.Stdlib.PandasTest do
 
     @tag timeout: 30_000
     test "pandas via platform.get_prices is faster than naive", %{platform: platform} do
-      opts = [timeout_ms: 20_000, modules: %{"platform" => platform}]
+      opts = [timeout: 20_000, modules: %{"platform" => platform}]
 
       naive_code = """
       import platform

--- a/test/support/math_oracle.ex
+++ b/test/support/math_oracle.ex
@@ -20,7 +20,7 @@ defmodule Pyex.Test.MathOracle do
     csv = "x\r\n" <> Enum.map_join(xs, "\r\n", &Integer.to_string/1) <> "\r\n"
     fs = Memory.new()
     {:ok, fs} = Memory.write(fs, "data.csv", csv, :write)
-    [filesystem: fs, timeout_ms: @timeout_ms]
+    [filesystem: fs, timeout: @timeout_ms]
   end
 
   @doc """
@@ -32,7 +32,7 @@ defmodule Pyex.Test.MathOracle do
     csv = "x\r\n" <> Enum.map_join(xs, "\r\n", &Float.to_string/1) <> "\r\n"
     fs = Memory.new()
     {:ok, fs} = Memory.write(fs, "data.csv", csv, :write)
-    [filesystem: fs, timeout_ms: @timeout_ms]
+    [filesystem: fs, timeout: @timeout_ms]
   end
 
   @doc """


### PR DESCRIPTION
## Summary
- move boto3 AWS credentials and endpoint selection into the host-owned `:aws` context option
- reject Python-supplied `boto3.client('s3', ...)` security kwargs and require explicit host AWS config for S3 operations
- tighten outbound policy validation by rejecting unknown network rule keys and enforcing network method checks for host-configured custom S3 endpoints

## Testing
- mix test
- mix dialyzer