### PR TITLE
Remove dead clauses flagged by compiler warnings

### DIFF
--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -673,20 +673,14 @@ defmodule Pyex.Interpreter do
                         {value, env, ctx}
 
                       :error ->
-                        case Methods.resolve(instance, attr) do
-                          {:ok, method} ->
-                            {method, env, ctx}
+                        case Dunder.call_dunder(instance, "__getattr__", [attr], env, ctx) do
+                          {:ok, val, env, ctx} ->
+                            {val, env, ctx}
 
-                          :error ->
-                            case Dunder.call_dunder(instance, "__getattr__", [attr], env, ctx) do
-                              {:ok, val, env, ctx} ->
-                                {val, env, ctx}
-
-                              :not_found ->
-                                {{:exception,
-                                  "AttributeError: '#{Helpers.py_type(instance)}' object has no attribute '#{attr}'"},
-                                 env, ctx}
-                            end
+                          :not_found ->
+                            {{:exception,
+                              "AttributeError: '#{Helpers.py_type(instance)}' object has no attribute '#{attr}'"},
+                             env, ctx}
                         end
                     end
                 end

--- a/lib/pyex/stdlib/pydantic.ex
+++ b/lib/pyex/stdlib/pydantic.ex
@@ -300,12 +300,7 @@ defmodule Pyex.Stdlib.Pydantic do
 
   defp coerce(value, "Optional[" <> rest, class) do
     inner = String.trim_trailing(rest, "]")
-
-    if value == nil do
-      {:ok, nil}
-    else
-      coerce(value, inner, class)
-    end
+    coerce(value, inner, class)
   end
 
   defp coerce({:py_list, reversed, _}, "List[" <> rest, class) do

--- a/lib/pyex/stdlib/requests.ex
+++ b/lib/pyex/stdlib/requests.ex
@@ -103,15 +103,10 @@ defmodule Pyex.Stdlib.Requests do
                current_headers = Map.get(ctx2.heap, headers_id, PyDict.new())
                merged_kwargs = merge_session_headers(kwargs, current_headers)
 
-               case do_request(method, url, merged_kwargs) do
-                 {:io_call, inner_fn} ->
-                   ctx2 = Pyex.Ctx.pause_compute(ctx2)
-                   {result, env2, ctx2} = inner_fn.(env2, ctx2)
-                   {result, env2, Pyex.Ctx.resume_compute(ctx2)}
-
-                 result ->
-                   {result, env2, ctx2}
-               end
+               {:io_call, inner_fn} = do_request(method, url, merged_kwargs)
+               ctx2 = Pyex.Ctx.pause_compute(ctx2)
+               {result, env2, ctx2} = inner_fn.(env2, ctx2)
+               {result, env2, Pyex.Ctx.resume_compute(ctx2)}
              end}
           end}
        end

--- a/test/pyex/streaming_test.exs
+++ b/test/pyex/streaming_test.exs
@@ -482,8 +482,7 @@ defmodule Pyex.StreamingTest do
       {:ok, app} = Lambda.boot(@generator_app)
       {:ok, resp, _app} = Lambda.handle_stream(app, %{method: "GET", path: "/stream"})
 
-      assert is_function(resp.chunks) or
-               (is_struct(resp.chunks) and resp.chunks.__struct__ == Stream)
+      assert is_function(resp.chunks)
 
       refute is_list(resp.chunks)
 


### PR DESCRIPTION
## Summary
- Drop four unreachable branches the Elixir type checker flagged during compile/test:
  - `pydantic.ex` Optional coerce: nil is already handled by an earlier clause
  - `requests.ex` session method: `do_request/3` always returns `{:io_call, _}`
  - `interpreter.ex` getattr fallback: `Methods.resolve` has no clause matching class instances
  - `streaming_test.exs`: `resp.chunks` is always a function, not a `Stream` struct

## Test plan
- [x] `mix format`
- [x] `mix compile --warnings-as-errors` (clean for pyex)
- [x] `mix test` — 3352 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)