### PR TITLE
ci: add release-please workflow for hex.pm publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,53 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: elixir
+
+  publish-hex:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "28.4"
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: deps
+          key: deps-${{ runner.os }}-28.4-1.19-${{ hashFiles('**/mix.lock') }}
+          restore-keys: deps-${{ runner.os }}-28.4-1.19-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Run tests
+        run: mix test
+
+      - name: Publish to Hex.pm
+        run: mix hex.publish --yes
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-please.yml` — Conventional Commits on `main` open a Release PR; merging it tags + creates a GitHub release + runs `mix hex.publish`.
- Uses OTP 28.4 / Elixir 1.19 to match `ci.yml` and `.tool-versions`.

## Test plan
- [ ] Merge this PR (chore commit, no release triggered).
- [ ] Land a follow-up PR with a `feat:` or `fix:` title — release-please should open a release PR shortly after.
- [ ] Review release PR's changelog + version bump, merge it, confirm tag + GitHub release + Hex publish all succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)