### PR TITLE
more stdlib and data structures

### DIFF
--- a/lib/pyex/builtins.ex
+++ b/lib/pyex/builtins.ex
@@ -705,44 +705,60 @@ defmodule Pyex.Builtins do
   defp builtin_list([{:instance, _, _} = inst]), do: {:iter_to_list, inst}
   defp builtin_list([{:iterator, _} = it]), do: {:iter_to_list, it}
 
-  @spec builtin_dict([Interpreter.pyvalue()]) :: PyDict.t() | {:exception, String.t()}
-  defp builtin_dict([]), do: PyDict.new()
-
-  defp builtin_dict([{:py_dict, _, _} = dict]) do
-    visible_dict(dict)
+  @doc false
+  @spec builtin_dict([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          PyDict.t() | {:exception, String.t()}
+  def builtin_dict(args, kwargs \\ %{}) do
+    with {:ok, dict} <- builtin_dict_positional(args) do
+      Enum.reduce(kwargs, dict, fn {k, v}, acc -> PyDict.put(acc, k, v) end)
+    end
   end
 
-  defp builtin_dict([map]) when is_map(map) do
-    map
-    |> visible_dict()
-    |> Map.reject(fn {_k, v} ->
-      match?({:builtin, _}, v) or match?({:builtin_kw, _}, v) or
-        match?({:function, _, _, _, _}, v) or match?({:bound_method, _, _}, v) or
-        match?({:bound_method, _, _, _}, v)
-    end)
-    |> PyDict.from_map()
+  @spec builtin_dict_positional([Interpreter.pyvalue()]) ::
+          {:ok, PyDict.t()} | {:exception, String.t()}
+  defp builtin_dict_positional([]), do: {:ok, PyDict.new()}
+
+  defp builtin_dict_positional([{:py_dict, _, _} = dict]) do
+    {:ok, visible_dict(dict)}
   end
 
-  defp builtin_dict([list]) when is_list(list) do
-    Enum.reduce(list, PyDict.new(), fn
-      {:tuple, [k, v]}, acc -> PyDict.put(acc, k, v)
-      [k, v], acc -> PyDict.put(acc, k, v)
-      _, acc -> acc
-    end)
+  defp builtin_dict_positional([map]) when is_map(map) do
+    {:ok,
+     map
+     |> visible_dict()
+     |> Map.reject(fn {_k, v} ->
+       match?({:builtin, _}, v) or match?({:builtin_kw, _}, v) or
+         match?({:function, _, _, _, _}, v) or match?({:bound_method, _, _}, v) or
+         match?({:bound_method, _, _, _}, v)
+     end)
+     |> PyDict.from_map()}
   end
 
-  defp builtin_dict([{:py_list, reversed, _}]) do
+  defp builtin_dict_positional([list]) when is_list(list) do
+    {:ok,
+     Enum.reduce(list, PyDict.new(), fn
+       {:tuple, [k, v]}, acc -> PyDict.put(acc, k, v)
+       [k, v], acc -> PyDict.put(acc, k, v)
+       _, acc -> acc
+     end)}
+  end
+
+  defp builtin_dict_positional([{:py_list, reversed, _}]) do
     list = Enum.reverse(reversed)
 
-    Enum.reduce(list, PyDict.new(), fn
-      {:tuple, [k, v]}, acc -> PyDict.put(acc, k, v)
-      [k, v], acc -> PyDict.put(acc, k, v)
-      _, acc -> acc
-    end)
+    {:ok,
+     Enum.reduce(list, PyDict.new(), fn
+       {:tuple, [k, v]}, acc -> PyDict.put(acc, k, v)
+       [k, v], acc -> PyDict.put(acc, k, v)
+       _, acc -> acc
+     end)}
   end
 
-  defp builtin_dict([_]),
-    do: {:exception, "TypeError: cannot convert to dict"}
+  defp builtin_dict_positional([_]), do: {:exception, "TypeError: cannot convert to dict"}
+
+  defp builtin_dict_positional(args) do
+    {:exception, "TypeError: dict expected at most 1 argument, got #{length(args)}"}
+  end
 
   @spec builtin_isinstance([Interpreter.pyvalue()]) :: boolean()
   defp builtin_isinstance([val, type_name]) when is_binary(type_name) do
@@ -957,17 +973,26 @@ defmodule Pyex.Builtins do
       length(args) >= 1 and Map.has_key?(kwargs, "file") ->
         {:exception, "TypeError: argument for open() given by name ('file') and position (1)"}
 
-      match?([path | _] when is_binary(path), args) ->
-        {:ok, hd(args)}
+      length(args) >= 1 ->
+        coerce_pathlike(hd(args), "open() argument 'file'")
 
-      match?(%{"file" => path} when is_binary(path), kwargs) ->
-        {:ok, Map.fetch!(kwargs, "file")}
+      Map.has_key?(kwargs, "file") ->
+        coerce_pathlike(Map.fetch!(kwargs, "file"), "open() argument 'file'")
 
       args == [] and not Map.has_key?(kwargs, "file") ->
         {:exception, "TypeError: open() missing required argument 'file' (pos 1)"}
 
       true ->
         {:exception, "TypeError: invalid arguments"}
+    end
+  end
+
+  @spec coerce_pathlike(Interpreter.pyvalue(), String.t()) ::
+          {:ok, String.t()} | {:exception, String.t()}
+  defp coerce_pathlike(value, label) do
+    case Pyex.Path.coerce(value) do
+      {:ok, path} -> {:ok, path}
+      :error -> {:exception, "TypeError: #{label} must be str or PathLike"}
     end
   end
 

--- a/lib/pyex/filesystem/memory.ex
+++ b/lib/pyex/filesystem/memory.ex
@@ -19,7 +19,7 @@ defmodule Pyex.Filesystem.Memory do
   Creates a new empty in-memory filesystem.
   """
   @spec new() :: t()
-  def new, do: %__MODULE__{}
+  def new, do: new(%{})
 
   @doc """
   Creates an in-memory filesystem pre-populated with files.

--- a/lib/pyex/filesystem/memory.ex
+++ b/lib/pyex/filesystem/memory.ex
@@ -2,17 +2,18 @@ defmodule Pyex.Filesystem.Memory do
   @moduledoc """
   In-memory filesystem backend.
 
-  Stores files as a map of path strings to content strings.
-  Fully serializable — suitable for use with `Pyex.Ctx`.
-  Directories are implicit (a file at "a/b/c.txt" implies "a/"
-  and "a/b/" exist).
+  Stores files as a map of path strings to content strings and keeps an
+  explicit directory set so empty directories can exist.
   """
 
   @behaviour Pyex.Filesystem
 
-  @type t :: %__MODULE__{files: %{optional(String.t()) => String.t()}}
+  @type t :: %__MODULE__{
+          files: %{optional(String.t()) => String.t()},
+          dirs: MapSet.t(String.t())
+        }
 
-  defstruct files: %{}
+  defstruct files: %{}, dirs: MapSet.new([""])
 
   @doc """
   Creates a new empty in-memory filesystem.
@@ -24,7 +25,10 @@ defmodule Pyex.Filesystem.Memory do
   Creates an in-memory filesystem pre-populated with files.
   """
   @spec new(%{optional(String.t()) => String.t()}) :: t()
-  def new(files) when is_map(files), do: %__MODULE__{files: files}
+  def new(files) when is_map(files) do
+    normalized = Map.new(files, fn {path, content} -> {normalize(path), content} end)
+    %__MODULE__{files: normalized, dirs: derive_dirs(normalized)}
+  end
 
   @impl Pyex.Filesystem
   @spec read(t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
@@ -38,56 +42,65 @@ defmodule Pyex.Filesystem.Memory do
   @impl Pyex.Filesystem
   @spec write(t(), String.t(), String.t(), Pyex.Filesystem.mode()) ::
           {:ok, t()} | {:error, String.t()}
-  def write(%__MODULE__{files: files} = fs, path, content, mode) do
+  def write(%__MODULE__{files: files, dirs: dirs} = fs, path, content, mode) do
     normalized = normalize(path)
 
     new_content =
       case mode do
-        :write ->
-          content
-
-        :append ->
-          existing = Map.get(files, normalized, "")
-          existing <> content
+        :write -> content
+        :append -> Map.get(files, normalized, "") <> content
       end
 
-    {:ok, %{fs | files: Map.put(files, normalized, new_content)}}
+    {:ok,
+     %{
+       fs
+       | files: Map.put(files, normalized, new_content),
+         dirs: MapSet.union(dirs, parent_dirs(normalized))
+     }}
   end
 
   @impl Pyex.Filesystem
   @spec exists?(t(), String.t()) :: boolean()
-  def exists?(%__MODULE__{files: files}, path) do
+  def exists?(%__MODULE__{files: files, dirs: dirs}, path) do
     normalized = normalize(path)
 
-    Map.has_key?(files, normalized) or
-      Enum.any?(files, fn {k, _v} -> String.starts_with?(k, normalized <> "/") end)
+    normalized == "" or Map.has_key?(files, normalized) or MapSet.member?(dirs, normalized)
   end
 
   @impl Pyex.Filesystem
   @spec list_dir(t(), String.t()) :: {:ok, [String.t()]} | {:error, String.t()}
-  def list_dir(%__MODULE__{files: files}, path) do
-    prefix =
-      case normalize(path) do
-        "" -> ""
-        p -> p <> "/"
-      end
+  def list_dir(%__MODULE__{files: files, dirs: dirs}, path) do
+    normalized = normalize(path)
 
-    entries =
-      files
-      |> Map.keys()
-      |> Enum.filter(&String.starts_with?(&1, prefix))
-      |> Enum.map(fn full_path ->
-        rest = String.replace_prefix(full_path, prefix, "")
+    cond do
+      normalized != "" and Map.has_key?(files, normalized) and
+          not MapSet.member?(dirs, normalized) ->
+        {:error, "NotADirectoryError: [Errno 20] Not a directory: '#{path}'"}
 
-        case String.split(rest, "/", parts: 2) do
-          [name | _] -> name
-          _ -> rest
-        end
-      end)
-      |> Enum.uniq()
-      |> Enum.sort()
+      normalized != "" and not MapSet.member?(dirs, normalized) ->
+        {:error, "FileNotFoundError: [Errno 2] No such file or directory: '#{path}'"}
 
-    {:ok, entries}
+      true ->
+        prefix = if normalized == "", do: "", else: normalized <> "/"
+
+        file_entries =
+          files
+          |> Map.keys()
+          |> Enum.filter(&String.starts_with?(&1, prefix))
+          |> Enum.map(&entry_name(&1, prefix))
+
+        dir_entries =
+          dirs
+          |> Enum.reject(&(&1 in ["", normalized]))
+          |> Enum.filter(&String.starts_with?(&1, prefix))
+          |> Enum.map(&entry_name(&1, prefix))
+
+        {:ok,
+         (file_entries ++ dir_entries)
+         |> Enum.reject(&(&1 == ""))
+         |> Enum.uniq()
+         |> Enum.sort()}
+    end
   end
 
   @impl Pyex.Filesystem
@@ -102,10 +115,84 @@ defmodule Pyex.Filesystem.Memory do
     end
   end
 
+  @doc """
+  Creates a directory and any missing parents.
+  """
+  @spec mkdir(t(), String.t()) :: {:ok, t()}
+  def mkdir(%__MODULE__{dirs: dirs} = fs, path) do
+    normalized = normalize(path)
+    {:ok, %{fs | dirs: MapSet.union(dirs, path_and_parent_dirs(normalized))}}
+  end
+
+  @doc """
+  Deletes a directory tree and all nested files.
+  """
+  @spec delete_tree(t(), String.t()) :: {:ok, t()} | {:error, String.t()}
+  def delete_tree(%__MODULE__{files: files, dirs: dirs} = fs, path) do
+    normalized = normalize(path)
+
+    cond do
+      normalized == "" ->
+        {:ok, %__MODULE__{}}
+
+      not MapSet.member?(dirs, normalized) ->
+        {:error, "FileNotFoundError: [Errno 2] No such file or directory: '#{path}'"}
+
+      true ->
+        new_files =
+          Map.reject(files, fn {file, _} ->
+            file == normalized or String.starts_with?(file, normalized <> "/")
+          end)
+
+        new_dirs =
+          dirs
+          |> Enum.reject(fn dir ->
+            dir == normalized or String.starts_with?(dir, normalized <> "/")
+          end)
+          |> MapSet.new()
+
+        {:ok, %{fs | files: new_files, dirs: MapSet.put(new_dirs, "")}}
+    end
+  end
+
   @spec normalize(String.t()) :: String.t()
   defp normalize(path) do
     path
     |> String.trim_leading("/")
     |> String.trim_trailing("/")
+  end
+
+  @spec derive_dirs(%{optional(String.t()) => String.t()}) :: MapSet.t(String.t())
+  defp derive_dirs(files) do
+    Enum.reduce(files, MapSet.new([""]), fn {path, _}, acc ->
+      MapSet.union(acc, parent_dirs(path))
+    end)
+  end
+
+  @spec parent_dirs(String.t()) :: MapSet.t(String.t())
+  defp parent_dirs(path) do
+    path
+    |> String.split("/", trim: true)
+    |> Enum.drop(-1)
+    |> Enum.reduce({MapSet.new([""]), []}, fn segment, {acc, prefix} ->
+      prefix = prefix ++ [segment]
+      {MapSet.put(acc, Enum.join(prefix, "/")), prefix}
+    end)
+    |> elem(0)
+  end
+
+  @spec path_and_parent_dirs(String.t()) :: MapSet.t(String.t())
+  defp path_and_parent_dirs(path) do
+    MapSet.put(parent_dirs(path), path)
+  end
+
+  @spec entry_name(String.t(), String.t()) :: String.t()
+  defp entry_name(full_path, prefix) do
+    rest = String.replace_prefix(full_path, prefix, "")
+
+    case String.split(rest, "/", parts: 2) do
+      [name | _] -> name
+      _ -> rest
+    end
   end
 end

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -548,8 +548,8 @@ defmodule Pyex.Interpreter do
     Statements.eval_del_var(var_name, env, ctx)
   end
 
-  def eval({:del, _, [:subscript, var_name, key_expr]}, env, ctx) do
-    Statements.eval_del_subscript(var_name, key_expr, env, ctx)
+  def eval({:del, _, [:subscript, target_expr, key_expr]}, env, ctx) do
+    Statements.eval_del_subscript(target_expr, key_expr, env, ctx)
   end
 
   def eval({:aug_subscript_assign, _, [var_name, key_expr, op, val_expr]}, env, ctx) do
@@ -1302,12 +1302,24 @@ defmodule Pyex.Interpreter do
     Invocation.call_builtin(fun, args, env, ctx)
   end
 
+  def call_function({:builtin_raw, fun}, args, _kwargs, env, ctx) do
+    Invocation.call_builtin_raw(fun, args, env, ctx)
+  end
+
+  def call_function({:builtin_type, "dict", _fun}, args, kwargs, env, ctx) do
+    Invocation.call_builtin_kw(&Builtins.builtin_dict/2, args, kwargs, env, ctx)
+  end
+
   def call_function({:builtin_type, _name, fun}, args, kwargs, env, ctx) do
     call_function({:builtin, fun}, args, kwargs, env, ctx)
   end
 
   def call_function({:builtin_kw, fun}, args, kwargs, env, ctx) do
     Invocation.call_builtin_kw(fun, args, kwargs, env, ctx)
+  end
+
+  def call_function({:builtin_kw_raw, fun}, args, kwargs, env, ctx) do
+    Invocation.call_builtin_kw_raw(fun, args, kwargs, env, ctx)
   end
 
   def call_function(

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -87,6 +87,7 @@ defmodule Pyex.Interpreter do
           | {:io_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})}
           | {:ctx_call, (Env.t(), Ctx.t() -> term())}
           | {:mutate, pyvalue(), pyvalue()}
+          | {:mutate_arg, non_neg_integer(), pyvalue(), pyvalue()}
           | {:dunder_call, pyvalue(), String.t(), [pyvalue()]}
           | {:map_call, pyvalue(), [pyvalue()]}
           | {:filter_call, pyvalue(), [pyvalue()]}
@@ -1276,6 +1277,8 @@ defmodule Pyex.Interpreter do
           | {pyvalue(), Env.t(), Ctx.t(), pyvalue()}
           | {:mutate, pyvalue(), pyvalue(), Ctx.t()}
           | {:mutate, pyvalue(), pyvalue(), Env.t(), Ctx.t()}
+          | {:mutate_arg, non_neg_integer(), pyvalue(), pyvalue(), Ctx.t()}
+          | {:mutate_arg, non_neg_integer(), pyvalue(), pyvalue(), Env.t(), Ctx.t()}
           | {{:register_route, String.t(), String.t(), pyvalue()}, Env.t(), Ctx.t()}
           | {{:exception, String.t()}, Env.t(), Ctx.t()}
 

--- a/lib/pyex/interpreter/assignments.ex
+++ b/lib/pyex/interpreter/assignments.ex
@@ -379,6 +379,41 @@ defmodule Pyex.Interpreter.Assignments do
           new_val = Interpreter.safe_binop(op, old_val, val)
           setattr_nested(target_expr, Map.put(map, key, new_val), env, ctx)
 
+        {:py_list, reversed, len} when is_integer(key) ->
+          idx = if key < 0, do: len + key, else: key
+
+          if idx < 0 or idx >= len do
+            {{:exception, "IndexError: list index out of range"}, env, ctx}
+          else
+            old_val = Enum.at(reversed, len - 1 - idx)
+
+            case Interpreter.safe_binop(op, old_val, val) do
+              {:exception, msg} ->
+                {{:exception, msg}, env, ctx}
+
+              new_val ->
+                updated = {:py_list, List.replace_at(reversed, len - 1 - idx, new_val), len}
+                setattr_nested(target_expr, updated, env, ctx)
+            end
+          end
+
+        list when is_list(list) and is_integer(key) ->
+          idx = if key < 0, do: length(list) + key, else: key
+
+          if idx < 0 or idx >= length(list) do
+            {{:exception, "IndexError: list index out of range"}, env, ctx}
+          else
+            old_val = Enum.at(list, idx)
+
+            case Interpreter.safe_binop(op, old_val, val) do
+              {:exception, msg} ->
+                {{:exception, msg}, env, ctx}
+
+              new_val ->
+                setattr_nested(target_expr, List.replace_at(list, idx, new_val), env, ctx)
+            end
+          end
+
         _ ->
           {{:exception, "TypeError: object does not support item assignment"}, env, ctx}
       end
@@ -598,6 +633,36 @@ defmodule Pyex.Interpreter.Assignments do
     List.replace_at(obj, key, val)
   end
 
+  @doc false
+  @spec delete_subscript_value(Interpreter.pyvalue(), Interpreter.pyvalue()) ::
+          Interpreter.pyvalue() | {:exception, String.t()}
+  def delete_subscript_value({:py_dict, _, _} = dict, key), do: PyDict.delete(dict, key)
+  def delete_subscript_value(obj, key) when is_map(obj), do: Map.delete(obj, key)
+
+  def delete_subscript_value({:py_list, reversed, len}, key) when is_integer(key) do
+    idx = if key < 0, do: len + key, else: key
+
+    if idx < 0 or idx >= len do
+      {:exception, "IndexError: list index out of range"}
+    else
+      {:py_list, List.delete_at(reversed, len - 1 - idx), len - 1}
+    end
+  end
+
+  def delete_subscript_value(obj, key) when is_list(obj) and is_integer(key) do
+    len = length(obj)
+    idx = if key < 0, do: len + key, else: key
+
+    if idx < 0 or idx >= len do
+      {:exception, "IndexError: list index out of range"}
+    else
+      List.delete_at(obj, idx)
+    end
+  end
+
+  def delete_subscript_value(_, _),
+    do: {:exception, "TypeError: object does not support item deletion"}
+
   @spec write_back_target(Parser.ast_node(), Interpreter.pyvalue(), Env.t(), Ctx.t()) ::
           eval_result()
   defp write_back_target({:var, _, [name]}, updated, env, ctx) do
@@ -612,16 +677,17 @@ defmodule Pyex.Interpreter.Assignments do
     {updated, env, ctx}
   end
 
+  @doc false
   @spec write_back_subscript(Parser.ast_node(), Interpreter.pyvalue(), Env.t(), Ctx.t()) ::
           eval_result()
-  defp write_back_subscript({:var, _, [name]}, updated, env, ctx) do
+  def write_back_subscript({:var, _, [name]}, updated, env, ctx) do
     case Env.get(env, name) do
       {:ok, {:ref, id}} -> {updated, env, Ctx.heap_put(ctx, id, updated)}
       _ -> {updated, Env.put_at_source(env, name, updated), ctx}
     end
   end
 
-  defp write_back_subscript({:subscript, _, [parent_expr, key_expr]}, updated, env, ctx) do
+  def write_back_subscript({:subscript, _, [parent_expr, key_expr]}, updated, env, ctx) do
     {raw_parent, env, ctx} = Interpreter.eval(parent_expr, env, ctx)
     parent = Ctx.deref(ctx, raw_parent)
     {key, env, ctx} = Interpreter.eval(key_expr, env, ctx)
@@ -629,11 +695,11 @@ defmodule Pyex.Interpreter.Assignments do
     write_back_subscript(parent_expr, updated_parent, env, ctx)
   end
 
-  defp write_back_subscript({:getattr, _, _} = target, updated, env, ctx) do
+  def write_back_subscript({:getattr, _, _} = target, updated, env, ctx) do
     setattr_nested(target, updated, env, ctx)
   end
 
-  defp write_back_subscript(_, updated, env, ctx) do
+  def write_back_subscript(_, updated, env, ctx) do
     {updated, env, ctx}
   end
 

--- a/lib/pyex/interpreter/bindings.ex
+++ b/lib/pyex/interpreter/bindings.ex
@@ -50,6 +50,7 @@ defmodule Pyex.Interpreter.Bindings do
     annotations = current_annotations(env)
     resolved = Interpreter.resolve_annotation(type_str, env)
     env = Env.smart_put(env, "__annotations__", Map.put(annotations, name, resolved))
+    env = Env.smart_put(env, "__annotations_order__", update_annotation_order(env, name))
     {nil, env, ctx}
   end
 
@@ -67,6 +68,7 @@ defmodule Pyex.Interpreter.Bindings do
         annotations = current_annotations(env)
         resolved = Interpreter.resolve_annotation(type_str, env)
         env = Env.smart_put(env, "__annotations__", Map.put(annotations, name, resolved))
+        env = Env.smart_put(env, "__annotations_order__", update_annotation_order(env, name))
         {value, Env.smart_put(env, name, value), ctx}
     end
   end
@@ -149,5 +151,19 @@ defmodule Pyex.Interpreter.Bindings do
       {:ok, map} when is_map(map) -> map
       _ -> %{}
     end
+  end
+
+  @spec current_annotation_order(Env.t()) :: [String.t()]
+  defp current_annotation_order(env) do
+    case Env.get(env, "__annotations_order__") do
+      {:ok, names} when is_list(names) -> names
+      _ -> []
+    end
+  end
+
+  @spec update_annotation_order(Env.t(), String.t()) :: [String.t()]
+  defp update_annotation_order(env, name) do
+    order = current_annotation_order(env)
+    if name in order, do: order, else: order ++ [name]
   end
 end

--- a/lib/pyex/interpreter/builtin_results.ex
+++ b/lib/pyex/interpreter/builtin_results.ex
@@ -27,6 +27,9 @@ defmodule Pyex.Interpreter.BuiltinResults do
       {:mutate, new_object, return_value} ->
         {:mutate, new_object, return_value, ctx}
 
+      {:mutate_arg, index, new_object, return_value} ->
+        {:mutate_arg, index, new_object, return_value, ctx}
+
       {:method_call, instance, func, method_args} ->
         Calls.call_method(instance, func, method_args, %{}, env, ctx)
 

--- a/lib/pyex/interpreter/calls.ex
+++ b/lib/pyex/interpreter/calls.ex
@@ -34,11 +34,21 @@ defmodule Pyex.Interpreter.Calls do
                   _ -> {return_value, Env.put_at_source(new_env, var_name, new_object), ctx}
                 end
 
+              {:mutate_arg, index, new_object, return_value, new_env, ctx} ->
+                {new_env, ctx} =
+                  mutate_target(Enum.at(arg_exprs, index), new_object, new_env, ctx)
+
+                {return_value, new_env, ctx}
+
               {:mutate, new_object, return_value, ctx} ->
                 case Env.get(env, var_name) do
                   {:ok, {:ref, id}} -> {return_value, env, Ctx.heap_put(ctx, id, new_object)}
                   _ -> {return_value, Env.put_at_source(env, var_name, new_object), ctx}
                 end
+
+              {:mutate_arg, index, new_object, return_value, ctx} ->
+                {env, ctx} = mutate_target(Enum.at(arg_exprs, index), new_object, env, ctx)
+                {return_value, env, ctx}
 
               {{:exception, _} = signal, env, ctx} ->
                 {signal, env, ctx}
@@ -76,9 +86,19 @@ defmodule Pyex.Interpreter.Calls do
                 {new_env, ctx} = mutate_target(target, new_object, new_env, ctx)
                 {return_value, new_env, ctx}
 
+              {:mutate_arg, index, new_object, return_value, new_env, ctx} ->
+                {new_env, ctx} =
+                  mutate_target(Enum.at(arg_exprs, index), new_object, new_env, ctx)
+
+                {return_value, new_env, ctx}
+
               {:mutate, new_object, return_value, ctx} ->
                 target = mutate_target_expr(func_expr, arg_exprs)
                 {env, ctx} = mutate_target(target, new_object, env, ctx)
+                {return_value, env, ctx}
+
+              {:mutate_arg, index, new_object, return_value, ctx} ->
+                {env, ctx} = mutate_target(Enum.at(arg_exprs, index), new_object, env, ctx)
                 {return_value, env, ctx}
 
               {{:exception, _} = signal, env, ctx} ->

--- a/lib/pyex/interpreter/import.ex
+++ b/lib/pyex/interpreter/import.ex
@@ -23,11 +23,12 @@ defmodule Pyex.Interpreter.Import do
           module_name when is_binary(module_name) -> {module_name, nil}
         end
 
-      bind_as = alias_name || module_name
+      bind_as = alias_name || import_binding_name(module_name)
 
       case resolve_module(module_name, env, ctx) do
         {:ok, module_value, ctx} ->
-          {:cont, {nil, Env.put(env, bind_as, module_value), ctx}}
+          bound_value = binding_value(module_name, alias_name, module_value, env, ctx)
+          {:cont, {nil, Env.put(env, bind_as, bound_value), ctx}}
 
         {:import_error, msg, ctx} ->
           {:halt, {{:exception, msg}, env, ctx}}
@@ -76,8 +77,8 @@ defmodule Pyex.Interpreter.Import do
   Returns a helpful error suffix for unknown module names.
   """
   @spec import_hint(String.t()) :: String.t()
-  def import_hint("urllib"), do: ". Use 'import requests' instead"
-  def import_hint("urllib." <> _), do: ". Use 'import requests' instead"
+  def import_hint("urllib.request"), do: ". Use 'import requests' instead"
+  def import_hint("urllib.error"), do: ". Use 'import requests' instead"
 
   def import_hint(name) when name in ["urllib2", "http", "httplib", "httpx", "aiohttp"],
     do: ". Use 'import requests' instead"
@@ -91,6 +92,29 @@ defmodule Pyex.Interpreter.Import do
   def import_hint(_) do
     names = ["os" | Pyex.Stdlib.module_names()] |> Enum.join(", ")
     ". Available modules: #{names}"
+  end
+
+  @spec import_binding_name(String.t()) :: String.t()
+  defp import_binding_name(module_name) do
+    module_name
+    |> String.split(".")
+    |> hd()
+  end
+
+  @spec binding_value(String.t(), String.t() | nil, map(), Env.t(), Ctx.t()) :: map()
+  defp binding_value(module_name, alias_name, module_value, env, ctx) do
+    cond do
+      alias_name != nil ->
+        module_value
+
+      String.contains?(module_name, ".") ->
+        root = import_binding_name(module_name)
+        {:ok, root_module, _ctx} = resolve_single_module(root, env, ctx)
+        root_module
+
+      true ->
+        module_value
+    end
   end
 
   @doc """
@@ -169,7 +193,8 @@ defmodule Pyex.Interpreter.Import do
        "environ" => ctx.env,
        "path" => path_module,
        "makedirs" => {:builtin, &os_makedirs/1},
-       "listdir" => {:builtin, &os_listdir/1}
+       "listdir" => {:builtin, &os_listdir/1},
+       "walk" => {:builtin, &os_walk/1}
      }}
   end
 
