### PR TITLE
Add staff-level requests patterns and dict | dict merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# Guidelines for Pyex Development
+
+## IMPORTANT: Code Requirement
+
+**ALWAYS run `mix format`, `mix compile --warnings-as-errors`, and `mix test` after every code change.** This is a non-negotiable requirement. All code must be properly formatted, warning-free, and tested before being committed.
+
+## Project Overview
+
+Pyex is a Python interpreter written in Elixir. Follow idiomatic Elixir conventions throughout.
+
+## General Guidelines
+
+- Use snake_case for variables/functions, PascalCase for modules
+- Return tagged tuples: `{:ok, result}` or `{:error, reason}`
+- Use pattern matching over conditional logic when possible
+- Use pipe operators (`|>`) for multi-step transformations
+- Organize aliases alphabetically
+- Use `with` statements for sequential operations that may fail
+
+## Testing
+
+- Run `mix test` or `mix test path/to/test_file.exs:line_number`
+- Don't use mocks
+- Test the happy path and edge cases
+
+## Workflow
+
+- **ALWAYS run `mix format` before committing any code changes**
+- **ALWAYS run `mix compile --warnings-as-errors` before committing**
+- **ALWAYS run `mix test` before committing**
+- Run `mix format --check-formatted` to verify all files are properly formatted

--- a/lib/pyex/interpreter/binary_ops.ex
+++ b/lib/pyex/interpreter/binary_ops.ex
@@ -528,7 +528,10 @@ defmodule Pyex.Interpreter.BinaryOps do
 
   defp dispatch(:pipe, {:py_dict, _, _} = l, {:py_dict, _, _} = r), do: PyDict.merge(l, r)
   defp dispatch(:pipe, {:py_dict, _, _} = l, r) when is_map(r), do: PyDict.merge_map(l, r)
-  defp dispatch(:pipe, l, {:py_dict, _, _} = r) when is_map(l), do: PyDict.merge(PyDict.from_map(l), r)
+
+  defp dispatch(:pipe, l, {:py_dict, _, _} = r) when is_map(l),
+    do: PyDict.merge(PyDict.from_map(l), r)
+
   defp dispatch(:pipe, l, r) when is_map(l) and is_map(r), do: Map.merge(l, r)
 
   defp dispatch(:pipe, l, r) when is_integer(l) and is_integer(r), do: bor(l, r)

--- a/lib/pyex/interpreter/binary_ops.ex
+++ b/lib/pyex/interpreter/binary_ops.ex
@@ -526,6 +526,11 @@ defmodule Pyex.Interpreter.BinaryOps do
 
   defp dispatch(:pipe, {:set, a}, {:frozenset, b}), do: {:set, MapSet.union(a, b)}
 
+  defp dispatch(:pipe, {:py_dict, _, _} = l, {:py_dict, _, _} = r), do: PyDict.merge(l, r)
+  defp dispatch(:pipe, {:py_dict, _, _} = l, r) when is_map(r), do: PyDict.merge_map(l, r)
+  defp dispatch(:pipe, l, {:py_dict, _, _} = r) when is_map(l), do: PyDict.merge(PyDict.from_map(l), r)
+  defp dispatch(:pipe, l, r) when is_map(l) and is_map(r), do: Map.merge(l, r)
+
   defp dispatch(:pipe, l, r) when is_integer(l) and is_integer(r), do: bor(l, r)
 
   defp dispatch(:pipe, l, r),

--- a/lib/pyex/parser/control_flow.ex
+++ b/lib/pyex/parser/control_flow.ex
@@ -240,16 +240,21 @@ defmodule Pyex.Parser.ControlFlow do
             error
         end
 
-      [{:name, _, exc_name}, {:keyword, _, "as"}, {:name, _, var_name} | rest] ->
-        with {:ok, rest} <- expect_block_start(rest, "except"),
-             {:ok, handler_body, rest} <- Parser.parse_block(rest) do
-          parse_except_clauses(rest, [{exc_name, var_name, handler_body} | acc])
-        end
+      [{:name, _, _} | _] ->
+        {exc_name, rest} = collect_dotted_name(rest)
 
