### PR TITLE
Fix file handle flushing on program exit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,11 @@
 ## Agent behavior
 - When the user gives feedback about how to work, update this file (AGENTS.md)
   immediately so the guidance is remembered across sessions.
+- Always match real Python behavior when choosing semantics.  If Pyex differs,
+  fix Pyex instead of documenting or depending on the mismatch.
+- Keep tests and implementation pure.  Do not introduce process messaging or
+  process-coupled test probes to observe behavior that should be verified via
+  returned state.
 - Never worry about how hard a fix is.  Worry about making a correct and
   performant system.  If the right fix is large, do the large fix.
 - Never work around Pyex limitations in fixture code or tests.  Fixtures

--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -114,10 +114,12 @@ defmodule Pyex do
 
     env = Builtins.runtime_env(ctx)
 
-    result = Interpreter.run_with_ctx(ast, env, ctx)
+    result = Interpreter.run_with_ctx_result(ast, env, ctx)
 
     case result do
       {:ok, value, _env, final_ctx} ->
+        final_ctx = close_open_handles(final_ctx)
+
         duration_ms =
           System.convert_time_unit(System.monotonic_time() - start_mono, :native, :microsecond) /
             1000.0
@@ -131,7 +133,9 @@ defmodule Pyex do
         {:ok, Interpreter.Helpers.to_python_view(derefed),
          %{final_ctx | duration_ms: duration_ms}}
 
-      {:error, msg} ->
+      {:error, msg, final_ctx} ->
+        close_open_handles(final_ctx)
+
         duration_ms =
           System.convert_time_unit(System.monotonic_time() - start_mono, :native, :microsecond) /
             1000.0
@@ -185,4 +189,14 @@ defmodule Pyex do
   """
   @spec output(Ctx.t()) :: String.t()
   def output(%Ctx{} = ctx), do: ctx |> Ctx.output() |> IO.iodata_to_binary()
+
+  @spec close_open_handles(Ctx.t()) :: Ctx.t()
+  defp close_open_handles(final_ctx) do
+    Enum.reduce(Map.keys(final_ctx.handles), final_ctx, fn id, ctx ->
+      case Ctx.close_handle(ctx, id) do
+        {:ok, ctx} -> ctx
+        {:error, _} -> ctx
+      end
+    end)
+  end
 end

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -141,11 +141,25 @@ defmodule Pyex.Interpreter do
           {:ok, pyvalue(), Env.t(), Ctx.t()}
           | {:error, String.t()}
   def run_with_ctx(ast, env, ctx) do
+    case run_with_ctx_result(ast, env, ctx) do
+      {:ok, value, env, ctx} -> {:ok, value, env, ctx}
+      {:error, msg, _ctx} -> {:error, msg}
+    end
+  end
+
+  @doc """
+  Evaluates an AST with a provided context, preserving the
+  final context even when execution ends with an exception.
+  """
+  @spec run_with_ctx_result(Parser.ast_node(), Env.t(), Ctx.t()) ::
+          {:ok, pyvalue(), Env.t(), Ctx.t()}
+          | {:error, String.t(), Ctx.t()}
+  def run_with_ctx_result(ast, env, ctx) do
     ctx = init_profile(ctx)
 
     case eval(ast, env, ctx) do
       {{:exception, msg}, _env, ctx} ->
-        {:error, Helpers.format_error(msg, ctx)}
+        {:error, Helpers.format_error(msg, ctx), ctx}
 
       {result, env, ctx} ->
         value = Helpers.unwrap(result)

--- a/test/pyex/filesystem_test.exs
+++ b/test/pyex/filesystem_test.exs
@@ -15,8 +15,27 @@ defmodule Pyex.FilesystemTest do
     ctx = Ctx.new(filesystem: fs)
 
     case Interpreter.run_with_ctx(ast, Builtins.env(), ctx) do
-      {:ok, value, _env, ctx} -> {value, ctx}
-      {:error, msg} -> {:error, msg}
+      {:ok, value, _env, ctx} ->
+        {value, close_handles(ctx)}
+
+      {:error, msg} ->
+        {:error, msg}
+    end
+  end
+
+  defp close_handles(ctx) do
+    Enum.reduce(Map.keys(ctx.handles), ctx, fn id, ctx ->
+      case Ctx.close_handle(ctx, id) do
+        {:ok, ctx} -> ctx
+        {:error, _} -> ctx
+      end
+    end)
+  end
+
+  defp run_with_fs_public!(source, fs \\ Memory.new()) do
+    case Pyex.run(source, filesystem: fs) do
+      {:ok, value, ctx} -> {value, ctx}
+      {:error, error} -> {:error, error.message}
     end
   end
 
@@ -160,15 +179,124 @@ defmodule Pyex.FilesystemTest do
       assert msg =~ "FileNotFoundError"
     end
 
-    test "writing without close doesn't persist" do
+    test "writing without close persists to filesystem on program exit" do
       code = """
       f = open("test.txt", "w")