@@ -184,32 +209,70 @@ defmodule Pyex.Interpreter.Import do
     os_listdir([""])
   end
 
-  defp os_listdir([path]) when is_binary(path) do
-    {:ctx_call,
-     fn env, ctx ->
-       case ctx.filesystem do
-         nil ->
-           {{:exception, "OSError: no filesystem configured"}, env, ctx}
+  defp os_listdir([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} ->
+        {:ctx_call,
+         fn env, ctx ->
+           case ctx.filesystem do
+             nil ->
+               {{:exception, "OSError: no filesystem configured"}, env, ctx}
 
-         fs ->
-           case fs.__struct__.list_dir(fs, path) do
-             {:ok, entries} ->
-               {entries, env, ctx}
+             fs ->
+               case fs.__struct__.list_dir(fs, path) do
+                 {:ok, entries} ->
+                   {entries, env, ctx}
 
-             {:error, msg} ->
-               {{:exception, msg}, env, ctx}
+                 {:error, msg} ->
+                   {{:exception, msg}, env, ctx}
+               end
            end
-       end
-     end}
-  end
+         end}
 
-  defp os_listdir([_arg]) do
-    {:exception, "TypeError: listdir: path should be string"}
+      :error ->
+        {:exception, "TypeError: listdir: path should be string"}
+    end
   end
 
   defp os_listdir(_args) do
     {:exception, "TypeError: listdir expected at most 1 argument"}
   end
+
+  @spec os_walk([Interpreter.pyvalue()]) ::
+          {:ctx_call, (Pyex.Env.t(), Ctx.t() -> {term(), Pyex.Env.t(), Ctx.t()})}
+          | {:exception, String.t()}
+  defp os_walk([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} ->
+        {:ctx_call,
+         fn env, ctx ->
+           case ctx.filesystem do
+             nil ->
+               {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+             fs ->
+               case Pyex.Path.walk(fs, path) do
+                 {:ok, entries} ->
+                   rows =
+                     Enum.map(entries, fn {root, dirs, files} ->
+                       {:tuple, [root, dirs, Enum.map(files, &Pyex.Path.basename/1)]}
+                     end)
+
+                   {token, ctx} = Ctx.new_iterator(ctx, rows)
+                   {token, env, ctx}
+
+                 {:error, msg} ->
+                   {{:exception, msg}, env, ctx}
+               end
+           end
+         end}
+
+      :error ->
+        {:exception, "TypeError: walk: top should be string"}
+    end
+  end
+
+  defp os_walk(_args), do: {:exception, "TypeError: walk expected exactly 1 argument"}
 
   @spec resolve_filesystem_module(String.t(), Env.t(), Ctx.t()) ::
           {:ok, Pyex.Stdlib.Module.module_value(), Ctx.t()}
@@ -267,51 +330,133 @@ defmodule Pyex.Interpreter.Import do
   end
 
   # os.path module functions
-  defp os_path_join([a, b]) when is_binary(a) and is_binary(b) do
-    Path.join(a, b)
-  end
-
-  defp os_path_join([a, b, c]) when is_binary(a) and is_binary(b) and is_binary(c) do
-    Path.join([a, b, c])
-  end
-
-  defp os_path_exists([path]) when is_binary(path) do
-    # For now, always return False since we don't have real filesystem access
-    false
-  end
-
-  defp os_path_basename([path]) when is_binary(path) do
-    Path.basename(path)
-  end
-
-  defp os_path_dirname([path]) when is_binary(path) do
-    Path.dirname(path)
-  end
-
-  defp os_path_splitext([path]) when is_binary(path) do
-    # Split path into base and extension
-    case Regex.run(~r/^(.*)(\.[^.]+)$/, path) do
-      [_, base, ext] -> {:tuple, [base, ext]}
-      nil -> {:tuple, [path, ""]}
+  defp os_path_join(args) when args != [] do
+    case coerce_paths(args) do
+      {:ok, parts} -> Pyex.Path.join(parts)
+      {:error, msg} -> {:exception, msg}
     end
   end
 
-  defp os_path_isfile([path]) when is_binary(path) do
-    # For now, always return False
-    false
+  defp os_path_join(_args) do
+    {:exception, "TypeError: join() takes at least 1 argument"}
   end
 
-  defp os_path_isdir([path]) when is_binary(path) do
-    # For now, always return False
-    false
+  defp os_path_exists([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} ->
+        {:ctx_call,
+         fn env, ctx ->
+           case ctx.filesystem do
+             nil -> {false, env, ctx}
+             fs -> {Pyex.Path.exists?(fs, path), env, ctx}
+           end
+         end}
+
+      :error ->
+        {:exception, "TypeError: path should be string"}
+    end
   end
 
-  defp os_makedirs([path]) when is_binary(path) do
-    # For now, just return nil (no-op)
-    nil
+  defp os_path_basename([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} -> Pyex.Path.basename(path)
+      :error -> {:exception, "TypeError: path should be string"}
+    end
   end
 
-  defp os_makedirs([path, kwargs]) when is_binary(path) and is_map(kwargs) do
-    nil
+  defp os_path_dirname([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} -> Pyex.Path.dirname(path)
+      :error -> {:exception, "TypeError: path should be string"}
+    end
+  end
+
+  defp os_path_splitext([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} ->
+        {root, ext} = Pyex.Path.splitext(path)
+        {:tuple, [root, ext]}
+
+      :error ->
+        {:exception, "TypeError: path should be string"}
+    end
+  end
+
+  defp os_path_isfile([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} ->
+        {:ctx_call,
+         fn env, ctx ->
+           case ctx.filesystem do
+             nil -> {false, env, ctx}
+             fs -> {Pyex.Path.file?(fs, path), env, ctx}
+           end
+         end}
+
+      :error ->
+        {:exception, "TypeError: path should be string"}
+    end
+  end
+
+  defp os_path_isdir([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} ->
+        {:ctx_call,
+         fn env, ctx ->
+           case ctx.filesystem do
+             nil -> {false, env, ctx}
+             fs -> {Pyex.Path.dir?(fs, path), env, ctx}
+           end
+         end}
+
+      :error ->
+        {:exception, "TypeError: path should be string"}
+    end
+  end
+
+  defp os_makedirs([path]) do
+    case Pyex.Path.coerce(path) do
+      {:ok, path} ->
+        {:ctx_call,
+         fn env, ctx ->
+           case ctx.filesystem do
+             nil ->
+               {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+             fs ->
+               case Pyex.Path.mkdir_p(fs, path) do
+                 {:ok, fs} -> {nil, env, %{ctx | filesystem: fs}}
+                 {:error, msg} -> {{:exception, msg}, env, ctx}
+               end
+           end
+         end}
+
+      :error ->
+        {:exception, "TypeError: path should be string"}
+    end
+  end
+
+  defp os_makedirs([path, kwargs]) when is_map(kwargs) do
+    case Map.keys(kwargs) -- ["exist_ok"] do
+      [] ->
+        os_makedirs([path])
+
+      [name | _] ->
+        {:exception, "TypeError: makedirs() got an unexpected keyword argument '#{name}'"}
+    end
+  end
+
+  @spec coerce_paths([Interpreter.pyvalue()]) :: {:ok, [String.t()]} | {:error, String.t()}
+  defp coerce_paths(paths) do
+    Enum.reduce_while(paths, {:ok, []}, fn path, {:ok, acc} ->
+      case Pyex.Path.coerce(path) do
+        {:ok, path} -> {:cont, {:ok, [path | acc]}}
+        :error -> {:halt, {:error, "TypeError: path should be string"}}
+      end
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, Enum.reverse(acc)}
+      {:error, _} = error -> error
+    end
   end
 end

--- a/lib/pyex/interpreter/import.ex
+++ b/lib/pyex/interpreter/import.ex
@@ -424,10 +424,8 @@ defmodule Pyex.Interpreter.Import do
                {{:exception, "OSError: no filesystem configured"}, env, ctx}
 
              fs ->
-               case Pyex.Path.mkdir_p(fs, path) do
-                 {:ok, fs} -> {nil, env, %{ctx | filesystem: fs}}
-                 {:error, msg} -> {{:exception, msg}, env, ctx}
-               end
+               {:ok, fs} = Pyex.Path.mkdir_p(fs, path)
+               {nil, env, %{ctx | filesystem: fs}}
            end
          end}
 

--- a/lib/pyex/interpreter/invocation.ex
+++ b/lib/pyex/interpreter/invocation.ex
@@ -130,6 +130,24 @@ defmodule Pyex.Interpreter.Invocation do
   end
 
   @doc false
+  @spec call_builtin_raw((list() -> term()), [Interpreter.pyvalue()], Env.t(), Ctx.t()) ::
+          Interpreter.call_result()
+  def call_builtin_raw(fun, args, env, ctx) do
+    result =
+      try do
+        fun.(args)
+      rescue
+        FunctionClauseError ->
+          {:exception, "TypeError: invalid arguments"}
+
+        e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
+          {:exception, "TypeError: #{Exception.message(e)}"}
+      end
+
+    BuiltinResults.handle_builtin_result(result, env, ctx)
+  end
+
+  @doc false
   @spec call_builtin_kw(
           (list(), %{optional(String.t()) => Interpreter.pyvalue()} -> term()),
           [Interpreter.pyvalue()],
@@ -156,6 +174,29 @@ defmodule Pyex.Interpreter.Invocation do
   end
 
   @doc false
+  @spec call_builtin_kw_raw(
+          (list(), %{optional(String.t()) => Interpreter.pyvalue()} -> term()),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()},
+          Env.t(),
+          Ctx.t()
+        ) :: Interpreter.call_result()
+  def call_builtin_kw_raw(fun, args, kwargs, env, ctx) do
+    result =
+      try do
+        fun.(args, kwargs)
+      rescue
+        FunctionClauseError ->
+          {:exception, "TypeError: invalid arguments"}
+
+        e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
+          {:exception, "TypeError: #{Exception.message(e)}"}
+      end
+
+    BuiltinResults.handle_builtin_kw_result(result, env, ctx)
+  end
+
+  @doc false
   @spec call_bound_builtin_kw(
           Interpreter.pyvalue(),
           (list(), %{optional(String.t()) => Interpreter.pyvalue()} -> term()),
@@ -169,15 +210,13 @@ defmodule Pyex.Interpreter.Invocation do
     derefed_args = Enum.map(args, &Ctx.deep_deref(ctx, &1))
     derefed_kwargs = Map.new(kwargs, fn {k, v} -> {k, Ctx.deep_deref(ctx, v)} end)
 
-    case fun.([derefed_instance | derefed_args], derefed_kwargs) do
-      {:exception, _} = signal ->
-        {signal, env, ctx}
-
-      {:mutate, new_obj, return_val, new_ctx} ->
-        {:mutate, new_obj, return_val, new_ctx}
-
-      result ->
-        {result, env, ctx}
+    case BuiltinResults.handle_builtin_kw_result(
+           fun.([derefed_instance | derefed_args], derefed_kwargs),
+           env,
+           ctx
+         ) do
+      {:mutate, new_obj, return_val, new_ctx} -> {:mutate, new_obj, return_val, new_ctx}
+      other -> other
     end
   end
 
@@ -193,12 +232,10 @@ defmodule Pyex.Interpreter.Invocation do
     derefed_instance = Ctx.deep_deref(ctx, instance)
     derefed_args = Enum.map(args, &Ctx.deep_deref(ctx, &1))
 
-    case fun.([derefed_instance | derefed_args]) do
-      {:exception, _} = signal ->
-        {signal, env, ctx}
-
-      result ->
-        {result, env, ctx}
+    BuiltinResults.handle_builtin_result(fun.([derefed_instance | derefed_args]), env, ctx)
+    |> case do
+      {:mutate, new_obj, return_val, new_ctx} -> {:mutate, new_obj, return_val, new_ctx}
+      other -> other
     end
   end
 

--- a/lib/pyex/interpreter/statements.ex
+++ b/lib/pyex/interpreter/statements.ex
@@ -6,8 +6,8 @@ defmodule Pyex.Interpreter.Statements do
   on dispatch while preserving the public `eval/3` entrypoint.
   """
 
-  alias Pyex.{Ctx, Env, Interpreter, Parser, PyDict}
-  alias Pyex.Interpreter.Helpers
+  alias Pyex.{Ctx, Env, Interpreter, Parser}
+  alias Pyex.Interpreter.{Assignments, Helpers}
 
   @typep eval_result :: {Interpreter.pyvalue() | tuple(), Env.t(), Ctx.t()}
 
@@ -40,65 +40,32 @@ defmodule Pyex.Interpreter.Statements do
   end
 
   @doc """
-  Evaluates `del obj[key]` for name-backed containers.
+  Evaluates `del obj[key]` for general subscript targets.
   """
-  @spec eval_del_subscript(String.t(), Parser.ast_node(), Env.t(), Ctx.t()) :: eval_result()
-  def eval_del_subscript(var_name, key_expr, env, ctx) do
-    case Env.get(env, var_name) do
-      {:ok, raw} ->
-        obj = Ctx.deref(ctx, raw)
+  @spec eval_del_subscript(Parser.ast_node(), Parser.ast_node(), Env.t(), Ctx.t()) ::
+          eval_result()
+  def eval_del_subscript(target_expr, key_expr, env, ctx) do
+    case Interpreter.eval(target_expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
 
-        case obj do
-          {:py_dict, _, _} = dict ->
-            case Interpreter.eval(key_expr, env, ctx) do
-              {{:exception, _} = signal, env, ctx} ->
+      {raw_target, env, ctx} ->
+        case Interpreter.eval(key_expr, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
+            {signal, env, ctx}
+
+          {key, env, ctx} ->
+            target = Ctx.deref(ctx, raw_target)
+
+            case Assignments.delete_subscript_value(target, key) do
+              {:exception, _} = signal ->
                 {signal, env, ctx}
 
-              {key, env, ctx} ->
-                {nil, Env.put(env, var_name, PyDict.delete(dict, key)), ctx}
+              updated ->
+                {_, env, ctx} = Assignments.write_back_subscript(target_expr, updated, env, ctx)
+                {nil, env, ctx}
             end
-
-          map when is_map(map) ->
-            case Interpreter.eval(key_expr, env, ctx) do
-              {{:exception, _} = signal, env, ctx} ->
-                {signal, env, ctx}
-
-              {key, env, ctx} ->
-                {nil, Env.put(env, var_name, Map.delete(map, key)), ctx}
-            end
-
-          {:py_list, reversed, len} ->
-            case Interpreter.eval(key_expr, env, ctx) do
-              {{:exception, _} = signal, env, ctx} ->
-                {signal, env, ctx}
-
-              {idx, env, ctx} when is_integer(idx) ->
-                real_idx = if idx < 0, do: len + idx, else: idx
-                new_reversed = List.delete_at(reversed, len - 1 - real_idx)
-                {nil, Env.put(env, var_name, {:py_list, new_reversed, len - 1}), ctx}
-
-              {_, env, ctx} ->
-                {{:exception, "TypeError: list indices must be integers"}, env, ctx}
-            end
-
-          list when is_list(list) ->
-            case Interpreter.eval(key_expr, env, ctx) do
-              {{:exception, _} = signal, env, ctx} ->
-                {signal, env, ctx}
-
-              {idx, env, ctx} when is_integer(idx) ->
-                {nil, Env.put(env, var_name, List.delete_at(list, idx)), ctx}
-
-              {_, env, ctx} ->
-                {{:exception, "TypeError: list indices must be integers"}, env, ctx}
-            end
-
-          _ ->
-            {{:exception, "TypeError: object does not support item deletion"}, env, ctx}
         end
-
-      :undefined ->
-        {{:exception, "NameError: name '#{var_name}' is not defined"}, env, ctx}
     end
   end
 

--- a/lib/pyex/methods.ex
+++ b/lib/pyex/methods.ex
@@ -72,6 +72,7 @@ defmodule Pyex.Methods do
   def resolve({:py_dict, _, _} = object, attr) do
     case dict_method(attr) do
       {:ok, method_fn} -> {:ok, {:builtin, bound(method_fn, object)}}
+      {:ok_raw, method_fn} -> {:ok, {:builtin_raw, bound(method_fn, object)}}
       :error -> :error
     end
   end
@@ -79,6 +80,7 @@ defmodule Pyex.Methods do
   def resolve(object, attr) when is_map(object) do
     case dict_method(attr) do
       {:ok, method_fn} -> {:ok, {:builtin, bound(method_fn, object)}}
+      {:ok_raw, method_fn} -> {:ok, {:builtin_raw, bound(method_fn, object)}}
       :error -> :error
     end
   end
@@ -227,7 +229,7 @@ defmodule Pyex.Methods do
   defp dict_method("items"), do: {:ok, &dict_items/2}
   defp dict_method("pop"), do: {:ok, &dict_pop/2}
   defp dict_method("update"), do: {:ok, &dict_update/2}
-  defp dict_method("setdefault"), do: {:ok, &dict_setdefault/2}
+  defp dict_method("setdefault"), do: {:ok_raw, &dict_setdefault/2}
   defp dict_method("clear"), do: {:ok, &dict_clear/2}
   defp dict_method("copy"), do: {:ok, &dict_copy/2}
   defp dict_method(_), do: :error

--- a/lib/pyex/methods.ex
+++ b/lib/pyex/methods.ex
@@ -222,6 +222,10 @@ defmodule Pyex.Methods do
            (%{optional(Interpreter.pyvalue()) => Interpreter.pyvalue()},
             [Interpreter.pyvalue()] ->
               Interpreter.pyvalue())}
+          | {:ok_raw,
+             (%{optional(Interpreter.pyvalue()) => Interpreter.pyvalue()},
+              [Interpreter.pyvalue()] ->
+                term())}
           | :error
   defp dict_method("get"), do: {:ok, &dict_get/2}
   defp dict_method("keys"), do: {:ok, &dict_keys/2}

--- a/lib/pyex/parser.ex
+++ b/lib/pyex/parser.ex
@@ -239,17 +239,18 @@ defmodule Pyex.Parser do
   end
 
   defp parse_statement([{:keyword, line, "del"} | rest]) do
-    case rest do
-      [{:name, _, var_name}, {:op, _, :lbracket} | subscript_rest] ->
-        with {:ok, key_expr, [{:op, _, :rbracket} | rest]} <- parse_expression(subscript_rest) do
-          {:ok, {:del, [line: line], [:subscript, var_name, key_expr]}, drop_newline(rest)}
-        end
-
-      [{:name, _, var_name} | rest] ->
+    case parse_expression(rest) do
+      {:ok, {:var, _, [var_name]}, rest} ->
         {:ok, {:del, [line: line], [:var, var_name]}, drop_newline(rest)}
 
-      _ ->
+      {:ok, {:subscript, _, [target_expr, key_expr]}, rest} ->
+        {:ok, {:del, [line: line], [:subscript, target_expr, key_expr]}, drop_newline(rest)}
+
+      {:ok, _expr, _rest} ->
         {:error, "expected variable or subscript after 'del' at line #{line}"}
+
+      {:error, _} = error ->
+        error
     end
   end
 

--- a/lib/pyex/path.ex
+++ b/lib/pyex/path.ex
@@ -1,0 +1,399 @@
+defmodule Pyex.Path do
+  @moduledoc """
+  Filesystem and path helpers shared across Pyex APIs.
+  """
+
+  @type pathlike :: String.t() | term()
+
+  @doc """
+  Coerces a Python path-like value to a path string.
+  """
+  @spec coerce(pathlike()) :: {:ok, String.t()} | :error
+  def coerce(path) when is_binary(path), do: {:ok, path}
+
+  def coerce({:instance, {:class, "Path", _, _}, %{"__path__" => path}}) when is_binary(path) do
+    {:ok, path}
+  end
+
+  def coerce(_), do: :error
+
+  @doc """
+  Joins path segments using Python-style path semantics.
+  """
+  @spec join([String.t()]) :: String.t()
+  def join([]), do: ""
+  def join(parts), do: Elixir.Path.join(parts)
+
+  @doc """
+  Returns the basename of a path.
+  """
+  @spec basename(String.t()) :: String.t()
+  def basename(path), do: Elixir.Path.basename(path)
+
+  @doc """
+  Returns the dirname of a path.
+  """
+  @spec dirname(String.t()) :: String.t()
+  def dirname(path), do: Elixir.Path.dirname(path)
+
+  @doc """
+  Splits a path into root and extension.
+  """
+  @spec splitext(String.t()) :: {String.t(), String.t()}
+  def splitext(path) do
+    base = basename(path)
+
+    case splitext_basename(base) do
+      {^base, ""} ->
+        {path, ""}
+
+      {root_base, ext} ->
+        prefix = binary_part(path, 0, byte_size(path) - byte_size(base))
+        {prefix <> root_base, ext}
+    end
+  end
+
+  @doc """
+  Returns the stem of a path.
+  """
+  @spec stem(String.t()) :: String.t()
+  def stem(path) do
+    {root, _ext} = splitext(path)
+    basename(root)
+  end
+
+  @doc """
+  Returns the suffix of a path.
+  """
+  @spec suffix(String.t()) :: String.t()
+  def suffix(path) do
+    {_root, ext} = splitext(path)
+    ext
+  end
+
+  @doc """
+  Returns true when the path exists.
+  """
+  @spec exists?(term(), String.t()) :: boolean()
+  def exists?(fs, path) do
+    file?(fs, path) or dir?(fs, path)
+  end
+
+  @doc """
+  Returns true when the path exists and is a regular file.
+  """
+  @spec file?(term(), String.t()) :: boolean()
+  def file?(fs, path) do
+    match?({:ok, _}, fs.__struct__.read(fs, path))
+  end
+
+  @doc """
+  Returns true when the path exists and behaves like a directory.
+  """
+  @spec dir?(term(), String.t()) :: boolean()
+  def dir?(fs, path) do
+    case fs.__struct__.list_dir(fs, path) do
+      {:ok, _} -> true
+      {:error, _} -> false
+    end
+  end
+
+  @doc """
+  Lists a directory, returning child names.
+  """
+  @spec list_dir(term(), String.t()) :: {:ok, [String.t()]} | {:error, String.t()}
+  def list_dir(fs, path) do
+    fs.__struct__.list_dir(fs, path)
+  end
+
+  @doc """
+  Creates a directory and any missing parents.
+  """
+  @spec mkdir_p(term(), String.t()) :: {:ok, term()} | {:error, String.t()}
+  def mkdir_p(%Pyex.Filesystem.Memory{} = fs, path), do: Pyex.Filesystem.Memory.mkdir(fs, path)
+  def mkdir_p(fs, _path), do: {:ok, fs}
+
+  @doc """
+  Deletes a file path.
+  """
+  @spec unlink(term(), String.t()) :: {:ok, term()} | {:error, String.t()}
+  def unlink(fs, path), do: fs.__struct__.delete(fs, path)
+
+  @doc """
+  Deletes a directory tree.
+  """
+  @spec delete_tree(term(), String.t()) :: {:ok, term()} | {:error, String.t()}
+  def delete_tree(%Pyex.Filesystem.Memory{} = fs, path),
+    do: Pyex.Filesystem.Memory.delete_tree(fs, path)
+
+  def delete_tree(fs, path) do
+    case walk(fs, path) do
+      {:ok, entries} ->
+        entries
+        |> Enum.flat_map(fn {_root, _dirs, files} -> files end)
+        |> Enum.reduce_while({:ok, fs}, fn file, {:ok, acc_fs} ->
+          case unlink(acc_fs, file) do
+            {:ok, acc_fs} -> {:cont, {:ok, acc_fs}}
+            {:error, _} = error -> {:halt, error}
+          end
+        end)
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Recursively walks a directory tree.
+  """
+  @spec walk(term(), String.t()) ::
+          {:ok, [{String.t(), [String.t()], [String.t()]}]} | {:error, String.t()}
+  def walk(fs, path) do
+    if dir?(fs, path) do
+      {:ok, do_walk(fs, normalize_dir(path))}
+    else
+      {:error, "FileNotFoundError: [Errno 2] No such file or directory: '#{path}'"}
+    end
+  end
+
+  @doc """
+  Copies a single file.
+  """
+  @spec copyfile(term(), String.t(), String.t()) :: {:ok, term()} | {:error, String.t()}
+  def copyfile(fs, src, dest) do
+    with {:ok, content} <- fs.__struct__.read(fs, src),
+         {:ok, fs} <- mkdir_p(fs, dirname(dest)),
+         {:ok, fs} <- fs.__struct__.write(fs, dest, content, :write) do
+      {:ok, fs}
+    end
+  end
+
+  @doc """
+  Copies a directory tree.
+  """
+  @spec copytree(term(), String.t(), String.t()) :: {:ok, term()} | {:error, String.t()}
+  def copytree(fs, src, dest) do
+    with true <- dir?(fs, src),
+         {:ok, fs} <- mkdir_p(fs, dest),
+         {:ok, entries} <- walk(fs, src) do
+      Enum.reduce_while(entries, {:ok, fs}, fn {root, dirs, files}, {:ok, acc_fs} ->
+        rel_root = relative_from(src, root)
+        target_root = if rel_root == "", do: dest, else: join([dest, rel_root])
+
+        with {:ok, acc_fs} <- mkdir_p(acc_fs, target_root),
+             {:ok, acc_fs} <- ensure_dirs(acc_fs, target_root, dirs),
+             {:ok, acc_fs} <- copy_files(acc_fs, root, target_root, files) do
+          {:cont, {:ok, acc_fs}}
+        else
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+    else
+      false -> {:error, "FileNotFoundError: [Errno 2] No such file or directory: '#{src}'"}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Moves a file or directory tree.
+  """
+  @spec move(term(), String.t(), String.t()) :: {:ok, term()} | {:error, String.t()}
+  def move(fs, src, dest) do
+    cond do
+      file?(fs, src) ->
+        with {:ok, fs} <- copyfile(fs, src, dest),
+             {:ok, fs} <- unlink(fs, src) do
+          {:ok, fs}
+        end
+
+      dir?(fs, src) ->
+        with {:ok, fs} <- copytree(fs, src, dest),
+             {:ok, fs} <- delete_tree(fs, src) do
+          {:ok, fs}
+        end
+
+      true ->
+        {:error, "FileNotFoundError: [Errno 2] No such file or directory: '#{src}'"}
+    end
+  end
+
+  @doc """
+  Expands a glob pattern against the configured filesystem.
+  """
+  @spec glob(term(), String.t()) :: {:ok, [String.t()]}
+  def glob(fs, pattern) do
+    absolute? = String.starts_with?(pattern, "/")
+
+    segments =
+      pattern
+      |> String.trim_leading("/")
+      |> String.split("/", trim: true)
+
+    initial = if absolute?, do: "/", else: ""
+
+    {:ok, expand_glob(fs, [initial], segments)}
+  end
+
+  @doc """
+  Returns true when a single path segment contains glob metacharacters.
+  """
+  @spec wildcard?(String.t()) :: boolean()
+  def wildcard?(segment) do
+    String.contains?(segment, ["*", "?"])
+  end
+
+  @doc """
+  Returns true when a path segment matches a glob pattern.
+  """
+  @spec glob_match?(String.t(), String.t()) :: boolean()
+  def glob_match?(name, pattern) do
+    if String.starts_with?(name, ".") and not String.starts_with?(pattern, ".") do
+      false
+    else
+      escaped =
+        pattern
+        |> Regex.escape()
+        |> String.replace("\\*", "[^/]*")
+        |> String.replace("\\?", "[^/]")
+
+      Regex.match?(~r/\A#{escaped}\z/, name)
+    end
+  end
+
+  @spec splitext_basename(String.t()) :: {String.t(), String.t()}
+  defp splitext_basename(base) do
+    case last_dot_index(base) do
+      nil ->
+        {base, ""}
+
+      idx ->
+        if idx <= first_non_dot_index(base) do
+          {base, ""}
+        else
+          {
+            binary_part(base, 0, idx),
+            binary_part(base, idx, byte_size(base) - idx)
+          }
+        end
+    end
+  end
+
+  @spec last_dot_index(String.t()) :: non_neg_integer() | nil
+  defp last_dot_index(base) do
+    case :binary.matches(base, ".") do
+      [] -> nil
+      matches -> matches |> List.last() |> elem(0)
+    end
+  end
+
+  @spec first_non_dot_index(String.t()) :: non_neg_integer()
+  defp first_non_dot_index(base) do
+    base
+    |> String.to_charlist()
+    |> Enum.find_index(&(&1 != ?.))
+    |> Kernel.||(byte_size(base))
+  end
+
+  @spec expand_glob(term(), [String.t()], [String.t()]) :: [String.t()]
+  defp expand_glob(_fs, paths, []), do: paths |> Enum.reject(&(&1 == "")) |> Enum.uniq()
+
+  defp expand_glob(fs, paths, [segment | rest]) do
+    next_paths =
+      Enum.flat_map(paths, fn current ->
+        expand_segment(fs, current, segment, rest == [])
+      end)
+
+    expand_glob(fs, next_paths, rest)
+  end
+
+  @spec expand_segment(term(), String.t(), String.t(), boolean()) :: [String.t()]
+  defp expand_segment(fs, current, segment, final?) do
+    cond do
+      wildcard?(segment) ->
+        case fs.__struct__.list_dir(fs, current) do
+          {:ok, entries} ->
+            entries
+            |> Enum.filter(&glob_match?(&1, segment))
+            |> Enum.map(&join_glob_path(current, &1))
+            |> Enum.filter(fn path -> final? or dir?(fs, path) end)
+
+          {:error, _} ->
+            []
+        end
+
+      final? ->
+        path = join_glob_path(current, segment)
+        if fs.__struct__.exists?(fs, path), do: [path], else: []
+
+      true ->
+        path = join_glob_path(current, segment)
+        if dir?(fs, path), do: [path], else: []
+    end
+  end
+
+  @spec join_glob_path(String.t(), String.t()) :: String.t()
+  defp join_glob_path("", entry), do: entry
+  defp join_glob_path("/", entry), do: "/" <> entry
+  defp join_glob_path(current, entry), do: join([current, entry])
+
+  @spec normalize_dir(String.t()) :: String.t()
+  defp normalize_dir(""), do: ""
+  defp normalize_dir("/"), do: "/"
+  defp normalize_dir(path), do: String.trim_trailing(path, "/")
+
+  @spec do_walk(term(), String.t()) :: [{String.t(), [String.t()], [String.t()]}]
+  defp do_walk(fs, root) do
+    {:ok, entries} = list_dir(fs, root)
+
+    {dirs, files} =
+      Enum.reduce(entries, {[], []}, fn entry, {dirs, files} ->
+        full = join_glob_path(root, entry)
+
+        if dir?(fs, full) do
+          {[entry | dirs], files}
+        else
+          {dirs, [full | files]}
+        end
+      end)
+
+    dirs = Enum.sort(dirs)
+    files = Enum.sort(files)
+    [{root, dirs, files} | Enum.flat_map(dirs, &do_walk(fs, join_glob_path(root, &1)))]
+  end
+
+  @spec relative_from(String.t(), String.t()) :: String.t()
+  defp relative_from(src, root) do
+    src = normalize_dir(src)
+    root = normalize_dir(root)
+
+    cond do
+      root == src -> ""
+      String.starts_with?(root, src <> "/") -> String.replace_prefix(root, src <> "/", "")
+      true -> root
+    end
+  end
+
+  @spec ensure_dirs(term(), String.t(), [String.t()]) :: {:ok, term()} | {:error, String.t()}
+  defp ensure_dirs(fs, root, dirs) do
+    {:ok,
+     Enum.reduce(dirs, fs, fn dir, acc_fs ->
+       {:ok, acc_fs} = mkdir_p(acc_fs, join([root, dir]))
+       acc_fs
+     end)}
+  end
+
+  @spec copy_files(term(), String.t(), String.t(), [String.t()]) ::
+          {:ok, term()} | {:error, String.t()}
+  defp copy_files(fs, root, target_root, files) do
+    Enum.reduce_while(files, {:ok, fs}, fn src_file, {:ok, acc_fs} ->
+      file_name = basename(src_file)
+      src = if root in ["", "/"], do: src_file, else: src_file
+      dest = join([target_root, file_name])
+
+      case copyfile(acc_fs, src, dest) do
+        {:ok, acc_fs} -> {:cont, {:ok, acc_fs}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+end

--- a/lib/pyex/path.ex
+++ b/lib/pyex/path.ex
@@ -109,7 +109,7 @@ defmodule Pyex.Path do
   @doc """
   Creates a directory and any missing parents.
   """
-  @spec mkdir_p(term(), String.t()) :: {:ok, term()} | {:error, String.t()}
+  @spec mkdir_p(term(), String.t()) :: {:ok, term()}
   def mkdir_p(%Pyex.Filesystem.Memory{} = fs, path), do: Pyex.Filesystem.Memory.mkdir(fs, path)
   def mkdir_p(fs, _path), do: {:ok, fs}
 

--- a/lib/pyex/stdlib.ex
+++ b/lib/pyex/stdlib.ex
@@ -34,7 +34,14 @@ defmodule Pyex.Stdlib do
     "secrets" => Pyex.Stdlib.Secrets,
     "pandas" => Pyex.Stdlib.Pandas,
     "yaml" => Pyex.Stdlib.Yaml,
-    "decimal" => Pyex.Stdlib.DecimalModule
+    "decimal" => Pyex.Stdlib.DecimalModule,
+    "glob" => Pyex.Stdlib.Glob,
+    "pathlib" => Pyex.Stdlib.Pathlib,
+    "fnmatch" => Pyex.Stdlib.Fnmatch,
+    "urllib" => Pyex.Stdlib.Urllib,
+    "shutil" => Pyex.Stdlib.Shutil,
+    "dataclasses" => Pyex.Stdlib.Dataclasses,
+    "heapq" => Pyex.Stdlib.Heapq
   }
 
   @doc """

--- a/lib/pyex/stdlib/dataclasses.ex
+++ b/lib/pyex/stdlib/dataclasses.ex
@@ -1,0 +1,257 @@
+defmodule Pyex.Stdlib.Dataclasses do
+  @moduledoc """
+  Minimal `dataclasses` support for common structured-data workflows.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.{Builtins, PyDict}
+  alias Pyex.Interpreter
+
+  @field_marker "__dataclass_field__"
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "dataclass" => {:builtin_kw, &dataclass/2},
+      "field" => {:builtin_kw, &field/2},
+      "asdict" => {:builtin, &asdict/1},
+      "replace" => {:builtin_kw, &replace/2}
+    }
+  end
+
+  @spec dataclass([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          Interpreter.pyvalue()
+  defp dataclass([{:class, _, _, _} = class], kwargs), do: decorate_class(class, kwargs)
+
+  defp dataclass([], kwargs) do
+    {:builtin_kw, fn [class], _inner_kwargs -> decorate_class(class, kwargs) end}
+  end
+
+  defp dataclass(_args, _kwargs),
+    do: {:exception, "TypeError: dataclass decorator expects a class"}
+
+  @spec field([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          map() | {:exception, String.t()}
+  defp field(args, kwargs) do
+    cond do
+      args != [] ->
+        {:exception, "TypeError: field() does not accept positional arguments"}
+
+      Map.has_key?(kwargs, "default") and Map.has_key?(kwargs, "default_factory") ->
+        {:exception, "ValueError: cannot specify both default and default_factory"}
+
+      true ->
+        %{
+          @field_marker => true,
+          "default" => Map.get(kwargs, "default", :__missing__),
+          "default_factory" => Map.get(kwargs, "default_factory", :__missing__)
+        }
+    end
+  end
+
+  @spec asdict([Interpreter.pyvalue()]) :: map() | {:exception, String.t()}
+  defp asdict([{:instance, {:class, _, _, attrs}, inst_attrs}]) do
+    fields = Map.get(attrs, "__dataclass_fields__", [])
+    Map.new(fields, fn field -> {field, deep_asdict(Map.get(inst_attrs, field))} end)
+  end
+
+  defp asdict(_args), do: {:exception, "TypeError: asdict() expects a dataclass instance"}
+
+  @spec replace([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          Interpreter.pyvalue()
+  defp replace([{:instance, {:class, _, _, attrs} = class, inst_attrs}], kwargs) do
+    fields = Map.get(attrs, "__dataclass_fields__", [])
+    allowed = MapSet.new(fields)
+
+    case Enum.find(Map.keys(kwargs), fn key -> not MapSet.member?(allowed, key) end) do
+      nil -> {:instance, class, Map.merge(inst_attrs, kwargs)}
+      key -> {:exception, "TypeError: replace() got an unexpected field '#{key}'"}
+    end
+  end
+
+  defp replace(_args, _kwargs),
+    do: {:exception, "TypeError: replace() expects a dataclass instance"}
+
+  @spec decorate_class(Interpreter.pyvalue(), %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          Interpreter.pyvalue()
+  defp decorate_class({:class, name, bases, class_attrs}, _kwargs) do
+    field_names =
+      case Map.get(class_attrs, "__annotations_order__") do
+        names when is_list(names) -> names
+        _ -> class_attrs |> Map.get("__annotations__", %{}) |> Map.keys()
+      end
+
+    defaults =
+      Enum.reduce(field_names, %{}, fn field, acc ->
+        case Map.get(class_attrs, field, :__missing__) do
+          :__missing__ -> acc
+          value -> Map.put(acc, field, value)
+        end
+      end)
+
+    generated = %{
+      "__dataclass_fields__" => field_names,
+      "__dataclass_defaults__" => defaults,
+      "__init__" => {:builtin_kw, &dataclass_init/2},
+      "__repr__" => {:builtin, &dataclass_repr/1},
+      "__eq__" => {:builtin, &dataclass_eq/1}
+    }
+
+    {:class, name, bases, Map.merge(class_attrs, generated)}
+  end
+
+  @spec dataclass_init([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          Interpreter.pyvalue()
+  defp dataclass_init(
+         [{:instance, {:class, _, _, attrs} = class, _old_attrs} | args],
+         kwargs
+       ) do
+    field_names = Map.get(attrs, "__dataclass_fields__", [])
+    defaults = Map.get(attrs, "__dataclass_defaults__", %{})
+
+    cond do
+      length(args) > length(field_names) ->
+        {:exception, "TypeError: too many positional arguments for dataclass __init__"}
+
+      true ->
+        positional = Enum.zip(Enum.take(field_names, length(args)), args) |> Map.new()
+
+        case duplicate_keyword(field_names, positional, kwargs) do
+          nil ->
+            case unknown_keyword(field_names, kwargs) do
+              nil ->
+                case build_dataclass_attrs(field_names, defaults, positional, kwargs) do
+                  {:ok, values} -> {:instance, class, values}
+                  {:error, msg} -> {:exception, msg}
+                end
+
+              key ->
+                {:exception, "TypeError: got an unexpected keyword argument '#{key}'"}
+            end
+
+          key ->
+            {:exception, "TypeError: got multiple values for argument '#{key}'"}
+        end
+    end
+  end
+
+  defp dataclass_init(_args, _kwargs),
+    do: {:exception, "TypeError: invalid dataclass initialization"}
+
+  @spec dataclass_repr([Interpreter.pyvalue()]) :: String.t() | {:exception, String.t()}
+  defp dataclass_repr([{:instance, {:class, name, _, attrs}, inst_attrs}]) do
+    fields = Map.get(attrs, "__dataclass_fields__", [])
+
+    rendered =
+      fields
+      |> Enum.map(fn field -> "#{field}=#{render_repr(Map.get(inst_attrs, field))}" end)
+      |> Enum.join(", ")
+
+    "#{name}(#{rendered})"
+  end
+
+  defp dataclass_repr(_args), do: {:exception, "TypeError: repr() expects a dataclass instance"}
+
+  @spec dataclass_eq([Interpreter.pyvalue()]) :: boolean() | {:exception, String.t()}
+  defp dataclass_eq([
+         {:instance, {:class, name, _, attrs}, left},
+         {:instance, {:class, other, _, _}, right}
+       ]) do
+    if name == other do
+      Enum.all?(Map.get(attrs, "__dataclass_fields__", []), fn field ->
+        Map.get(left, field) == Map.get(right, field)
+      end)
+    else
+      false
+    end
+  end
+
+  defp dataclass_eq([_left, _right]), do: false
+
+  @spec build_dataclass_attrs([String.t()], map(), map(), map()) ::
+          {:ok, map()} | {:error, String.t()}
+  defp build_dataclass_attrs(field_names, defaults, positional, kwargs) do
+    Enum.reduce_while(field_names, {:ok, %{}}, fn field, {:ok, acc} ->
+      cond do
+        Map.has_key?(positional, field) ->
+          {:cont, {:ok, Map.put(acc, field, Map.fetch!(positional, field))}}
+
+        Map.has_key?(kwargs, field) ->
+          {:cont, {:ok, Map.put(acc, field, Map.fetch!(kwargs, field))}}
+
+        Map.has_key?(defaults, field) ->
+          {:cont, {:ok, Map.put(acc, field, resolve_default(Map.fetch!(defaults, field)))}}
+
+        true ->
+          {:halt, {:error, "TypeError: missing required argument '#{field}'"}}
+      end
+    end)
+  end
+
+  @spec resolve_default(Interpreter.pyvalue()) :: Interpreter.pyvalue()
+  defp resolve_default(%{@field_marker => true, "default_factory" => factory})
+       when factory != :__missing__ do
+    run_default_factory(factory)
+  end
+
+  defp resolve_default(%{@field_marker => true, "default" => default})
+       when default != :__missing__, do: default
+
+  defp resolve_default(value), do: value
+
+  @spec run_default_factory(Interpreter.pyvalue()) :: Interpreter.pyvalue()
+  defp run_default_factory({:builtin_type, _, fun}), do: fun.([])
+  defp run_default_factory({:builtin, fun}), do: fun.([])
+
+  defp run_default_factory({:py_dict, _, _} = dict),
+    do: PyDict.from_map(Builtins.visible_dict(dict))
+
+  defp run_default_factory(map) when is_map(map), do: Map.new(map)
+  defp run_default_factory(list) when is_list(list), do: Enum.map(list, & &1)
+  defp run_default_factory(other), do: other
+
+  @spec duplicate_keyword([String.t()], map(), map()) :: String.t() | nil
+  defp duplicate_keyword(field_names, positional, kwargs) do
+    Enum.find(field_names, fn field ->
+      Map.has_key?(positional, field) and Map.has_key?(kwargs, field)
+    end)
+  end
+
+  @spec unknown_keyword([String.t()], map()) :: String.t() | nil
+  defp unknown_keyword(field_names, kwargs) do
+    allowed = MapSet.new(field_names)
+    Enum.find(Map.keys(kwargs), fn key -> not MapSet.member?(allowed, key) end)
+  end
+
+  @spec deep_asdict(Interpreter.pyvalue()) :: Interpreter.pyvalue()
+  defp deep_asdict({:instance, {:class, _, _, attrs}, inst_attrs}) do
+    case Map.get(attrs, "__dataclass_fields__") do
+      fields when is_list(fields) ->
+        Map.new(fields, fn field -> {field, deep_asdict(Map.get(inst_attrs, field))} end)
+
+      _ ->
+        inst_attrs
+    end
+  end
+
+  defp deep_asdict({:py_dict, _, _} = dict) do
+    dict
+    |> Builtins.visible_dict()
+    |> Map.new(fn {k, v} -> {k, deep_asdict(v)} end)
+  end
+
+  defp deep_asdict(map) when is_map(map), do: Map.new(map, fn {k, v} -> {k, deep_asdict(v)} end)
+  defp deep_asdict(list) when is_list(list), do: Enum.map(list, &deep_asdict/1)
+  defp deep_asdict({:tuple, items}), do: {:tuple, Enum.map(items, &deep_asdict/1)}
+  defp deep_asdict(other), do: other
+
+  @spec render_repr(Interpreter.pyvalue()) :: String.t()
+  defp render_repr(value) when is_binary(value) do
+    escaped = value |> String.replace("\\", "\\\\") |> String.replace("'", "\\'")
+    "'" <> escaped <> "'"
+  end
+
+  defp render_repr(value), do: Builtins.py_repr(value)
+end

--- a/lib/pyex/stdlib/fnmatch.ex
+++ b/lib/pyex/stdlib/fnmatch.ex
@@ -1,0 +1,52 @@
+defmodule Pyex.Stdlib.Fnmatch do
+  @moduledoc """
+  Minimal `fnmatch` support.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.Interpreter
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "fnmatch" => {:builtin, &fnmatch/1},
+      "fnmatchcase" => {:builtin, &fnmatchcase/1},
+      "filter" => {:builtin, &filter/1}
+    }
+  end
+
+  @spec fnmatch([Interpreter.pyvalue()]) :: boolean() | {:exception, String.t()}
+  defp fnmatch([name, pattern]) when is_binary(name) and is_binary(pattern) do
+    glob_match(String.downcase(name), String.downcase(pattern))
+  end
+
+  defp fnmatch(_args), do: {:exception, "TypeError: fnmatch() expects (name, pat) strings"}
+
+  @spec fnmatchcase([Interpreter.pyvalue()]) :: boolean() | {:exception, String.t()}
+  defp fnmatchcase([name, pattern]) when is_binary(name) and is_binary(pattern) do
+    glob_match(name, pattern)
+  end
+
+  defp fnmatchcase(_args),
+    do: {:exception, "TypeError: fnmatchcase() expects (name, pat) strings"}
+
+  @spec filter([Interpreter.pyvalue()]) :: [String.t()] | {:exception, String.t()}
+  defp filter([names, pattern]) when is_list(names) and is_binary(pattern) do
+    Enum.filter(names, &(is_binary(&1) and glob_match(&1, pattern)))
+  end
+
+  defp filter([{:py_list, reversed, _}, pattern]) when is_binary(pattern) do
+    reversed
+    |> Enum.reverse()
+    |> Enum.filter(&(is_binary(&1) and glob_match(&1, pattern)))
+  end
+
+  defp filter(_args), do: {:exception, "TypeError: filter() expects (names, pat)"}
+
+  @spec glob_match(String.t(), String.t()) :: boolean()
+  defp glob_match(name, pattern) do
+    Pyex.Path.glob_match?(name, pattern)
+  end
+end

--- a/lib/pyex/stdlib/glob.ex
+++ b/lib/pyex/stdlib/glob.ex
@@ -1,0 +1,44 @@
+defmodule Pyex.Stdlib.Glob do
+  @moduledoc """
+  Minimal `glob` module support for filesystem-backed sandboxes.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.{Ctx, Env, Interpreter}
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "glob" => {:builtin, &glob/1}
+    }
+  end
+
+  @spec glob([Interpreter.pyvalue()]) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})}
+          | {:exception, String.t()}
+  defp glob([pattern]) do
+    case Pyex.Path.coerce(pattern) do
+      {:ok, pattern} ->
+        {:ctx_call,
+         fn env, ctx ->
+           case ctx.filesystem do
+             nil ->
+               {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+             fs ->
+               {:ok, matches} = Pyex.Path.glob(fs, pattern)
+               {matches, env, ctx}
+           end
+         end}
+
+      :error ->
+        {:exception, "TypeError: glob() pathname must be str or PathLike"}
+    end
+  end
+
+  defp glob(_args) do
+    {:exception, "TypeError: glob() takes exactly 1 argument"}
+  end
+end

--- a/lib/pyex/stdlib/heapq.ex
+++ b/lib/pyex/stdlib/heapq.ex
@@ -1,0 +1,166 @@
+defmodule Pyex.Stdlib.Heapq do
+  @moduledoc """
+  Minimal `heapq` support for interview-style min-heap workflows.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.Interpreter
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "heapify" => {:builtin, &heapify/1},
+      "heappush" => {:builtin, &heappush/1},
+      "heappop" => {:builtin, &heappop/1},
+      "heapreplace" => {:builtin, &heapreplace/1}
+    }
+  end
+
+  @spec heapify([Interpreter.pyvalue()]) :: term()
+  defp heapify([heap]) do
+    with {:ok, items, wrap} <- heap_parts(heap) do
+      {:mutate_arg, 0, wrap.(build_heap(items)), nil}
+    end
+  end
+
+  defp heapify(_args), do: {:exception, "TypeError: heapify() takes exactly 1 argument"}
+
+  @spec heappush([Interpreter.pyvalue()]) :: term()
+  defp heappush([heap, item]) do
+    with {:ok, items, wrap} <- heap_parts(heap) do
+      {:mutate_arg, 0, wrap.(sift_up(items ++ [item])), nil}
+    end
+  end
+
+  defp heappush(_args), do: {:exception, "TypeError: heappush() takes exactly 2 arguments"}
+
+  @spec heappop([Interpreter.pyvalue()]) :: term()
+  defp heappop([heap]) do
+    with {:ok, items, wrap} <- heap_parts(heap) do
+      case items do
+        [] ->
+          {:exception, "IndexError: index out of range"}
+
+        [item] ->
+          {:mutate_arg, 0, wrap.([]), item}
+
+        _ ->
+          [root | rest] = items
+          last = List.last(rest)
+          rest = List.delete_at(rest, length(rest) - 1)
+          new_heap = sift_down([last | rest], 0)
+          {:mutate_arg, 0, wrap.(new_heap), root}
+      end
+    end
+  end
+
+  defp heappop(_args), do: {:exception, "TypeError: heappop() takes exactly 1 argument"}
+
+  @spec heapreplace([Interpreter.pyvalue()]) :: term()
+  defp heapreplace([heap, item]) do
+    with {:ok, items, wrap} <- heap_parts(heap) do
+      case items do
+        [] ->
+          {:exception, "IndexError: index out of range"}
+
+        [_root | rest] ->
+          root = hd(items)
+          new_heap = sift_down([item | rest], 0)
+          {:mutate_arg, 0, wrap.(new_heap), root}
+      end
+    end
+  end
+
+  defp heapreplace(_args), do: {:exception, "TypeError: heapreplace() takes exactly 2 arguments"}
+
+  @spec heap_parts(Interpreter.pyvalue()) ::
+          {:ok, [Interpreter.pyvalue()], ([Interpreter.pyvalue()] -> Interpreter.pyvalue())}
+          | {:exception, String.t()}
+  defp heap_parts({:py_list, reversed, _len}) do
+    {:ok, Enum.reverse(reversed), fn items -> {:py_list, Enum.reverse(items), len_for(items)} end}
+  end
+
+  defp heap_parts(list) when is_list(list) do
+    {:ok, list, &Function.identity/1}
+  end
+
+  defp heap_parts(_other), do: {:exception, "TypeError: heap argument must be list"}
+
+  @spec len_for([Interpreter.pyvalue()]) :: non_neg_integer()
+  defp len_for(items), do: length(items)
+
+  @spec build_heap([Interpreter.pyvalue()]) :: [Interpreter.pyvalue()]
+  defp build_heap([]), do: []
+  defp build_heap([item]), do: [item]
+
+  defp build_heap(items) do
+    start = div(length(items), 2) - 1
+    Enum.reduce(start..0, items, fn idx, acc -> sift_down(acc, idx) end)
+  end
+
+  @spec sift_up([Interpreter.pyvalue()]) :: [Interpreter.pyvalue()]
+  defp sift_up(items) do
+    do_sift_up(items, length(items) - 1)
+  end
+
+  @spec do_sift_up([Interpreter.pyvalue()], integer()) :: [Interpreter.pyvalue()]
+  defp do_sift_up(items, idx) when idx <= 0, do: items
+
+  defp do_sift_up(items, idx) do
+    parent = div(idx - 1, 2)
+
+    if Enum.at(items, idx) < Enum.at(items, parent) do
+      items
+      |> swap(idx, parent)
+      |> do_sift_up(parent)
+    else
+      items
+    end
+  end
+
+  @spec sift_down([Interpreter.pyvalue()], non_neg_integer()) :: [Interpreter.pyvalue()]
+  defp sift_down(items, idx) do
+    left = idx * 2 + 1
+    right = idx * 2 + 2
+    len = length(items)
+
+    smallest =
+      idx
+      |> smaller_child(items, left, len)
+      |> smaller_child(items, right, len)
+
+    if smallest != idx do
+      items
+      |> swap(idx, smallest)
+      |> sift_down(smallest)
+    else
+      items
+    end
+  end
+
+  @spec smaller_child(
+          non_neg_integer(),
+          [Interpreter.pyvalue()],
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: non_neg_integer()
+  defp smaller_child(current, items, child, len) when child < len do
+    if Enum.at(items, child) < Enum.at(items, current), do: child, else: current
+  end
+
+  defp smaller_child(current, _items, _child, _len), do: current
+
+  @spec swap([Interpreter.pyvalue()], non_neg_integer(), non_neg_integer()) :: [
+          Interpreter.pyvalue()
+        ]
+  defp swap(items, a, b) do
+    va = Enum.at(items, a)
+    vb = Enum.at(items, b)
+
+    items
+    |> List.replace_at(a, vb)
+    |> List.replace_at(b, va)
+  end
+end

--- a/lib/pyex/stdlib/pathlib.ex
+++ b/lib/pyex/stdlib/pathlib.ex
@@ -1,0 +1,415 @@
+defmodule Pyex.Stdlib.Pathlib do
+  @moduledoc """
+  Minimal `pathlib` support for sandboxed filesystem workflows.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.{Ctx, Env, Interpreter}
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "Path" => path_class()
+    }
+  end
+
+  @spec path_class() ::
+          {:class, String.t(), [Interpreter.pyvalue()],
+           %{optional(String.t()) => Interpreter.pyvalue()}}
+  defp path_class do
+    {:class, "Path", [],
+     %{
+       "__init__" => {:builtin_kw, &path_init/2},
+       "__str__" => {:builtin, fn [self] -> path_string(self) end},
+       "__repr__" => {:builtin, fn [self] -> "Path(#{inspect(path_string(self))})" end},
+       "__fspath__" => {:builtin, fn [self] -> path_string(self) end},
+       "__truediv__" => {:builtin, fn [self, other] -> path_div(self, other) end},
+       "exists" => {:builtin_kw, &path_exists/2},
+       "is_file" => {:builtin_kw, &path_is_file/2},
+       "is_dir" => {:builtin_kw, &path_is_dir/2},
+       "mkdir" => {:builtin_kw, &path_mkdir/2},
+       "iterdir" => {:builtin_kw, &path_iterdir/2},
+       "unlink" => {:builtin_kw, &path_unlink/2},
+       "with_suffix" => {:builtin_kw, &path_with_suffix/2},
+       "with_name" => {:builtin_kw, &path_with_name/2},
+       "read_text" => {:builtin_kw, &path_read_text/2},
+       "write_text" => {:builtin_kw, &path_write_text/2},
+       "glob" => {:builtin_kw, &path_glob/2}
+     }}
+  end
+
+  @spec path_init([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          Interpreter.pyvalue()
+  defp path_init([instance | parts], kwargs) do
+    cond do
+      kwargs != %{} ->
+        {:exception, "TypeError: Path() does not accept keyword arguments"}
+
+      true ->
+        case coerce_parts(parts) do
+          {:ok, []} -> path_instance(instance, ".")
+          {:ok, coerced} -> path_instance(instance, Pyex.Path.join(coerced))
+          {:error, msg} -> {:exception, msg}
+        end
+    end
+  end
+
+  @spec path_div(Interpreter.pyvalue(), Interpreter.pyvalue()) :: Interpreter.pyvalue()
+  defp path_div(self, other) do
+    with {:ok, left} <- Pyex.Path.coerce(self),
+         {:ok, right} <- Pyex.Path.coerce(other) do
+      path_instance(self, Pyex.Path.join([left, right]))
+    else
+      :error -> {:exception, "TypeError: unsupported operand type(s) for /"}
+    end
+  end
+
+  @spec path_read_text([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_read_text([self], kwargs) do
+    with :ok <- no_kwargs("read_text", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil ->
+             {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+           _ ->
+             case Ctx.open_handle(ctx, path, :read) do
+               {:ok, id, ctx} ->
+                 case Ctx.read_handle(ctx, id) do
+                   {:ok, content, ctx} ->
+                     case Ctx.close_handle(ctx, id) do
+                       {:ok, ctx} -> {content, env, ctx}
+                       {:error, _} -> {content, env, ctx}
+                     end
+
+                   {:error, msg} ->
+                     {{:exception, msg}, env, ctx}
+                 end
+
+               {:error, msg} ->
+                 {{:exception, msg}, env, ctx}
+             end
+         end
+       end}
+    end
+  end
+
+  defp path_read_text(_args, _kwargs) do
+    {:exception, "TypeError: Path.read_text() takes no positional arguments"}
+  end
+
+  @spec path_write_text([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_write_text([self, data], kwargs) when is_binary(data) do
+    with :ok <- no_kwargs("write_text", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil ->
+             {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+           _ ->
+             case Ctx.open_handle(ctx, path, :write) do
+               {:ok, id, ctx} ->
+                 case Ctx.write_handle(ctx, id, data) do
+                   {:ok, ctx} ->
+                     case Ctx.close_handle(ctx, id) do
+                       {:ok, ctx} -> {byte_size(data), env, ctx}
+                       {:error, _} -> {byte_size(data), env, ctx}
+                     end
+
+                   {:error, msg} ->
+                     {{:exception, msg}, env, ctx}
+                 end
+
+               {:error, msg} ->
+                 {{:exception, msg}, env, ctx}
+             end
+         end
+       end}
+    end
+  end
+
+  defp path_write_text([_self, _data], _kwargs) do
+    {:exception, "TypeError: Path.write_text() argument must be str"}
+  end
+
+  defp path_write_text(_args, _kwargs) do
+    {:exception, "TypeError: Path.write_text() takes exactly 1 positional argument"}
+  end
+
+  @spec path_glob([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_glob([self, pattern], kwargs) when is_binary(pattern) do
+    with :ok <- no_kwargs("glob", kwargs),
+         {:ok, base} <- coerce_path(self) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil ->
+             {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+           fs ->
+             pattern = Pyex.Path.join([base, pattern])
+             {:ok, matches} = Pyex.Path.glob(fs, pattern)
+             {Enum.map(matches, &path_instance(self, &1)), env, ctx}
+         end
+       end}
+    end
+  end
+
+  defp path_glob([_self, _pattern], _kwargs) do
+    {:exception, "TypeError: Path.glob() pattern must be str"}
+  end
+
+  defp path_glob(_args, _kwargs) do
+    {:exception, "TypeError: Path.glob() takes exactly 1 argument"}
+  end
+
+  @spec path_exists([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_exists([self], kwargs) do
+    with :ok <- no_kwargs("exists", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil -> {false, env, ctx}
+           fs -> {Pyex.Path.exists?(fs, path), env, ctx}
+         end
+       end}
+    end
+  end
+
+  @spec path_is_file([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_is_file([self], kwargs) do
+    with :ok <- no_kwargs("is_file", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil -> {false, env, ctx}
+           fs -> {Pyex.Path.file?(fs, path), env, ctx}
+         end
+       end}
+    end
+  end
+
+  @spec path_is_dir([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_is_dir([self], kwargs) do
+    with :ok <- no_kwargs("is_dir", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil -> {false, env, ctx}
+           fs -> {Pyex.Path.dir?(fs, path), env, ctx}
+         end
+       end}
+    end
+  end
+
+  @spec path_mkdir([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_mkdir([self], kwargs) do
+    with {:ok, path} <- coerce_path(self),
+         :ok <- validate_mkdir_kwargs(kwargs) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil ->
+             {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+           fs ->
+             case Pyex.Path.mkdir_p(fs, path) do
+               {:ok, fs} -> {nil, env, %{ctx | filesystem: fs}}
+               {:error, msg} -> {{:exception, msg}, env, ctx}
+             end
+         end
+       end}
+    end
+  end
+
+  defp path_mkdir(_args, _kwargs) do
+    {:exception, "TypeError: Path.mkdir() takes no positional arguments"}
+  end
+
+  @spec path_iterdir([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_iterdir([self], kwargs) do
+    with :ok <- no_kwargs("iterdir", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil ->
+             {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+           fs ->
+             case Pyex.Path.list_dir(fs, path) do
+               {:ok, entries} ->
+                 children = Enum.map(entries, &path_instance(self, Pyex.Path.join([path, &1])))
+                 {token, ctx} = Ctx.new_iterator(ctx, children)
+                 {token, env, ctx}
+
+               {:error, msg} ->
+                 {{:exception, msg}, env, ctx}
+             end
+         end
+       end}
+    end
+  end
+
+  @spec path_unlink([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp path_unlink([self], kwargs) do
+    with :ok <- no_kwargs("unlink", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      {:ctx_call,
+       fn env, ctx ->
+         case ctx.filesystem do
+           nil ->
+             {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+           fs ->
+             case Pyex.Path.unlink(fs, path) do
+               {:ok, fs} -> {nil, env, %{ctx | filesystem: fs}}
+               {:error, msg} -> {{:exception, msg}, env, ctx}
+             end
+         end
+       end}
+    end
+  end
+
+  @spec path_with_suffix([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          Interpreter.pyvalue()
+  defp path_with_suffix([self, suffix], kwargs) when is_binary(suffix) do
+    with :ok <- no_kwargs("with_suffix", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      {root, _old} = Pyex.Path.splitext(path)
+      path_instance(self, root <> suffix)
+    end
+  end
+
+  defp path_with_suffix([_self, _suffix], _kwargs),
+    do: {:exception, "TypeError: suffix must be str"}
+
+  defp path_with_suffix(_args, _kwargs),
+    do: {:exception, "TypeError: Path.with_suffix() takes exactly 1 argument"}
+
+  @spec path_with_name([Interpreter.pyvalue()], %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          Interpreter.pyvalue()
+  defp path_with_name([self, name], kwargs) when is_binary(name) do
+    with :ok <- no_kwargs("with_name", kwargs),
+         {:ok, path} <- coerce_path(self) do
+      path_instance(self, Pyex.Path.join([Pyex.Path.dirname(path), name]))
+    end
+  end
+
+  defp path_with_name([_self, _name], _kwargs), do: {:exception, "TypeError: name must be str"}
+
+  defp path_with_name(_args, _kwargs),
+    do: {:exception, "TypeError: Path.with_name() takes exactly 1 argument"}
+
+  @spec no_kwargs(String.t(), %{optional(String.t()) => Interpreter.pyvalue()}) ::
+          :ok | {:exception, String.t()}
+  defp no_kwargs(name, kwargs) do
+    case Map.keys(kwargs) do
+      [] ->
+        :ok
+
+      [key | _] ->
+        {:exception, "TypeError: Path.#{name}() got an unexpected keyword argument '#{key}'"}
+    end
+  end
+
+  @spec validate_mkdir_kwargs(%{optional(String.t()) => Interpreter.pyvalue()}) ::
+          :ok | {:exception, String.t()}
+  defp validate_mkdir_kwargs(kwargs) do
+    case Map.keys(kwargs) -- ["parents", "exist_ok"] do
+      [] ->
+        :ok
+
+      [key | _] ->
+        {:exception, "TypeError: Path.mkdir() got an unexpected keyword argument '#{key}'"}
+    end
+  end
+
+  @spec coerce_parts([Interpreter.pyvalue()]) :: {:ok, [String.t()]} | {:error, String.t()}
+  defp coerce_parts(parts) do
+    Enum.reduce_while(parts, {:ok, []}, fn part, {:ok, acc} ->
+      case Pyex.Path.coerce(part) do
+        {:ok, part} -> {:cont, {:ok, [part | acc]}}
+        :error -> {:halt, {:error, "TypeError: expected str or PathLike object"}}
+      end
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, Enum.reverse(acc)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @spec coerce_path(Interpreter.pyvalue()) :: {:ok, String.t()} | {:exception, String.t()}
+  defp coerce_path(value) do
+    case Pyex.Path.coerce(value) do
+      {:ok, path} -> {:ok, path}
+      :error -> {:exception, "TypeError: expected str or PathLike object"}
+    end
+  end
+
+  @spec path_string(Interpreter.pyvalue()) :: String.t()
+  defp path_string({:instance, {:class, "Path", _, _}, %{"__path__" => path}}), do: path
+
+  @spec path_instance(Interpreter.pyvalue(), String.t()) :: Interpreter.pyvalue()
+  defp path_instance({:instance, {:class, "Path", _, _} = class, _}, path) do
+    {:instance, class,
+     %{
+       "__path__" => path,
+       "name" => Pyex.Path.basename(path),
+       "stem" => Pyex.Path.stem(path),
+       "suffix" => Pyex.Path.suffix(path),
+       "parent" => basic_path_instance(class, parent_path(path))
+     }}
+  end
+
+  defp path_instance(_class_or_instance, path) do
+    class = path_class()
+
+    {:instance, class,
+     %{
+       "__path__" => path,
+       "name" => Pyex.Path.basename(path),
+       "stem" => Pyex.Path.stem(path),
+       "suffix" => Pyex.Path.suffix(path),
+       "parent" => basic_path_instance(class, parent_path(path))
+     }}
+  end
+
+  @spec basic_path_instance(Interpreter.pyvalue(), String.t()) :: Interpreter.pyvalue()
+  defp basic_path_instance(class, path) do
+    {:instance, class,
+     %{
+       "__path__" => path,
+       "name" => Pyex.Path.basename(path),
+       "stem" => Pyex.Path.stem(path),
+       "suffix" => Pyex.Path.suffix(path)
+     }}
+  end
+
+  @spec parent_path(String.t()) :: String.t()
+  defp parent_path("/"), do: "/"
+  defp parent_path("."), do: "."
+
+  defp parent_path(path) do
+    parent = Pyex.Path.dirname(path)
+    if parent == "", do: ".", else: parent
+  end
+end

--- a/lib/pyex/stdlib/pathlib.ex
+++ b/lib/pyex/stdlib/pathlib.ex
@@ -229,10 +229,8 @@ defmodule Pyex.Stdlib.Pathlib do
              {{:exception, "OSError: no filesystem configured"}, env, ctx}
 
            fs ->
-             case Pyex.Path.mkdir_p(fs, path) do
-               {:ok, fs} -> {nil, env, %{ctx | filesystem: fs}}
-               {:error, msg} -> {{:exception, msg}, env, ctx}
-             end
+             {:ok, fs} = Pyex.Path.mkdir_p(fs, path)
+             {nil, env, %{ctx | filesystem: fs}}
          end
        end}
     end

--- a/lib/pyex/stdlib/shutil.ex
+++ b/lib/pyex/stdlib/shutil.ex
@@ -1,0 +1,86 @@
+defmodule Pyex.Stdlib.Shutil do
+  @moduledoc """
+  Minimal `shutil` support for filesystem-backed sandboxes.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.{Ctx, Env, Interpreter}
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "copyfile" => {:builtin, &copyfile/1},
+      "copytree" => {:builtin, &copytree/1},
+      "rmtree" => {:builtin, &rmtree/1},
+      "move" => {:builtin, &move/1}
+    }
+  end
+
+  @spec copyfile([Interpreter.pyvalue()]) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp copyfile([src, dest]) do
+    with {:ok, src} <- coerce(src), {:ok, dest} <- coerce(dest) do
+      ctx_fs_call(fn fs -> Pyex.Path.copyfile(fs, src, dest) end, dest)
+    end
+  end
+
+  defp copyfile(_args), do: {:exception, "TypeError: copyfile() expects src and dst"}
+
+  @spec copytree([Interpreter.pyvalue()]) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp copytree([src, dest]) do
+    with {:ok, src} <- coerce(src), {:ok, dest} <- coerce(dest) do
+      ctx_fs_call(fn fs -> Pyex.Path.copytree(fs, src, dest) end, dest)
+    end
+  end
+
+  defp copytree(_args), do: {:exception, "TypeError: copytree() expects src and dst"}
+
+  @spec rmtree([Interpreter.pyvalue()]) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp rmtree([path]) do
+    with {:ok, path} <- coerce(path) do
+      ctx_fs_call(fn fs -> Pyex.Path.delete_tree(fs, path) end, nil)
+    end
+  end
+
+  defp rmtree(_args), do: {:exception, "TypeError: rmtree() expects a path"}
+
+  @spec move([Interpreter.pyvalue()]) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})} | {:exception, String.t()}
+  defp move([src, dest]) do
+    with {:ok, src} <- coerce(src), {:ok, dest} <- coerce(dest) do
+      ctx_fs_call(fn fs -> Pyex.Path.move(fs, src, dest) end, dest)
+    end
+  end
+
+  defp move(_args), do: {:exception, "TypeError: move() expects src and dst"}
+
+  @spec coerce(Interpreter.pyvalue()) :: {:ok, String.t()} | {:exception, String.t()}
+  defp coerce(value) do
+    case Pyex.Path.coerce(value) do
+      {:ok, path} -> {:ok, path}
+      :error -> {:exception, "TypeError: expected str or PathLike object"}
+    end
+  end
+
+  @spec ctx_fs_call((term() -> {:ok, term()} | {:error, String.t()}), String.t() | nil) ::
+          {:ctx_call, (Env.t(), Ctx.t() -> {term(), Env.t(), Ctx.t()})}
+  defp ctx_fs_call(fun, return_path) do
+    {:ctx_call,
+     fn env, ctx ->
+       case ctx.filesystem do
+         nil ->
+           {{:exception, "OSError: no filesystem configured"}, env, ctx}
+
+         fs ->
+           case fun.(fs) do
+             {:ok, fs} -> {return_path, env, %{ctx | filesystem: fs}}
+             {:error, msg} -> {{:exception, msg}, env, ctx}
+           end
+       end
+     end}
+  end
+end

--- a/lib/pyex/stdlib/urllib.ex
+++ b/lib/pyex/stdlib/urllib.ex
@@ -1,0 +1,69 @@
+defmodule Pyex.Stdlib.Urllib do
+  @moduledoc """
+  Minimal `urllib.parse` support.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.Interpreter
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "parse" => %{
+        "urljoin" => {:builtin, &urljoin/1},
+        "quote" => {:builtin, &url_quote/1},
+        "unquote" => {:builtin, &url_unquote/1},
+        "urlparse" => {:builtin, &urlparse/1},
+        "urlencode" => {:builtin, &urlencode/1}
+      }
+    }
+  end
+
+  @spec urljoin([Interpreter.pyvalue()]) :: String.t() | {:exception, String.t()}
+  defp urljoin([base, url]) when is_binary(base) and is_binary(url),
+    do: URI.merge(base, url) |> to_string()
+
+  defp urljoin(_args), do: {:exception, "TypeError: urljoin() expects (base, url) strings"}
+
+  @spec url_quote([Interpreter.pyvalue()]) :: String.t() | {:exception, String.t()}
+  defp url_quote([value]) when is_binary(value), do: URI.encode(value, &URI.char_unreserved?/1)
+  defp url_quote(_args), do: {:exception, "TypeError: quote() expects a string"}
+
+  @spec url_unquote([Interpreter.pyvalue()]) :: String.t() | {:exception, String.t()}
+  defp url_unquote([value]) when is_binary(value), do: URI.decode(value)
+  defp url_unquote(_args), do: {:exception, "TypeError: unquote() expects a string"}
+
+  @spec urlparse([Interpreter.pyvalue()]) :: Interpreter.pyvalue() | {:exception, String.t()}
+  defp urlparse([value]) when is_binary(value) do
+    uri = URI.parse(value)
+
+    {:tuple,
+     [
+       uri.scheme || "",
+       uri.authority || "",
+       uri.path || "",
+       uri.query || "",
+       uri.fragment || ""
+     ]}
+  end
+
+  defp urlparse(_args), do: {:exception, "TypeError: urlparse() expects a string"}
+
+  @spec urlencode([Interpreter.pyvalue()]) :: String.t() | {:exception, String.t()}
+  defp urlencode([{:py_dict, _, _} = dict]) do
+    dict
+    |> Pyex.PyDict.items()
+    |> Map.new()
+    |> URI.encode_query()
+  end
+
+  defp urlencode([map]) when is_map(map) do
+    map
+    |> Pyex.Builtins.visible_dict()
+    |> URI.encode_query()
+  end
+
+  defp urlencode(_args), do: {:exception, "TypeError: urlencode() expects a mapping"}
+end

--- a/lib/pyex/stdlib/urllib.ex
+++ b/lib/pyex/stdlib/urllib.ex
@@ -41,11 +41,11 @@ defmodule Pyex.Stdlib.Urllib do
 
     {:tuple,
      [
-       uri.scheme || "",
-       uri.authority || "",
-       uri.path || "",
-       uri.query || "",
-       uri.fragment || ""
+       uri_part(uri.scheme),
+       uri_part(uri.authority),
+       uri_part(uri.path),
+       uri_part(uri.query),
+       uri_part(uri.fragment)
      ]}
   end
 
@@ -66,4 +66,8 @@ defmodule Pyex.Stdlib.Urllib do
   end
 
   defp urlencode(_args), do: {:exception, "TypeError: urlencode() expects a mapping"}
+
+  @spec uri_part(String.t() | nil) :: String.t()
+  defp uri_part(nil), do: ""
+  defp uri_part(value), do: value
 end

--- a/test/pyex/builtins_test.exs
+++ b/test/pyex/builtins_test.exs
@@ -570,6 +570,40 @@ defmodule Pyex.BuiltinsTest do
     test "dict with no args" do
       assert Pyex.run!("dict()") == %{}
     end
+
+    test "dict with keyword arguments" do
+      assert Pyex.run!("dict(slug='post', body='hello')") == %{
+               "body" => "hello",
+               "slug" => "post"
+             }
+    end
+
+    test "dict merges mapping and keyword arguments without mutating source" do
+      result =
+        Pyex.run!("""
+        front = {"title": "Hello"}
+        merged = dict(front, slug="hello", body="Body")
+        (front, merged)
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  %{"title" => "Hello"},
+                  %{"body" => "Body", "slug" => "hello", "title" => "Hello"}
+                ]}
+    end
+
+    test "dict merges unpacked kwargs" do
+      result =
+        Pyex.run!("""
+        base = {"title": "Hello"}
+        extra = {"slug": "hello", "body": "Body"}
+        dict(base, **extra)
+        """)
+
+      assert result == %{"body" => "Body", "slug" => "hello", "title" => "Hello"}
+    end
   end
 
   describe "isinstance()" do

--- a/test/pyex/error_messages_test.exs
+++ b/test/pyex/error_messages_test.exs
@@ -205,13 +205,13 @@ defmodule Pyex.ErrorMessagesTest do
       end
     end
 
-    test "http-like module suggests requests" do
-      {:error, %Error{message: msg}} = Pyex.run("import urllib")
+    test "unsupported urllib submodule suggests requests" do
+      {:error, %Error{message: msg}} = Pyex.run("import urllib.request")
       assert msg =~ "requests"
     end
 
-    test "dotted urllib.request suggests requests" do
-      {:error, %Error{message: msg}} = Pyex.run("import urllib.request")
+    test "urllib.error suggests requests" do
+      {:error, %Error{message: msg}} = Pyex.run("import urllib.error")
       assert msg =~ "requests"
     end
 

--- a/test/pyex/filesystem_test.exs
+++ b/test/pyex/filesystem_test.exs
@@ -583,6 +583,47 @@ defmodule Pyex.FilesystemTest do
       assert value == ["main.py", "utils.py"]
     end
 
+    test "lists files from absolute subdirectory paths" do
+      fs =
+        Memory.new(%{
+          "posts/hello.md" => "",
+          "posts/intro.md" => "",
+          "posts/readme.txt" => ""
+        })
+
+      code = """
+      import os
+      slugs = [os.path.splitext(name)[0] for name in sorted(os.listdir("/posts")) if name.endswith(".md")]
+      slugs
+      """
+
+      {value, _ctx} = run_with_fs_public!(code, fs)
+      assert value == ["hello", "intro"]
+    end
+
+    test "os.walk traverses nested directories" do
+      fs =
+        Memory.new(%{
+          "posts/a.md" => "A",
+          "posts/nested/b.md" => "B"
+        })
+
+      code = """
+      import os
+      rows = []
+      for root, dirs, files in os.walk("/posts"):
+          rows.append((root, sorted(dirs), sorted(files)))
+      rows
+      """
+
+      {value, _ctx} = run_with_fs_public!(code, fs)
+
+      assert value == [
+               {:tuple, ["/posts", ["nested"], ["a.md"]]},
+               {:tuple, ["/posts/nested", [], ["b.md"]]}
+             ]
+    end
+
     test "lists subdirectories as entries" do
       fs =
         Memory.new(%{

--- a/test/pyex/interpreter_test.exs
+++ b/test/pyex/interpreter_test.exs
@@ -268,6 +268,22 @@ defmodule Pyex.InterpreterTest do
       assert result == [[1, 2, 3, 4], {:tuple, [1, 2, 3, 4]}, 1, 2]
     end
 
+    test "dict unpacking creates a new dict without mutating the source" do
+      result =
+        Pyex.run!("""
+        post = {"title": "Hello"}
+        final_data = {**post, "css": "body {}"}
+        (post, final_data)
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  %{"title" => "Hello"},
+                  %{"css" => "body {}", "title" => "Hello"}
+                ]}
+    end
+
     test "single-line compound statements execute" do
       result =
         Pyex.run!("""
@@ -482,11 +498,14 @@ defmodule Pyex.InterpreterTest do
 
     test "os.makedirs" do
       result =
-        Pyex.run!("""
-        import os
-        os.makedirs("public/posts", exist_ok=True)
-        "ok"
-        """)
+        Pyex.run!(
+          """
+          import os
+          os.makedirs("public/posts", exist_ok=True)
+          "ok"
+          """,
+          filesystem: Pyex.Filesystem.Memory.new()
+        )
 
       assert result == "ok"
     end
@@ -1556,6 +1575,18 @@ defmodule Pyex.InterpreterTest do
              del lst[1]
              lst
              """) == [1, 3]
+    end
+
+    test "del attribute-backed dict key" do
+      assert Pyex.run!("""
+             class Box:
+                 def __init__(self):
+                     self.data = {"a": 1, "b": 2}
+
+             box = Box()
+             del box.data["a"]
+             box.data
+             """) == %{"b" => 2}
     end
   end
 

--- a/test/pyex/methods_test.exs
+++ b/test/pyex/methods_test.exs
@@ -777,6 +777,18 @@ defmodule Pyex.MethodsTest do
 
       assert Pyex.run!(code) == {:tuple, [nil, true]}
     end
+
+    test "returns the inserted mutable object, not a detached copy" do
+      code = """
+      d = {}
+      child = d.setdefault("a", {})
+      child["b"] = 2
+      (child, d["a"], d)
+      """
+
+      assert Pyex.run!(code) ==
+               {:tuple, [%{"b" => 2}, %{"b" => 2}, %{"a" => %{"b" => 2}}]}
+    end
   end
 
   describe "dict.clear()" do

--- a/test/pyex/stdlib/dataclasses_test.exs
+++ b/test/pyex/stdlib/dataclasses_test.exs
@@ -1,0 +1,29 @@
+defmodule Pyex.Stdlib.DataclassesTest do
+  use ExUnit.Case, async: true
+
+  test "dataclass decorator, field, asdict, and replace work" do
+    result =
+      Pyex.run!("""
+      from dataclasses import dataclass, field, asdict, replace
+
+      @dataclass
+      class Post:
+          title: str
+          slug: str
+          tags: list = field(default_factory=list)
+
+      post = Post(title="Hello", slug="hello")
+      updated = replace(post, slug="updated")
+      (asdict(post), asdict(updated), post == Post(title="Hello", slug="hello"), repr(post))
+      """)
+
+    assert result ==
+             {:tuple,
+              [
+                %{"slug" => "hello", "tags" => [], "title" => "Hello"},
+                %{"slug" => "updated", "tags" => [], "title" => "Hello"},
+                true,
+                "Post(title='Hello', slug='hello', tags=[])"
+              ]}
+  end
+end

--- a/test/pyex/stdlib/fnmatch_test.exs
+++ b/test/pyex/stdlib/fnmatch_test.exs
@@ -1,0 +1,17 @@
+defmodule Pyex.Stdlib.FnmatchTest do
+  use ExUnit.Case, async: true
+
+  test "fnmatch and filter work" do
+    result =
+      Pyex.run!("""
+      import fnmatch
+      (
+          fnmatch.fnmatch("hello.md", "*.md"),
+          fnmatch.fnmatchcase("HELLO.md", "*.md"),
+          fnmatch.filter(["a.md", "b.txt", "c.md"], "*.md")
+      )
+      """)
+
+    assert result == {:tuple, [true, true, ["a.md", "c.md"]]}
+  end
+end

--- a/test/pyex/stdlib/glob_test.exs
+++ b/test/pyex/stdlib/glob_test.exs
@@ -1,0 +1,37 @@
+defmodule Pyex.Stdlib.GlobTest do
+  use ExUnit.Case, async: true
+
+  alias Pyex.Filesystem.Memory
+
+  describe "glob.glob" do
+    test "matches files in an absolute directory" do
+      fs = Memory.new(%{"posts/a.md" => "", "posts/b.md" => "", "posts/c.txt" => ""})
+
+      result =
+        Pyex.run!(
+          """
+          import glob
+          sorted(glob.glob("/posts/*.md"))
+          """,
+          filesystem: fs
+        )
+
+      assert result == ["/posts/a.md", "/posts/b.md"]
+    end
+
+    test "returns empty list when nothing matches" do
+      fs = Memory.new(%{"posts/a.txt" => ""})
+
+      result =
+        Pyex.run!(
+          """
+          import glob
+          glob.glob("posts/*.md")
+          """,
+          filesystem: fs
+        )
+
+      assert result == []
+    end
+  end
+end

--- a/test/pyex/stdlib/heapq_test.exs
+++ b/test/pyex/stdlib/heapq_test.exs
@@ -1,0 +1,18 @@
+defmodule Pyex.Stdlib.HeapqTest do
+  use ExUnit.Case, async: true
+
+  test "heapq push pop and replace maintain heap semantics" do
+    result =
+      Pyex.run!("""
+      import heapq
+      heap = [5, 1, 4]
+      heapq.heapify(heap)
+      heapq.heappush(heap, 2)
+      first = heapq.heappop(heap)
+      replaced = heapq.heapreplace(heap, 9)
+      (first, replaced, heap)
+      """)
+
+    assert result == {:tuple, [1, 2, [4, 5, 9]]}
+  end
+end

--- a/test/pyex/stdlib/pathlib_test.exs
+++ b/test/pyex/stdlib/pathlib_test.exs
@@ -1,0 +1,93 @@
+defmodule Pyex.Stdlib.PathlibTest do
+  use ExUnit.Case, async: true
+
+  alias Pyex.Filesystem.Memory
+
+  describe "pathlib.Path" do
+    test "glob returns path objects with usable stem values" do
+      fs = Memory.new(%{"posts/alpha.md" => "", "posts/beta.md" => "", "posts/readme.txt" => ""})
+
+      result =
+        Pyex.run!(
+          """
+          from pathlib import Path
+          sorted([path.stem for path in Path("/posts").glob("*.md")])
+          """,
+          filesystem: fs
+        )
+
+      assert result == ["alpha", "beta"]
+    end
+
+    test "write_text and read_text persist data" do
+      fs = Memory.new()
+
+      result =
+        Pyex.run!(
+          """
+          from pathlib import Path
+          path = Path("/dist") / "index.html"
+          wrote = path.write_text("hello")
+          (wrote, path.read_text(), path.stem)
+          """,
+          filesystem: fs
+        )
+
+      assert result == {:tuple, [5, "hello", "index"]}
+    end
+
+    test "path objects work with open" do
+      fs = Memory.new(%{"posts/hello.md" => "hello world"})
+
+      result =
+        Pyex.run!(
+          """
+          from pathlib import Path
+          path = Path("/posts") / "hello.md"
+          with open(path) as f:
+              f.read()
+          """,
+          filesystem: fs
+        )
+
+      assert result == "hello world"
+    end
+
+    test "exists parent and with_suffix helpers work" do
+      fs = Memory.new(%{"posts/hello.md" => "hello world"})
+
+      result =
+        Pyex.run!(
+          """
+          from pathlib import Path
+          path = Path("/posts/hello.md")
+          (path.exists(), path.is_file(), path.parent.name, str(path.with_suffix(".html")))
+          """,
+          filesystem: fs
+        )
+
+      assert result == {:tuple, [true, true, "posts", "/posts/hello.html"]}
+    end
+
+    test "mkdir iterdir and unlink work" do
+      fs = Memory.new()
+
+      result =
+        Pyex.run!(
+          """
+          from pathlib import Path
+          out = Path("/dist")
+          out.mkdir(parents=True, exist_ok=True)
+          page = out / "index.html"
+          page.write_text("hello")
+          names = sorted([child.name for child in out.iterdir()])
+          page.unlink()
+          (names, out.is_dir(), page.exists())
+          """,
+          filesystem: fs
+        )
+
+      assert result == {:tuple, [["index.html"], true, false]}
+    end
+  end
+end

--- a/test/pyex/stdlib/shutil_test.exs
+++ b/test/pyex/stdlib/shutil_test.exs
@@ -1,0 +1,30 @@
+defmodule Pyex.Stdlib.ShutilTest do
+  use ExUnit.Case, async: true
+
+  alias Pyex.Filesystem.Memory
+
+  test "copytree move and rmtree work" do
+    fs =
+      Memory.new(%{
+        "src/posts/a.md" => "A",
+        "src/posts/nested/b.md" => "B"
+      })
+
+    result =
+      Pyex.run!(
+        """
+        import os
+        import shutil
+        shutil.copytree("/src/posts", "/dist/posts")
+        shutil.move("/dist/posts/a.md", "/dist/index.md")
+        before = sorted([name for root, dirs, files in os.walk("/dist") for name in files])
+        shutil.rmtree("/src")
+        after = sorted([name for root, dirs, files in os.walk("/dist") for name in files])
+        (before, after)
+        """,
+        filesystem: fs
+      )
+
+    assert result == {:tuple, [["b.md", "index.md"], ["b.md", "index.md"]]}
+  end
+end

--- a/test/pyex/stdlib/urllib_test.exs
+++ b/test/pyex/stdlib/urllib_test.exs
@@ -1,0 +1,27 @@
+defmodule Pyex.Stdlib.UrllibTest do
+  use ExUnit.Case, async: true
+
+  test "urllib.parse helpers work" do
+    result =
+      Pyex.run!("""
+      import urllib.parse
+      (
+          urllib.parse.urljoin("https://example.com/blog/", "post"),
+          urllib.parse.quote("hello world"),
+          urllib.parse.unquote("hello%20world"),
+          urllib.parse.urlparse("https://example.com/blog/post?q=1#frag"),
+          urllib.parse.urlencode({"q": "hello world", "page": 2})
+      )
+      """)
+
+    assert result ==
+             {:tuple,
+              [
+                "https://example.com/blog/post",
+                "hello%20world",
+                "hello world",
+                {:tuple, ["https", "example.com", "/blog/post", "q=1", "frag"]},
+                "page=2&q=hello+world"
+              ]}
+  end
+end

--- a/test/pyex_test.exs
+++ b/test/pyex_test.exs
@@ -210,6 +210,296 @@ defmodule PyexTest do
     end
   end
 
+  describe "end-to-end: staff-level LRU cache" do
+    test "hash map plus doubly linked list stays correct under updates and eviction" do
+      result =
+        Pyex.run!("""
+        class Node:
+            def __init__(self, key, value):
+                self.key = key
+                self.value = value
+                self.prev = None
+                self.next = None
+
+        class LRUCache:
+            def __init__(self, capacity):
+                if capacity <= 0:
+                    raise ValueError("capacity must be positive")
+
+                self.capacity = capacity
+                self.lookup = {}
+                self.head = Node(None, None)
+                self.tail = Node(None, None)
+                self.head.next = self.tail
+                self.tail.prev = self.head
+
+            def _detach(self, node):
+                prev = node.prev
+                nxt = node.next
+                prev.next = nxt
+                nxt.prev = prev
+
+            def _add_after_head(self, node):
+                first = self.head.next
+                node.prev = self.head
+                node.next = first
+                self.head.next = node
+                first.prev = node
+
+            def get(self, key):
+                node = self.lookup.get(key)
+                if node is None:
+                    return -1
+
+                self._detach(node)
+                self._add_after_head(node)
+                return node.value
+
+            def put(self, key, value):
+                node = self.lookup.get(key)
+                if node is not None:
+                    node.value = value
+                    self._detach(node)
+                    self._add_after_head(node)
+                    return
+
+                node = Node(key, value)
+                self.lookup[key] = node
+                self._add_after_head(node)
+
+                if len(self.lookup) > self.capacity:
+                    lru = self.tail.prev
+                    self._detach(lru)
+                    del self.lookup[lru.key]
+
+            def items(self):
+                out = []
+                node = self.head.next
+                while node is not self.tail:
+                    out.append((node.key, node.value))
+                    node = node.next
+                return out
+
+        cache = LRUCache(2)
+        cache.put("a", 1)
+        cache.put("b", 2)
+        first_hit = cache.get("a")
+        cache.put("c", 3)
+        missing_b = cache.get("b")
+        cache.put("a", 10)
+        cache.put("d", 4)
+
+        (
+            first_hit,
+            missing_b,
+            cache.get("a"),
+            cache.get("c"),
+            cache.items(),
+            sorted(cache.lookup.keys())
+        )
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  1,
+                  -1,
+                  10,
+                  -1,
+                  [{:tuple, ["a", 10]}, {:tuple, ["d", 4]}],
+                  ["a", "d"]
+                ]}
+    end
+  end
+
+  describe "end-to-end: staff-level trie" do
+    test "prefix index supports insert, search, starts_with, and prefix expansion" do
+      result =
+        Pyex.run!("""
+        class Trie:
+            def __init__(self):
+                self.root = {}
+                self.end = "#"
+
+            def insert(self, word):
+                node = self.root
+                for ch in word:
+                    node = node.setdefault(ch, {})
+                node[self.end] = True
+
+            def _walk(self, text):
+                node = self.root
+                for ch in text:
+                    node = node.get(ch)
+                    if node is None:
+                        return None
+                return node
+
+            def search(self, word):
+                node = self._walk(word)
+                return node is not None and self.end in node
+
+            def starts_with(self, prefix):
+                return self._walk(prefix) is not None
+
+            def words_with_prefix(self, prefix):
+                start = self._walk(prefix)
+                if start is None:
+                    return []
+
+                out = []
+
+                def dfs(node, path):
+                    if self.end in node:
+                        out.append(path)
+
+                    for ch in sorted(node.keys()):
+                        if ch != self.end:
+                            dfs(node[ch], path + ch)
+
+                dfs(start, prefix)
+                return out
+
+        trie = Trie()
+        for word in ["app", "apple", "apply", "apt", "bat"]:
+            trie.insert(word)
+
+        (
+            trie.search("app"),
+            trie.search("appl"),
+            trie.starts_with("ap"),
+            trie.starts_with("cat"),
+            trie.words_with_prefix("app"),
+            trie.words_with_prefix("ba"),
+            trie.words_with_prefix("cat")
+        )
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  true,
+                  false,
+                  true,
+                  false,
+                  ["app", "apple", "apply"],
+                  ["bat"],
+                  []
+                ]}
+    end
+  end
+
+  describe "end-to-end: staff-level union find" do
+    test "path compression and union by size keep connectivity queries correct" do
+      result =
+        Pyex.run!("""
+        class UnionFind:
+            def __init__(self, size):
+                self.parent = list(range(size))
+                self.sz = [1] * size
+
+            def find(self, x):
+                if self.parent[x] != x:
+                    self.parent[x] = self.find(self.parent[x])
+                return self.parent[x]
+
+            def union(self, a, b):
+                ra = self.find(a)
+                rb = self.find(b)
+                if ra == rb:
+                    return False
+
+                if self.sz[ra] < self.sz[rb]:
+                    ra, rb = rb, ra
+
+                self.parent[rb] = ra
+                self.sz[ra] += self.sz[rb]
+                return True
+
+            def connected(self, a, b):
+                return self.find(a) == self.find(b)
+
+            def component_size(self, x):
+                return self.sz[self.find(x)]
+
+        uf = UnionFind(8)
+        ops = [
+            uf.union(0, 1),
+            uf.union(1, 2),
+            uf.union(3, 4),
+            uf.union(5, 6),
+            uf.union(6, 7),
+            uf.union(2, 7),
+            uf.union(0, 7)
+        ]
+
+        root_before = uf.parent[7]
+        connected = uf.connected(0, 6)
+        root_after = uf.parent[7]
+
+        (
+            ops,
+            connected,
+            uf.connected(0, 4),
+            uf.component_size(0),
+            uf.component_size(3),
+            root_before,
+            root_after,
+            uf.parent
+        )
+        """)
+
+      assert result ==
+               {:tuple,
+                [
+                  [true, true, true, true, true, true, false],
+                  true,
+                  false,
+                  6,
+                  2,
+                  0,
+                  0,
+                  [0, 0, 0, 3, 3, 0, 0, 0]
+                ]}
+    end
+  end
+
+  describe "end-to-end: staff-level top-k min-heap" do
+    test "streaming kth-largest uses heapq min-heap correctly" do
+      result =
+        Pyex.run!("""
+        import heapq
+
+        class KthLargest:
+            def __init__(self, k, nums):
+                self.k = k
+                self.heap = []
+                for n in nums:
+                    self.add(n)
+
+            def add(self, val):
+                if len(self.heap) < self.k:
+                    heapq.heappush(self.heap, val)
+                elif val > self.heap[0]:
+                    heapq.heapreplace(self.heap, val)
+                return self.heap[0]
+
+        kth = KthLargest(3, [4, 5, 8, 2])
+        results = [
+            kth.add(3),
+            kth.add(5),
+            kth.add(10),
+            kth.add(9),
+            kth.add(4)
+        ]
+
+        (results, kth.heap, kth.heap[0])
+        """)
+
+      assert result == {:tuple, [[4, 5, 5, 8, 8], [8, 10, 9], 8]}
+    end
+  end
+
   describe "end-to-end: FastAPI handler calls external API" do
     setup do
       bypass = Bypass.open()


### PR DESCRIPTION
## Summary
- add Pythonic filesystem and stdlib support for `dict(**kwargs)`, `os.path`, `os.walk`, `glob`, `pathlib`, `fnmatch`, `urllib.parse`, `shutil`, `dataclasses`, and `heapq`
- fix mutable aliasing and nested deletion semantics so real interview-style implementations like LRU cache, trie, union-find, and top-k heap behave like CPython
- tighten Dialyzer-visible specs and path helper typing so the branch passes static analysis cleanly

## Verification
- mix test
- mix dialyzer