### PR TITLE
Close 4 sandbox gaps that cause LLM agent retry loops

### DIFF
--- a/lib/pyex/builtins.ex
+++ b/lib/pyex/builtins.ex
@@ -1033,7 +1033,7 @@ defmodule Pyex.Builtins do
     end
   end
 
-  @open_supported_kwargs ["file", "mode", "encoding", "newline"]
+  @open_supported_kwargs ["file", "mode", "encoding", "newline", "errors"]
 
   @spec validate_open_kwargs(%{optional(String.t()) => Interpreter.pyvalue()}) ::
           :ok | {:exception, String.t()}
@@ -1107,7 +1107,9 @@ defmodule Pyex.Builtins do
           {:ctx_call, (Pyex.Env.t(), Pyex.Ctx.t() -> term())}
           | {:exception, String.t()}
   defp open_file_handle(path, mode_str) do
-    case mode_str do
+    normalized = String.replace(mode_str, "b", "")
+
+    case normalized do
       m when m in ["r", "w", "a"] ->
         mode = %{"r" => :read, "w" => :write, "a" => :append} |> Map.fetch!(m)
 
@@ -1123,7 +1125,7 @@ defmodule Pyex.Builtins do
          end}
 
       _ ->
-        {:exception, "ValueError: invalid mode: '#{mode_str}'"}
+        {:exception, "ValueError: invalid mode: '#{mode_str}' (normalized: '#{normalized}')"}
     end
   end
 

--- a/lib/pyex/stdlib.ex
+++ b/lib/pyex/stdlib.ex
@@ -50,7 +50,8 @@ defmodule Pyex.Stdlib do
     "enum" => Pyex.Stdlib.EnumModule,
     "string" => Pyex.Stdlib.String,
     "typing" => Pyex.Stdlib.Typing,
-    "textwrap" => Pyex.Stdlib.Textwrap
+    "textwrap" => Pyex.Stdlib.Textwrap,
+    "sys" => Pyex.Stdlib.Sys
   }
 
   @doc """

--- a/lib/pyex/stdlib/json.ex
+++ b/lib/pyex/stdlib/json.ex
@@ -19,8 +19,55 @@ defmodule Pyex.Stdlib.Json do
   def module_value do
     %{
       "loads" => {:builtin, &do_loads/1},
-      "dumps" => {:builtin_kw, &do_dumps/2}
+      "dumps" => {:builtin_kw, &do_dumps/2},
+      "load" => {:builtin, &do_load/1},
+      "dump" => {:builtin_kw, &do_dump/2}
     }
+  end
+
+  @spec do_load([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()
+  defp do_load([{:file_handle, id}]) do
+    {:io_call,
+     fn env, ctx ->
+       case Pyex.Ctx.read_handle(ctx, id) do
+         {:ok, content, ctx} ->
+           case Jason.decode(content) do
+             {:ok, value} -> {from_json(value), env, ctx}
+             {:error, reason} -> {{:exception, "json.load failed: #{inspect(reason)}"}, env, ctx}
+           end
+
+         {:error, msg} ->
+           {{:exception, msg}, env, ctx}
+       end
+     end}
+  end
+
+  defp do_load(_args) do
+    {:exception, "TypeError: json.load() argument must be a file object"}
+  end
+
+  @spec do_dump(
+          [Pyex.Interpreter.pyvalue()],
+          %{optional(String.t()) => Pyex.Interpreter.pyvalue()}
+        ) :: Pyex.Interpreter.pyvalue()
+  defp do_dump([value, {:file_handle, id}], kwargs) do
+    case do_dumps([value], kwargs) do
+      {:exception, _} = err ->
+        err
+
+      json_str ->
+        {:io_call,
+         fn env, ctx ->
+           case Pyex.Ctx.write_handle(ctx, id, json_str) do
+             {:ok, ctx} -> {nil, env, ctx}
+             {:error, msg} -> {{:exception, msg}, env, ctx}
+           end
+         end}
+    end
+  end
+
+  defp do_dump(_args, _kwargs) do
+    {:exception, "TypeError: json.dump() requires a value and a file object"}
   end
 
   @spec do_loads([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()

--- a/lib/pyex/stdlib/sys.ex
+++ b/lib/pyex/stdlib/sys.ex
@@ -1,0 +1,30 @@
+defmodule Pyex.Stdlib.Sys do
+  @moduledoc """
+  Minimal Python `sys` module stub.
+
+  Provides `sys.stdout`, `sys.stderr`, `sys.argv`, `sys.version`,
+  `sys.exit()`, and `sys.maxsize` so that `import sys` does not fail
+  in the sandbox.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "argv" => {:py_list, [], 0},
+      "version" => "3.11.0 (Pyex sandbox) [Python compatible]",
+      "maxsize" => 9_223_372_036_854_775_807,
+      "stdout" => {:stringio, make_ref()},
+      "stderr" => {:stringio, make_ref()},
+      "exit" => {:builtin, &do_exit/1}
+    }
+  end
+
+  @spec do_exit([Pyex.Interpreter.pyvalue()]) :: {:exception, String.t()}
+  defp do_exit([]), do: {:exception, "SystemExit: 0"}
+  defp do_exit([code]) when is_integer(code), do: {:exception, "SystemExit: #{code}"}
+  defp do_exit([msg]) when is_binary(msg), do: {:exception, "SystemExit: #{msg}"}
+  defp do_exit(_), do: {:exception, "SystemExit"}
+end