-      f.write("not flushed")
-      g = open("test.txt", "r")
+      f.write("not explicitly closed")
       """
 
-      assert {:error, msg} = run_with_fs!(code)
-      assert msg =~ "FileNotFoundError"
+      {_value, ctx} = run_with_fs!(code)
+
+      assert {:ok, "not explicitly closed"} =
+               Pyex.Filesystem.Memory.read(ctx.filesystem, "test.txt")
+    end
+
+    test "one-liner open().write() persists to filesystem" do
+      code = ~S|open("out.txt", "w").write("hello")|
+
+      {_value, ctx} = run_with_fs!(code)
+      assert {:ok, "hello"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "out.txt")
+    end
+
+    test "unclosed append handle flushes on program exit" do
+      fs = Pyex.Filesystem.Memory.new(%{"log.txt" => "line1,"})
+
+      code = """
+      f = open("log.txt", "a")
+      f.write("line2")
+      """
+
+      {_value, ctx} = run_with_fs!(code, fs)
+      assert {:ok, "line1,line2"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "log.txt")
+    end
+
+    test "multiple unclosed handles all flush on program exit" do
+      code = """
+      a = open("a.txt", "w")
+      b = open("b.txt", "w")
+      a.write("aaa")
+      b.write("bbb")
+      """
+
+      {_value, ctx} = run_with_fs!(code)
+      assert {:ok, "aaa"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "a.txt")
+      assert {:ok, "bbb"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "b.txt")
+    end
+
+    test "no open handles remain in ctx after program exit" do
+      code = """
+      f = open("test.txt", "w")
+      f.write("data")
+      """
+
+      {_value, ctx} = run_with_fs!(code)
+      assert ctx.handles == %{}
+    end
+
+    test "Pyex.run flushes unclosed handles on program exit" do
+      code = ~S|open("out.txt", "w").write("hello")|
+
+      assert {:ok, _, ctx} = Pyex.run(code, filesystem: Memory.new())
+      assert {:ok, "hello"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "out.txt")
+      assert ctx.handles == %{}
+    end
+
+    test "Pyex.run flushes unclosed append handles on program exit" do
+      fs = Memory.new(%{"log.txt" => "line1,"})
+
+      code = """
+      f = open("log.txt", "a")
+      f.write("line2")
+      """
+
+      {_value, ctx} = run_with_fs_public!(code, fs)
+      assert {:ok, "line1,line2"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "log.txt")
+      assert ctx.handles == %{}
+    end
+
+    test "Pyex.run flushes multiple unclosed handles on program exit" do
+      code = """
+      a = open("a.txt", "w")
+      b = open("b.txt", "w")
+      a.write("aaa")
+      b.write("bbb")
+      """
+
+      {_value, ctx} = run_with_fs_public!(code)
+      assert {:ok, "aaa"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "a.txt")
+      assert {:ok, "bbb"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "b.txt")
+      assert ctx.handles == %{}
+    end
+
+    test "Pyex.run clears unclosed read handles on program exit" do
+      fs = Memory.new(%{"in.txt" => "data"})
+
+      code = """
+      f = open("in.txt", "r")
+      f.read()
+      """
+
+      {_value, ctx} = run_with_fs_public!(code, fs)
+      assert {:ok, "data"} = Pyex.Filesystem.Memory.read(ctx.filesystem, "in.txt")
+      assert ctx.handles == %{}
+    end
+
+    test "error results preserve ctx so unclosed writes can be flushed purely" do
+      code = """
+      f = open("boom.txt", "w")
+      f.write("before error")
+      raise ValueError("boom")
+      """
+
+      ast = parse!(code)
+      ctx = Ctx.new(filesystem: Memory.new())
+
+      assert {:error, msg, final_ctx} = Interpreter.run_with_ctx_result(ast, Builtins.env(), ctx)
+      assert msg =~ "ValueError"
+
+      final_ctx = close_handles(final_ctx)
+      assert {:ok, "before error"} = Pyex.Filesystem.Memory.read(final_ctx.filesystem, "boom.txt")
+      assert final_ctx.handles == %{}
     end
 
     test "multiple file handles simultaneously" do


### PR DESCRIPTION
## Summary
- flush any remaining file handles before `Pyex.run/2` returns so unclosed writes and appends persist like real Python
- preserve the final interpreter context on internal error results so error-path flushing can be tested without process messaging
- replace the old filesystem regression with coverage for implicit close on exit, public API behavior, and pure error-path state

## Verification
- mix test
- mix compile --warnings-as-errors
- mix format
- mix dialyzer