### PR TITLE
Add sys.path, urllib.request.urlopen, and requests.__version__

### DIFF
--- a/lib/pyex/interpreter/import.ex
+++ b/lib/pyex/interpreter/import.ex
@@ -77,9 +77,6 @@ defmodule Pyex.Interpreter.Import do
   Returns a helpful error suffix for unknown module names.
   """
   @spec import_hint(String.t()) :: String.t()
-  def import_hint("urllib.request"), do: ". Use 'import requests' instead"
-  def import_hint("urllib.error"), do: ". Use 'import requests' instead"
-
   def import_hint(name) when name in ["urllib2", "http", "httplib", "httpx", "aiohttp"],
     do: ". Use 'import requests' instead"
 

--- a/lib/pyex/stdlib/requests.ex
+++ b/lib/pyex/stdlib/requests.ex
@@ -36,9 +36,23 @@ defmodule Pyex.Stdlib.Requests do
       "head" => {:builtin_kw, &do_head/2},
       "options" => {:builtin_kw, &do_options/2},
       "Session" => {:builtin, fn [] -> build_session() end},
-      "HTTPError" => "requests.HTTPError"
+      "HTTPError" => "requests.HTTPError",
+      "__version__" => "2.31.0"
     }
   end
+
+  @doc """
+  Public entry point used by `urllib.request.urlopen` to reuse the same
+  HTTP client, network-policy enforcement, and telemetry pipeline as
+  `requests.get/post/...`. Returns an `{:io_call, fn}` whose result is
+  the same response py_dict as `requests.get`.
+  """
+  @spec request_io_call(
+          atom(),
+          String.t(),
+          %{optional(String.t()) => Pyex.Interpreter.pyvalue()}
+        ) :: {:io_call, (Pyex.Env.t(), Pyex.Ctx.t() -> {term(), Pyex.Env.t(), Pyex.Ctx.t()})}
+  def request_io_call(method, url, kwargs), do: do_request(method, url, kwargs)
 
   @spec do_get(
           [Pyex.Interpreter.pyvalue()],

--- a/lib/pyex/stdlib/sys.ex
+++ b/lib/pyex/stdlib/sys.ex
@@ -14,6 +14,7 @@ defmodule Pyex.Stdlib.Sys do
   def module_value do
     %{
       "argv" => {:py_list, [], 0},
+      "path" => {:py_list, [], 0},
       "version" => "3.11.0 (Pyex sandbox) [Python compatible]",
       "maxsize" => 9_223_372_036_854_775_807,
       "stdin" => {:stringio, make_ref()},

--- a/lib/pyex/stdlib/urllib.ex
+++ b/lib/pyex/stdlib/urllib.ex
@@ -1,11 +1,14 @@
 defmodule Pyex.Stdlib.Urllib do
   @moduledoc """