--- a/test/pyex/error_messages_test.exs
+++ b/test/pyex/error_messages_test.exs
@@ -215,9 +215,8 @@ defmodule Pyex.ErrorMessagesTest do
       assert msg =~ "requests"
     end
 
-    test "sys module suggests os" do
-      {:error, %Error{message: msg}} = Pyex.run("import sys")
-      assert msg =~ "os"
+    test "sys module imports successfully" do
+      {:ok, _result, _ctx} = Pyex.run("import sys")
     end
   end
 

--- a/test/pyex/stdlib/sandbox_gaps_test.exs
+++ b/test/pyex/stdlib/sandbox_gaps_test.exs
@@ -1,0 +1,174 @@
+defmodule Pyex.Stdlib.SandboxGapsTest do
+  use ExUnit.Case, async: true
+
+  @fs_opts [filesystem: Pyex.Filesystem.Memory.new()]
+
+  # ---------------------------------------------------------------------------
+  # Gap 1: json.load(f) / json.dump(obj, f)
+  # ---------------------------------------------------------------------------
+  describe "json.load/1 — deserialize file handle contents as JSON" do
+    test "json.load(f) reads a file handle and parses the JSON string into a dict" do
+      code = """
+      import json
+      with open("data.json", "w") as f:
+          f.write('{"name": "Alice", "age": 30}')
+      with open("data.json", "r") as f:
+          data = json.load(f)
+      data["name"]
+      """
+
+      assert Pyex.run!(code, @fs_opts) == "Alice"
+    end
+
+    test "json.load(f) raises ValueError when the file contains invalid JSON" do
+      code = """
+      import json
+      with open("bad.json", "w") as f:
+          f.write("not json")
+      with open("bad.json", "r") as f:
+          json.load(f)
+      """
+
+      assert_raise RuntimeError, ~r/json\.load failed/, fn ->
+        Pyex.run!(code, @fs_opts)
+      end
+    end
+  end
+
+  describe "json.dump/2 — serialize a Python object as JSON into a file handle" do
+    test "json.dump(obj, f) writes JSON string to the file that can be read back" do
+      code = """
+      import json
+      data = {"key": "value", "num": 42}
+      with open("out.json", "w") as f:
+          json.dump(data, f)
+      with open("out.json", "r") as f:
+          result = f.read()
+      result
+      """
+
+      result = Pyex.run!(code, @fs_opts)
+      assert result =~ "key"
+      assert result =~ "value"
+      assert result =~ "42"
+    end
+
+    test "json.dump(obj, f, indent=2) writes pretty-printed JSON with newlines and indentation" do
+      code = """
+      import json
+      data = {"a": 1}
+      with open("pretty.json", "w") as f:
+          json.dump(data, f, indent=2)
+      with open("pretty.json", "r") as f:
+          result = f.read()
+      result
+      """
+
+      result = Pyex.run!(code, @fs_opts)
+      assert result =~ "\n"
+      assert result =~ "  "
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Gap 2: open(f, errors="ignore")
+  # ---------------------------------------------------------------------------
+  describe "open() errors kwarg — accept and ignore the encoding error handler" do
+    test "open(path, mode, errors='ignore') does not raise TypeError for unsupported kwarg" do
+      code = """
+      with open("test.txt", "w") as f:
+          f.write("hello")
+      with open("test.txt", "r", errors="ignore") as f:
+          data = f.read()
+      data
+      """
+
+      assert Pyex.run!(code, @fs_opts) == "hello"
+    end
+
+    test "open(path, mode, errors='replace') is also accepted without raising" do
+      code = """
+      with open("test.txt", "w") as f:
+          f.write("hello")
+      with open("test.txt", "r", errors="replace") as f:
+          data = f.read()
+      data
+      """
+
+      assert Pyex.run!(code, @fs_opts) == "hello"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Gap 3: open(f, "wb") / "rb" / "ab" — binary mode flags
+  # ---------------------------------------------------------------------------
+  describe "open() binary mode flags — strip 'b' and map to text equivalents" do
+    test "open(path, 'rb') strips the b flag and reads the file as if mode were 'r'" do
+      code = """
+      with open("test.txt", "w") as f:
+          f.write("binary read")
+      with open("test.txt", "rb") as f:
+          data = f.read()
+      data
+      """
+
+      assert Pyex.run!(code, @fs_opts) == "binary read"
+    end
+
+    test "open(path, 'wb') strips the b flag and writes the file as if mode were 'w'" do
+      code = """
+      with open("out.txt", "wb") as f:
+          f.write("binary write")
+      with open("out.txt", "r") as f:
+          data = f.read()
+      data
+      """
+
+      assert Pyex.run!(code, @fs_opts) == "binary write"
+    end
+
+    test "open(path, 'ab') strips the b flag and appends to the file as if mode were 'a'" do
+      code = """
+      with open("app.txt", "w") as f:
+          f.write("first")
+      with open("app.txt", "ab") as f:
+          f.write(" second")
+      with open("app.txt", "r") as f:
+          data = f.read()
+      data
+      """
+
+      assert Pyex.run!(code, @fs_opts) == "first second"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Gap 4: import sys — minimal sys module
+  # ---------------------------------------------------------------------------
+  describe "sys module — minimal stub so 'import sys' does not raise ModuleNotFoundError" do
+    test "sys.argv returns an empty list since there are no CLI arguments in the sandbox" do
+      assert Pyex.run!("import sys\nsys.argv") == []
+    end
+
+    test "sys.version returns a Python-style version string containing 'Python'" do
+      result = Pyex.run!("import sys\nsys.version")
+      assert is_binary(result)
+      assert result =~ "Python"
+    end
+
+    test "sys.maxsize returns a large integer matching Python's 64-bit sys.maxsize" do
+      result = Pyex.run!("import sys\nsys.maxsize")
+      assert is_integer(result)
+      assert result > 1_000_000_000
+    end
+
+    test "sys.stdout is accessible without raising AttributeError" do
+      code = """
+      import sys
+      sys.stdout
+      """
+
+      Pyex.run!(code)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **json.load(f) / json.dump(obj, f)**: Added file-handle variants that read/write via `{:io_call, fn}`, reusing existing `loads`/`dumps` logic
- **open(path, errors="ignore")**: Added `"errors"` to `@open_supported_kwargs` so the kwarg is accepted and ignored
- **open(path, "rb"/"wb"/"ab")**: Strip the `b` flag in `open_file_handle/2`, mapping binary modes to their text equivalents
- **import sys**: New minimal `Pyex.Stdlib.Sys` module with `argv`, `version`, `maxsize`, `stdout`, `stderr`, and `exit()`

## Test plan

- [x] 13 new tests in `test/pyex/stdlib/sandbox_gaps_test.exs` all pass
- [x] Updated existing `error_messages_test.exs` that expected `import sys` to fail
- [x] Full suite passes: 3325 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)