-      [{:name, _, exc_name} | rest] ->
-        with {:ok, rest} <- expect_block_start(rest, "except"),
-             {:ok, handler_body, rest} <- Parser.parse_block(rest) do
-          parse_except_clauses(rest, [{exc_name, nil, handler_body} | acc])
+        case rest do
+          [{:keyword, _, "as"}, {:name, _, var_name} | rest] ->
+            with {:ok, rest} <- expect_block_start(rest, "except"),
+                 {:ok, handler_body, rest} <- Parser.parse_block(rest) do
+              parse_except_clauses(rest, [{exc_name, var_name, handler_body} | acc])
+            end
+
+          _ ->
+            with {:ok, rest} <- expect_block_start(rest, "except"),
+                 {:ok, handler_body, rest} <- Parser.parse_block(rest) do
+              parse_except_clauses(rest, [{exc_name, nil, handler_body} | acc])
+            end
         end
 
       _ ->
@@ -261,14 +266,31 @@ defmodule Pyex.Parser.ControlFlow do
     {:ok, Enum.reverse(acc), rest}
   end
 
-  @spec collect_except_names([Lexer.token()], [String.t()]) ::
-          {:ok, [String.t()], [Lexer.token()]} | {:error, String.t()}
-  defp collect_except_names([{:name, _, name}, {:op, _, :rparen} | rest], acc) do
-    {:ok, Enum.reverse([name | acc]), rest}
+  @spec collect_dotted_name([Lexer.token()]) :: {String.t(), [Lexer.token()]}
+  defp collect_dotted_name([{:name, _, name}, {:op, _, :dot} | rest]) do
+    {suffix, rest} = collect_dotted_name(rest)
+    {name <> "." <> suffix, rest}
   end
 
-  defp collect_except_names([{:name, _, name}, {:op, _, :comma} | rest], acc) do
-    collect_except_names(rest, [name | acc])
+  defp collect_dotted_name([{:name, _, name} | rest]) do
+    {name, rest}
+  end
+
+  @spec collect_except_names([Lexer.token()], [String.t()]) ::
+          {:ok, [String.t()], [Lexer.token()]} | {:error, String.t()}
+  defp collect_except_names([{:name, _, _} | _] = tokens, acc) do
+    {name, rest} = collect_dotted_name(tokens)
+
+    case rest do
+      [{:op, _, :rparen} | rest] ->
+        {:ok, Enum.reverse([name | acc]), rest}
+
+      [{:op, _, :comma} | rest] ->
+        collect_except_names(rest, [name | acc])
+
+      _ ->
+        {:error, "expected ')' or ',' in except tuple at #{token_line(rest)}"}
+    end
   end
 
   defp collect_except_names(tokens, _acc) do

--- a/lib/pyex/stdlib/requests.ex
+++ b/lib/pyex/stdlib/requests.ex
@@ -5,8 +5,12 @@ defmodule Pyex.Stdlib.Requests do
   Provides `requests.get`, `requests.post`, `requests.put`,
   `requests.patch`, `requests.delete`, `requests.head`, and
   `requests.options` which return an object with `.text`,
-  `.status_code`, `.ok`, `.headers`, and `.json()` attributes,
-  matching the real `requests.Response` interface.
+  `.status_code`, `.ok`, `.headers`, `.json()`, and
+  `.raise_for_status()` attributes, matching the real
+  `requests.Response` interface.
+
+  Also provides `requests.Session()` for persistent headers and
+  `requests.HTTPError` for exception catching.
 
   All HTTP calls emit `:telemetry` events (`[:pyex, :request, :start]`
   and `[:pyex, :request, :stop]`). I/O time is excluded from the
@@ -30,7 +34,9 @@ defmodule Pyex.Stdlib.Requests do
       "patch" => {:builtin_kw, &do_patch/2},
       "delete" => {:builtin_kw, &do_delete/2},
       "head" => {:builtin_kw, &do_head/2},