-  Minimal `urllib.parse` support.
+  `urllib.parse` and a minimal `urllib.request.urlopen` that delegates to
+  the same HTTP client as `requests.get`, so network policy, telemetry,
+  and I/O-budget accounting are identical.
   """
 
   @behaviour Pyex.Stdlib.Module
 
-  alias Pyex.Interpreter
+  alias Pyex.{Interpreter, PyDict}
+  alias Pyex.Stdlib.Requests
 
   @impl Pyex.Stdlib.Module
   @spec module_value() :: Pyex.Stdlib.Module.module_value()
@@ -17,9 +20,70 @@ defmodule Pyex.Stdlib.Urllib do
         "unquote" => {:builtin, &url_unquote/1},
         "urlparse" => {:builtin, &urlparse/1},
         "urlencode" => {:builtin, &urlencode/1}
+      },
+      "request" => %{
+        "urlopen" => {:builtin, &urlopen/1}
+      },
+      "error" => %{
+        "URLError" => "urllib.error.URLError",
+        "HTTPError" => "urllib.error.HTTPError"
       }
     }
   end
+
+  @spec urlopen([Interpreter.pyvalue()]) ::
+          {:io_call, (Pyex.Env.t(), Pyex.Ctx.t() -> {term(), Pyex.Env.t(), Pyex.Ctx.t()})}
+          | {:exception, String.t()}
+  defp urlopen([url]) when is_binary(url) do
+    {:io_call, inner} = Requests.request_io_call(:get, url, %{})
+
+    {:io_call,
+     fn env, ctx ->
+       case inner.(env, ctx) do
+         {{:exception, _} = signal, env, ctx} ->
+           {signal, env, ctx}
+
+         {response, env, ctx} ->
+           {build_urlopen_response(response), env, ctx}
+       end
+     end}
+  end
+
+  defp urlopen(_), do: {:exception, "TypeError: urlopen() expects a URL string"}
+
+  @spec build_urlopen_response(Interpreter.pyvalue()) :: Interpreter.pyvalue()
+  defp build_urlopen_response({:py_dict, _, _} = resp) do
+    status = PyDict.get(resp, "status_code", 0)
+    text = PyDict.get(resp, "text", "")
+    headers = PyDict.get(resp, "headers", PyDict.from_pairs([]))
+
+    getheader = fn
+      [name] when is_binary(name) ->
+        PyDict.get(headers, String.downcase(name), nil)
+
+      [name, default] when is_binary(name) ->
+        PyDict.get(headers, String.downcase(name), default)
+
+      _ ->
+        {:exception, "TypeError: getheader() expects a header name"}
+    end
+
+    read = fn
+      [] -> text
+      [n] when is_integer(n) and n >= 0 -> String.slice(text, 0, n)
+      _ -> {:exception, "TypeError: read() expects 0 or 1 integer argument"}
+    end
+
+    PyDict.from_pairs([
+      {"status", status},
+      {"code", status},
+      {"read", {:builtin, read}},
+      {"getheader", {:builtin, getheader}},
+      {"headers", headers}
+    ])
+  end
+
+  defp build_urlopen_response(other), do: other
 
   @spec urljoin([Interpreter.pyvalue()]) :: String.t() | {:exception, String.t()}
   defp urljoin([base, url]) when is_binary(base) and is_binary(url),

--- a/test/pyex/error_messages_test.exs
+++ b/test/pyex/error_messages_test.exs
@@ -205,14 +205,12 @@ defmodule Pyex.ErrorMessagesTest do
       end
     end
 
-    test "unsupported urllib submodule suggests requests" do
-      {:error, %Error{message: msg}} = Pyex.run("import urllib.request")
-      assert msg =~ "requests"
+    test "urllib.request imports successfully and exposes urlopen" do
+      {:ok, _result, _ctx} = Pyex.run("from urllib.request import urlopen\ncallable(urlopen)")
     end
 
-    test "urllib.error suggests requests" do
-      {:error, %Error{message: msg}} = Pyex.run("import urllib.error")
-      assert msg =~ "requests"
+    test "urllib.error imports successfully" do
+      {:ok, _result, _ctx} = Pyex.run("import urllib.error")
     end
 
     test "sys module imports successfully" do

--- a/test/pyex/stdlib/sandbox_gaps_test.exs
+++ b/test/pyex/stdlib/sandbox_gaps_test.exs
@@ -223,6 +223,128 @@ defmodule Pyex.Stdlib.SandboxGapsTest do
   end
 
   # ---------------------------------------------------------------------------
+  # Gap 5: sys.path is a mutable list, not a dict
+  # ---------------------------------------------------------------------------
+  describe "sys.path — list of import search paths" do
+    test "sys.path.insert(0, p) prepends and sys.path[0] returns the inserted value" do
+      code = """
+      import sys
+      sys.path.insert(0, "/app")
+      sys.path.insert(0, "/first")
+      (sys.path[0], sys.path[1])
+      """
+
+      assert Pyex.run!(code) == {:tuple, ["/first", "/app"]}
+    end
+
+    test "sys.path.append adds to the end and len() reflects the new length" do
+      code = """
+      import sys
+      before = len(sys.path)
+      sys.path.append("/lib/one")
+      sys.path.append("/lib/two")
+      (len(sys.path) - before, sys.path[-2], sys.path[-1])
+      """
+
+      assert Pyex.run!(code) == {:tuple, [2, "/lib/one", "/lib/two"]}
+    end
+
+    test "sys.argv[1] parsing under `if __name__ == '__main__'` matches a CLI-style script epilogue" do
+      # Mirrors the epilogue of an LLM-generated API-client script:
+      #   if __name__ == "__main__":
+      #       import sys
+      #       vid = int(sys.argv[1]) if len(sys.argv) > 1 else 50227
+      # We pre-populate sys.argv to simulate `python3 /api.py 50227`.
+      code = """
+      import sys
+      sys.argv.append("/api.py")
+      sys.argv.append("50227")
+
+      parsed = None
+      default_used = None
+      if __name__ == "__main__":
+          vid = int(sys.argv[1]) if len(sys.argv) > 1 else 50227
+          parsed = vid
+          default_used = len(sys.argv) <= 1
+      (parsed, default_used)
+      """
+
+      assert Pyex.run!(code) == {:tuple, [50227, false]}
+    end
+
+    test "sys.argv default branch: len(sys.argv) <= 1 falls through to the literal default" do
+      code = """
+      import sys
+      vid = int(sys.argv[1]) if len(sys.argv) > 1 else 50227
+      vid
+      """
+
+      assert Pyex.run!(code) == 50227
+    end
+
+    test "sys.path mutations persist across statements within a single run" do
+      code = """
+      import sys
+      sys.path.append("/persisted")
+      "/persisted" in sys.path
+      """
+
+      assert Pyex.run!(code) == true
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Gap 6: module dunder attributes resolve via attribute access
+  # ---------------------------------------------------------------------------
+  describe "imported modules expose dunder attributes via attribute access" do
+    test "requests.__version__ is a non-empty dotted version string" do
+      code = """
+      import requests
+      v = requests.__version__
+      (isinstance(v, str), len(v) > 0, "." in v)
+      """
+
+      assert Pyex.run!(code) == {:tuple, [true, true, true]}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Gap 7: urllib.request — urlopen returns a response with read() and status
+  # ---------------------------------------------------------------------------
+  describe "urllib.request.urlopen — HTTP GET returning a response object" do
+    @describetag :external_http
+    @describetag timeout: 30_000
+
+    test "urlopen(url).read() returns a body that echoes the query arg and status is 200" do
+      code = """
+      from urllib.request import urlopen
+      resp = urlopen("https://postman-echo.com/get?source=pyex")
+      body = resp.read()
+      (resp.status, "pyex" in body)
+      """
+
+      assert Pyex.run!(code,
+               network: [%{allowed_url_prefix: "https://postman-echo.com/get"}]
+             ) == {:tuple, [200, true]}
+    end
+
+    test "urlopen response exposes getheader('Content-Type') matching the server-reported type" do
+      code = """
+      from urllib.request import urlopen
+      resp = urlopen("https://postman-echo.com/get")
+      ctype = resp.getheader("Content-Type")
+      # Req returns header values as a list; take the first entry.
+      first = ctype[0] if isinstance(ctype, list) else ctype
+      (resp.status, first.startswith("application/json"))
+      """
+
+      assert Pyex.run!(code,
+               network: [%{allowed_url_prefix: "https://postman-echo.com/get"}]
+             ) == {:tuple, [200, true]}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Regex evaluation on large inputs with bounded quantifiers
   # ---------------------------------------------------------------------------
   describe "re.search with bounded quantifiers on large inputs" do


### PR DESCRIPTION
## Summary
- `sys.path` is now a mutable `py_list` — `insert`/`append`/indexing/`len()` all work, and mutations persist across statements via the existing list-mutate writeback path. Previously `sys.path.insert(0, '/')` raised `AttributeError: 'dict' object has no attribute 'path'`.
- `urllib.request.urlopen` implemented by delegating to a new public `Pyex.Stdlib.Requests.request_io_call/3`, so it shares the HTTP client, network policy, telemetry, and I/O-budget accounting with `requests.get`. Response exposes `status`, `code`, `read()`, `getheader()`, `headers`.
- `urllib.error` added as a minimal submodule so `import urllib.error` resolves.
- `requests.__version__` exposed (was raising `AttributeError` on dunder access).
- Removed stale `import_hint` clauses for `urllib.request`/`urllib.error` that told users to "use requests instead".

All of these gaps surfaced from an LLM eval agent trying to run an API-client script — `sys.path.insert(0, '/'); import api`, `int(sys.argv[1])`, `requests.__version__`, `from urllib.request import urlopen`.

## Test plan
- [x] `mix test` — 3390 tests, 0 failures
- [x] `mix test --include external_http test/pyex/stdlib/sandbox_gaps_test.exs` — live postman-echo GETs pass
- [x] `mix format` / `mix compile --warnings-as-errors` clean
- [x] New correctness tests (not just non-crashing):
  - `sys.path.insert(0, p)` ordering across two inserts
  - `sys.path.append` length delta and last-two elements
  - `sys.path` mutation persistence across statements
  - `sys.argv[1]` parsing under `if __name__ == "__main__"` (mirrors the agent's script epilogue)
  - `sys.argv` default branch when no args supplied
  - `requests.__version__` is a non-empty dotted string
  - `urllib.request.urlopen` returns `status == 200` and body contains query arg (live HTTP)
  - `urllib.request.urlopen` `getheader("Content-Type")` starts with `application/json` (live HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)