-      "options" => {:builtin_kw, &do_options/2}
+      "options" => {:builtin_kw, &do_options/2},
+      "Session" => {:builtin, fn [] -> build_session() end},
+      "HTTPError" => "requests.HTTPError"
     }
   end
 
@@ -76,6 +82,84 @@ defmodule Pyex.Stdlib.Requests do
         ) :: {:io_call, (Pyex.Env.t(), Pyex.Ctx.t() -> {term(), Pyex.Env.t(), Pyex.Ctx.t()})}
   defp do_options([url], kwargs) when is_binary(url), do: do_request(:options, url, kwargs)
 
+  # ── Session ─────────────────────────────────────────────────────
+
+  @spec build_session() :: Pyex.Interpreter.pyvalue()
+  defp build_session do
+    # Use an Agent to hold mutable session headers so closures always
+    # read the latest state, matching Python's mutable Session semantics.
+    {:ok, agent} = Agent.start_link(fn -> PyDict.new() end)
+
+    session_method = fn method ->
+      {:builtin_kw,
+       fn [url], kwargs when is_binary(url) ->
+         current_headers = Agent.get(agent, & &1)
+         merged_kwargs = merge_session_headers(kwargs, current_headers)
+         do_request(method, url, merged_kwargs)
+       end}
+    end
+
+    # The "headers" value is a PyDict that supports .update() and []= via
+    # the interpreter's normal dict mutation paths. We intercept reads of
+    # session.headers to return the agent's current value, and intercept
+    # mutations by wrapping update in a custom builtin.
+    headers_obj =
+      PyDict.from_pairs([
+        {"update",
+         {:builtin,
+          fn [new_headers] ->
+            Agent.update(agent, fn current ->
+              case new_headers do
+                {:py_dict, _, _} = h -> PyDict.merge(current, h)
+                %{} = m -> PyDict.merge_map(current, m)
+                _ -> current
+              end
+            end)
+
+            nil
+          end}},
+        {"__setitem__",
+         {:builtin,
+          fn [key, value] ->
+            Agent.update(agent, fn current -> PyDict.put(current, key, value) end)
+            nil
+          end}}
+      ])
+
+    PyDict.from_pairs([
+      {"headers", headers_obj},
+      {"get", session_method.(:get)},
+      {"post", session_method.(:post)},
+      {"put", session_method.(:put)},
+      {"patch", session_method.(:patch)},
+      {"delete", session_method.(:delete)},
+      {"head", session_method.(:head)},
+      {"options", session_method.(:options)}
+    ])
+  end
+
+  @spec merge_session_headers(
+          %{optional(String.t()) => Pyex.Interpreter.pyvalue()},
+          PyDict.t()
+        ) :: %{optional(String.t()) => Pyex.Interpreter.pyvalue()}
+  defp merge_session_headers(kwargs, session_headers) do
+    per_request = Map.get(kwargs, "headers")
+
+    merged =
+      case per_request do
+        {:py_dict, _, _} = h -> PyDict.merge(session_headers, h)
+        _ -> session_headers
+      end
+
+    if PyDict.empty?(merged) do
+      kwargs
+    else
+      Map.put(kwargs, "headers", merged)
+    end
+  end
+
+  # ── Core request ────────────────────────────────────────────────
+
   @spec do_request(
           atom(),
           String.t(),
@@ -84,6 +168,7 @@ defmodule Pyex.Stdlib.Requests do
   defp do_request(method, url, kwargs) do
     user_headers = build_headers(kwargs)
     method_str = method |> Atom.to_string() |> String.upcase()
+    url = append_params(url, kwargs)
 
     {:io_call,
      fn env, ctx ->
@@ -96,7 +181,8 @@ defmodule Pyex.Stdlib.Requests do
            headers = merge_headers(user_headers, inject_headers)
 
            req_opts =
-             [headers: headers, method: method, url: url, redirect: false] ++ body_opts(kwargs)
+             [headers: headers, method: method, url: url, redirect: false, retry: false] ++
+               body_opts(kwargs)
 
            start_mono = System.monotonic_time()
            telemetry_meta = %{method: method_str, url: url}
@@ -151,6 +237,29 @@ defmodule Pyex.Stdlib.Requests do
     filtered ++ inject_headers
   end
 
+  # ── params= kwarg ───────────────────────────────────────────────
+
+  @spec append_params(String.t(), %{optional(String.t()) => Pyex.Interpreter.pyvalue()}) ::
+          String.t()
+  defp append_params(url, kwargs) do
+    case Map.get(kwargs, "params") do
+      {:py_dict, _, _} = params ->
+        query =
+          params
+          |> PyDict.items()
+          |> Enum.map(fn {k, v} -> {to_string(k), to_string(v)} end)
+          |> URI.encode_query()
+
+        separator = if String.contains?(url, "?"), do: "&", else: "?"
+        url <> separator <> query
+
+      _ ->
+        url
+    end
+  end
+
+  # ── body opts ───────────────────────────────────────────────────
+
   @spec body_opts(%{optional(String.t()) => Pyex.Interpreter.pyvalue()}) :: keyword()
   defp body_opts(kwargs) do
     json_data = Map.get(kwargs, "json")
@@ -159,9 +268,26 @@ defmodule Pyex.Stdlib.Requests do
     cond do
       json_data != nil -> [json: to_jason_compatible(json_data)]
       data != nil && is_binary(data) -> [body: data]
+      data != nil -> [body: form_encode(data)]
       true -> []
     end
   end
+
+  @spec form_encode(Pyex.Interpreter.pyvalue()) :: String.t()
+  defp form_encode({:py_dict, _, _} = dict) do
+    dict
+    |> PyDict.items()
+    |> Enum.map(fn {k, v} -> {to_string(k), to_string(v)} end)
+    |> URI.encode_query()
+  end
+
+  defp form_encode(%{} = map) do
+    map
+    |> Enum.map(fn {k, v} -> {to_string(k), to_string(v)} end)
+    |> URI.encode_query()
+  end
+
+  # ── Response ────────────────────────────────────────────────────
 
   @spec build_response(Req.Response.t()) :: Pyex.Interpreter.pyvalue()
   defp build_response(%Req.Response{status: status, body: body, headers: resp_headers}) do
@@ -179,6 +305,13 @@ defmodule Pyex.Stdlib.Requests do
       Enum.map(resp_headers, fn {k, v} -> {String.downcase(k), v} end)
       |> PyDict.from_pairs()
 
+    error_kind =
+      cond do
+        status >= 400 and status < 500 -> "Client Error"
+        status >= 500 -> "Server Error"
+        true -> nil
+      end
+
     PyDict.from_pairs([
       {"text", text},
       {"content", text},
@@ -191,6 +324,15 @@ defmodule Pyex.Stdlib.Requests do
           case Jason.decode(text) do
             {:ok, value} -> value
             {:error, reason} -> {:exception, "json.JSONDecodeError: #{inspect(reason)}"}
+          end
+        end}},
+      {"raise_for_status",
+       {:builtin,
+        fn [] ->
+          if error_kind do
+            {:exception, "requests.HTTPError: #{status} #{error_kind}"}
+          else
+            nil
           end
         end}}
     ])

--- a/test/pyex/interpreter_test.exs
+++ b/test/pyex/interpreter_test.exs
@@ -2756,43 +2756,47 @@ defmodule Pyex.InterpreterTest do
 
   describe "dict | dict merge (PEP 584)" do
     test "basic dict merge with |" do
-      result = Pyex.run!("""
-      a = {"x": 1, "y": 2}
-      b = {"y": 3, "z": 4}
-      c = a | b
-      [c["x"], c["y"], c["z"]]
-      """)
+      result =
+        Pyex.run!("""
+        a = {"x": 1, "y": 2}
+        b = {"y": 3, "z": 4}
+        c = a | b
+        [c["x"], c["y"], c["z"]]
+        """)
 
       assert result == [1, 3, 4]
     end
 
     test "dict |= augmented assignment" do
-      result = Pyex.run!("""
-      a = {"x": 1}
-      a |= {"y": 2, "x": 10}
-      [a["x"], a["y"]]
-      """)
+      result =
+        Pyex.run!("""
+        a = {"x": 1}
+        a |= {"y": 2, "x": 10}
+        [a["x"], a["y"]]
+        """)
 
       assert result == [10, 2]
     end
 
     test "dict merge preserves insertion order" do
-      result = Pyex.run!("""
-      a = {"a": 1, "b": 2}
-      b = {"c": 3, "b": 99}
-      c = a | b
-      list(c.keys())
-      """)
+      result =
+        Pyex.run!("""
+        a = {"a": 1, "b": 2}
+        b = {"c": 3, "b": 99}
+        c = a | b
+        list(c.keys())
+        """)
 
       assert result == ["a", "b", "c"]
     end
 
     test "building request params with |" do
-      result = Pyex.run!("""
-      base_params = {"api_key": "abc", "format": "json"}
-      day_params = base_params | {"day": "2026-04-02"}
-      list(day_params.keys())
-      """)
+      result =
+        Pyex.run!("""
+        base_params = {"api_key": "abc", "format": "json"}
+        day_params = base_params | {"day": "2026-04-02"}
+        list(day_params.keys())
+        """)
 
       assert result == ["api_key", "format", "day"]
     end

--- a/test/pyex/interpreter_test.exs
+++ b/test/pyex/interpreter_test.exs
@@ -2753,4 +2753,57 @@ defmodule Pyex.InterpreterTest do
       assert msg =~ "ValueError"
     end
   end
+
+  describe "dict | dict merge (PEP 584)" do
+    test "basic dict merge with |" do
+      result = Pyex.run!("""
+      a = {"x": 1, "y": 2}
+      b = {"y": 3, "z": 4}
+      c = a | b
+      [c["x"], c["y"], c["z"]]
+      """)
+
+      assert result == [1, 3, 4]
+    end
+
+    test "dict |= augmented assignment" do
+      result = Pyex.run!("""
+      a = {"x": 1}
+      a |= {"y": 2, "x": 10}
+      [a["x"], a["y"]]
+      """)
+
+      assert result == [10, 2]
+    end
+
+    test "dict merge preserves insertion order" do
+      result = Pyex.run!("""
+      a = {"a": 1, "b": 2}
+      b = {"c": 3, "b": 99}
+      c = a | b
+      list(c.keys())
+      """)
+
+      assert result == ["a", "b", "c"]
+    end
+
+    test "building request params with |" do
+      result = Pyex.run!("""
+      base_params = {"api_key": "abc", "format": "json"}
+      day_params = base_params | {"day": "2026-04-02"}
+      list(day_params.keys())
+      """)
+
+      assert result == ["api_key", "format", "day"]
+    end
+
+    test "dict | non-dict raises TypeError" do
+      assert {:error, %Pyex.Error{message: msg}} = Pyex.run(~s[{"a": 1} | 42])
+      assert msg =~ "TypeError"
+    end
+
+    test "int | int still works (bitwise OR unchanged)" do
+      assert Pyex.run!("5 | 3") == 7
+    end
+  end
 end

--- a/test/pyex/stdlib/requests_session_test.exs
+++ b/test/pyex/stdlib/requests_session_test.exs
@@ -1,0 +1,402 @@
+defmodule Pyex.Stdlib.RequestsSessionTest do
+  @moduledoc """
+  Tests for staff-level requests patterns: Session, params=, data=dict,
+  and raise_for_status().
+  """
+  use ExUnit.Case
+
+  @network [%{dangerously_allow_full_internet_access: true, methods: :all}]
+
+  setup do
+    bypass = Bypass.open()
+    {:ok, bypass: bypass}
+  end
+
+  # ── requests.Session ──────────────────────────────────────────────
+
+  describe "requests.Session" do
+    test "session headers flow into every request", %{bypass: bypass} do
+      Bypass.expect(bypass, fn conn ->
+        [auth] = Plug.Conn.get_req_header(conn, "authorization")
+        assert auth == "Bearer tok123"
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          s = requests.Session()
+          s.headers.update({"Authorization": "Bearer tok123"})
+          r = s.get("http://localhost:#{port}/a")
+          r.status_code
+          """,
+          network: @network
+        )
+
+      assert result == 200
+    end
+
+    test "session headers can be set via update", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/b", fn conn ->
+        [key] = Plug.Conn.get_req_header(conn, "x-api-key")
+        assert key == "secret"
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          s = requests.Session()
+          s.headers.update({"X-Api-Key": "secret"})
+          r = s.get("http://localhost:#{port}/b")
+          r.status_code
+          """,
+          network: @network
+        )
+
+      assert result == 200
+    end
+
+    test "per-request headers merge with session headers", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/c", fn conn ->
+        [auth] = Plug.Conn.get_req_header(conn, "authorization")
+        [extra] = Plug.Conn.get_req_header(conn, "x-extra")
+        assert auth == "Bearer session"
+        assert extra == "per-request"
+        Plug.Conn.resp(conn, 201, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          s = requests.Session()
+          s.headers.update({"Authorization": "Bearer session"})
+          r = s.post("http://localhost:#{port}/c", json={}, headers={"X-Extra": "per-request"})
+          r.status_code
+          """,
+          network: @network
+        )
+
+      assert result == 201
+    end
+
+    test "session supports all HTTP methods", %{bypass: bypass} do
+      for method <- ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] do
+        Bypass.expect_once(bypass, method, "/#{String.downcase(method)}", fn conn ->
+          Plug.Conn.resp(conn, 200, "")
+        end)
+      end
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          s = requests.Session()
+          codes = []
+          codes.append(s.get("http://localhost:#{port}/get").status_code)
+          codes.append(s.post("http://localhost:#{port}/post", json={}).status_code)
+          codes.append(s.put("http://localhost:#{port}/put", json={}).status_code)
+          codes.append(s.patch("http://localhost:#{port}/patch", json={}).status_code)
+          codes.append(s.delete("http://localhost:#{port}/delete").status_code)
+          codes.append(s.head("http://localhost:#{port}/head").status_code)
+          codes.append(s.options("http://localhost:#{port}/options").status_code)
+          codes
+          """,
+          network: @network
+        )
+
+      assert result == [200, 200, 200, 200, 200, 200, 200]
+    end
+  end
+
+  # ── params= kwarg ─────────────────────────────────────────────────
+
+  describe "params= kwarg" do
+    test "params dict is appended as query string", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["q"] == "elixir"
+        assert conn.query_params["page"] == "2"
+        Plug.Conn.resp(conn, 200, "results")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          r = requests.get("http://localhost:#{port}/search", params={"q": "elixir", "page": "2"})
+          r.text
+          """,
+          network: @network
+        )
+
+      assert result == "results"
+    end
+
+    test "params with integer values are stringified", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/api", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["venue_id"] == "5456"
+        assert conn.query_params["day"] == "2026-04-02"
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          r = requests.get("http://localhost:#{port}/api", params={"venue_id": 5456, "day": "2026-04-02"})
+          r.status_code
+          """,
+          network: @network
+        )
+
+      assert result == 200
+    end
+
+    test "params appends to URL that already has a query string", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["existing"] == "1"
+        assert conn.query_params["added"] == "2"
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          r = requests.get("http://localhost:#{port}/search?existing=1", params={"added": "2"})
+          r.status_code
+          """,
+          network: @network
+        )
+
+      assert result == 200
+    end
+
+    test "params works with Session too", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/sess", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["token"] == "abc"
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          s = requests.Session()
+          r = s.get("http://localhost:#{port}/sess", params={"token": "abc"})
+          r.status_code
+          """,
+          network: @network
+        )
+
+      assert result == 200
+    end
+  end
+
+  # ── data=dict auto-encoding ───────────────────────────────────────
+
+  describe "data=dict auto form-encoding" do
+    test "data=dict sends form-encoded body", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/login", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        params = URI.decode_query(body)
+        assert params["email"] == "a@b.com"
+        assert params["password"] == "hunter2"
+        Plug.Conn.resp(conn, 200, "logged in")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          r = requests.post("http://localhost:#{port}/login", data={"email": "a@b.com", "password": "hunter2"})
+          r.text
+          """,
+          network: @network
+        )
+
+      assert result == "logged in"
+    end
+
+    test "data=dict works with Session", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/form", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        params = URI.decode_query(body)
+        assert params["user"] == "alice"
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          s = requests.Session()
+          r = s.post("http://localhost:#{port}/form", data={"user": "alice"})
+          r.text
+          """,
+          network: @network
+        )
+
+      assert result == "ok"
+    end
+
+    test "data=string still sends raw body", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/raw", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert body == "raw payload"
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          r = requests.post("http://localhost:#{port}/raw", data="raw payload")
+          r.text
+          """,
+          network: @network
+        )
+
+      assert result == "ok"
+    end
+  end
+
+  # ── raise_for_status() ────────────────────────────────────────────
+
+  describe "response.raise_for_status()" do
+    test "no-op on 200", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/ok", fn conn ->
+        Plug.Conn.resp(conn, 200, "fine")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          r = requests.get("http://localhost:#{port}/ok")
+          r.raise_for_status()
+          r.text
+          """,
+          network: @network
+        )
+
+      assert result == "fine"
+    end
+
+    test "raises HTTPError on 404", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/missing", fn conn ->
+        Plug.Conn.resp(conn, 404, "not found")
+      end)
+
+      port = bypass.port
+
+      assert_raise RuntimeError, ~r/requests\.HTTPError.*404/, fn ->
+        Pyex.run!(
+          """
+          import requests
+          r = requests.get("http://localhost:#{port}/missing")
+          r.raise_for_status()
+          """,
+          network: @network
+        )
+      end
+    end
+
+    test "no-op on 302 redirect", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/redir", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "/other")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          r = requests.get("http://localhost:#{port}/redir")
+          r.raise_for_status()
+          r.status_code
+          """,
+          network: @network
+        )
+
+      assert result == 302
+    end
+
+    test "raises HTTPError on 500", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/error", fn conn ->
+        Plug.Conn.resp(conn, 500, "internal error")
+      end)
+
+      port = bypass.port
+
+      assert_raise RuntimeError, ~r/requests\.HTTPError.*500/, fn ->
+        Pyex.run!(
+          """
+          import requests
+          r = requests.get("http://localhost:#{port}/error")
+          r.raise_for_status()
+          """,
+          network: @network
+        )
+      end
+    end
+
+    test "catchable with except requests.HTTPError", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/fail", fn conn ->
+        Plug.Conn.resp(conn, 403, "forbidden")
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          try:
+              r = requests.get("http://localhost:#{port}/fail")
+              r.raise_for_status()
+          except requests.HTTPError as e:
+              result = "caught"
+          result
+          """,
+          network: @network
+        )
+
+      assert result == "caught"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **requests.Session**: persistent headers via `s.headers.update({...})`, all HTTP methods, per-request header merging
- **params= kwarg**: `requests.get(url, params={"venue_id": 5456})` auto-appends query string with value stringification
- **data=dict auto-encoding**: `requests.post(url, data={"email": "a@b.com"})` auto form-encodes dicts; raw strings unchanged
- **response.raise_for_status()**: no-op on 2xx/3xx, raises `requests.HTTPError` on 4xx/5xx, catchable via `except requests.HTTPError`
- **dict | dict merge (PEP 584)**: `{"a": 1} | {"b": 2}`, `|=` augmented assignment, insertion order preserved
- **Dotted except names**: `except requests.HTTPError` now parses correctly
- **Disable Req retries**: matches Python requests behavior (no auto-retry on 5xx)

## Test plan
- [x] 22 new tests across `requests_session_test.exs` and `interpreter_test.exs`
- [x] Full suite passes (3131 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)