### PR TITLE
Python semantics hardening: exception classes as values, raise-from __cause__, generator exceptions, super().__init__, f-string nested specs, heap-allocated StringIO

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -96,21 +96,4 @@ Known limitations:
   allows it directly because count/cycle return iterator objects natively.
   In Pyex they return bounded lists/ranges (works with `list()`, `for`,
   `islice`, etc., just not `next()` directly).
-- `csv.writer(io.StringIO())` doesn't propagate writes back to the
-  StringIO variable because Pyex's StringIO is value-typed.  Workaround:
-  use `csv.writer()` without args (Pyex extension) to get string output
-  from `writerow(...)` directly.  Fix requires heap-allocating StringIO.
-- F-string nested format specs (e.g. `f"{x:{width}d}"`) are not yet
-  supported.  The spec string must be parsed as a nested f-string; Pyex
-  currently parses the literal text.
-- Exception classes like `ValueError`, `TypeError`, `KeyboardInterrupt`,
-  `BaseException` aren't first-class runtime values.  They work as
-  `except` targets and `raise X` instantiation, but can't appear in
-  expressions like `issubclass(ValueError, Exception)` or tuple literals
-  inside an `except` clause: `except (ValueError, TypeError) as e:`.
-- `raise X from Y` doesn't set the `__cause__` attribute on the raised
-  exception.
-- User-defined `__init__` calling `super().__init__(msg)` in an
-  exception subclass mixes up the args list.
-- Exceptions raised inside a generator body don't propagate cleanly to
-  the consumer (`list(gen())` raises TypeError instead of the inner exc).
+

--- a/lib/pyex/builtins.ex
+++ b/lib/pyex/builtins.ex
@@ -68,11 +68,26 @@ defmodule Pyex.Builtins do
           Env.put(env, name, {:builtin, fun})
       end)
 
-    Enum.reduce(type_constructors(), env, fn {name, fun}, env ->
-      Env.put(env, name, {:builtin_type, name, fun})
-    end)
-    |> Env.put("Ellipsis", :ellipsis)
+    env =
+      Enum.reduce(type_constructors(), env, fn {name, fun}, env ->
+        Env.put(env, name, {:builtin_type, name, fun})
+      end)
+
+    env = Enum.reduce(exception_class_names(), env, &Env.put(&2, &1, {:exception_class, &1}))
+
+    Env.put(env, "Ellipsis", :ellipsis)
   end
+
+  @doc """
+  Returns the full list of Python builtin exception class names.
+
+  Each becomes a first-class `{:exception_class, name}` runtime value in
+  the environment, so it can appear in expressions like `isinstance(e,
+  ValueError)`, `except (A, B) as e`, and `[ValueError, TypeError]`.
+  Sourced from `Pyex.ExceptionsHierarchy.all_names/0`.
+  """
+  @spec exception_class_names() :: [String.t()]
+  def exception_class_names, do: Pyex.ExceptionsHierarchy.all_names()
 
   @spec all() :: [{String.t(), ([Interpreter.pyvalue()] -> Interpreter.pyvalue())}]
   defp all do
@@ -825,6 +840,13 @@ defmodule Pyex.Builtins do
   defp builtin_list([{:deque, items, _}]), do: items
   defp builtin_list([{:generator, items}]), do: items
 
+  # When a generator raises during accumulation, we receive a
+  # {:generator_error, items, msg}.  Consuming the generator via list()
+  # should surface that exception after yielding partial results, but
+  # in practice CPython raises immediately from `list(gen())` — we do
+  # the same and discard the partial items.
+  defp builtin_list([{:generator_error, _items, msg}]), do: {:exception, msg}
+
   defp builtin_list([{:range, _, _, _} = r]) do
     case range_to_list(r) do
       {:exception, _} = err -> err
@@ -933,12 +955,18 @@ defmodule Pyex.Builtins do
     name == target_name or check_bases(bases, target_name)
   end
 
+  # Built-in exception classes as runtime values: handle both sides.
+  defp builtin_isinstance([{:instance, {:class, name, bases, _}, _}, {:exception_class, target}]) do
+    Pyex.ExceptionsHierarchy.subclass?(name, target) or check_bases(bases, target)
+  end
+
   defp builtin_isinstance([val, {:tuple, types}]) do
     Enum.any?(types, fn t ->
       builtin_isinstance([val, t])
     end)
   end
 
+  defp builtin_isinstance([val, {:exception_class, _}]) when not is_tuple(val), do: false
   defp builtin_isinstance([_, _]), do: false
 
   @spec builtin_issubclass([Interpreter.pyvalue()]) :: boolean() | {:exception, String.t()}
@@ -956,6 +984,10 @@ defmodule Pyex.Builtins do
     end)
   end
 
+  defp builtin_issubclass([{:class, name, bases, _}, {:exception_class, target}]) do
+    Pyex.ExceptionsHierarchy.subclass?(name, target) or check_bases(bases, target)
+  end
+
   defp builtin_issubclass([{:class, _, _, _}, _]), do: false
 
   # Built-in type hierarchy: bool is a subtype of int
@@ -968,6 +1000,22 @@ defmodule Pyex.Builtins do
   end
 
   defp builtin_issubclass([{:builtin_type, _, _}, _]), do: false
+
+  # Exception classes: subclass relationships both ways.
+  defp builtin_issubclass([{:exception_class, sub}, {:exception_class, sup}]) do
+    Pyex.ExceptionsHierarchy.subclass?(sub, sup)
+  end
+
+  defp builtin_issubclass([{:exception_class, _} = cls, {:tuple, types}]) do
+    Enum.any?(types, fn t -> builtin_issubclass([cls, t]) end)
+  end
+
+  defp builtin_issubclass([{:exception_class, sub}, {:class, sup, bases, _}]) do
+    Pyex.ExceptionsHierarchy.subclass?(sub, sup) or
+      Enum.any?(bases, fn _ -> false end)
+  end
+
+  defp builtin_issubclass([{:exception_class, _}, _]), do: false
 
   defp builtin_issubclass([arg1, _arg2]) do
     {:exception, "TypeError: issubclass() arg 1 must be a class, not #{pytype(arg1)}"}
@@ -1986,6 +2034,8 @@ defmodule Pyex.Builtins do
 
   def py_repr({:instance, {:class, name, _, _}, _}), do: "<#{name} instance>"
   def py_repr({:class, name, _, _}), do: "<class '#{name}'>"
+  def py_repr({:exception_class, name}), do: "<class '#{name}'>"
+  def py_repr({:builtin_type, name, _}), do: "<class '#{name}'>"
   def py_repr({:function, name, _, _, _}), do: "<function #{name}>"
   def py_repr({:builtin, _}), do: "<built-in function>"
   def py_repr({:builtin_kw, _}), do: "<built-in function>"

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -733,10 +733,19 @@ defmodule Pyex.Ctx do
 
   @spec deep_deref(t(), term(), MapSet.t()) :: term()
   def deep_deref(%__MODULE__{} = ctx, {:ref, id} = ref, visited) do
-    if MapSet.member?(visited, id) do
-      ref
-    else
-      deep_deref(ctx, deref(ctx, ref), MapSet.put(visited, id))
+    cond do
+      MapSet.member?(visited, id) ->
+        ref
+
+      # StringIO must round-trip through heap refs so callers with an
+      # aliased reference (e.g. a csv.writer holding it in a closure)
+      # observe each other's writes.  Preserve the ref; consumers who
+      # actually need the buffer string call `deref` themselves.
+      match?({:stringio, _}, deref(ctx, ref)) ->
+        ref
+
+      true ->
+        deep_deref(ctx, deref(ctx, ref), MapSet.put(visited, id))
     end
   end
 

--- a/lib/pyex/exceptions_hierarchy.ex
+++ b/lib/pyex/exceptions_hierarchy.ex
@@ -1,0 +1,120 @@
+defmodule Pyex.ExceptionsHierarchy do
+  @moduledoc """
+  Built-in Python exception class hierarchy.
+
+  Maps each concrete exception name to its direct parent.  Used by the
+  interpreter's `except` matcher, by `isinstance` and `issubclass` when
+  comparing `{:exception_class, _}` runtime values, and by
+  `{:exception_class, _}` runtime class identity checks.
+
+  Sourced from https://docs.python.org/3/library/exceptions.html#exception-hierarchy.
+  """
+
+  @parents %{
+    "BaseException" => nil,
+    "SystemExit" => "BaseException",
+    "KeyboardInterrupt" => "BaseException",
+    "GeneratorExit" => "BaseException",
+    "Exception" => "BaseException",
+    "StopIteration" => "Exception",
+    "StopAsyncIteration" => "Exception",
+    "ArithmeticError" => "Exception",
+    "FloatingPointError" => "ArithmeticError",
+    "OverflowError" => "ArithmeticError",
+    "ZeroDivisionError" => "ArithmeticError",
+    "AssertionError" => "Exception",
+    "AttributeError" => "Exception",
+    "BufferError" => "Exception",
+    "EOFError" => "Exception",
+    "ImportError" => "Exception",
+    "ModuleNotFoundError" => "ImportError",
+    "LookupError" => "Exception",
+    "IndexError" => "LookupError",
+    "KeyError" => "LookupError",
+    "MemoryError" => "Exception",
+    "NameError" => "Exception",
+    "UnboundLocalError" => "NameError",
+    "OSError" => "Exception",
+    "BlockingIOError" => "OSError",
+    "ChildProcessError" => "OSError",
+    "ConnectionError" => "OSError",
+    "BrokenPipeError" => "ConnectionError",
+    "ConnectionAbortedError" => "ConnectionError",
+    "ConnectionRefusedError" => "ConnectionError",
+    "ConnectionResetError" => "ConnectionError",
+    "FileExistsError" => "OSError",
+    "FileNotFoundError" => "OSError",
+    "InterruptedError" => "OSError",
+    "IsADirectoryError" => "OSError",
+    "NotADirectoryError" => "OSError",
+    "PermissionError" => "OSError",
+    "ProcessLookupError" => "OSError",
+    "TimeoutError" => "OSError",
+    "ReferenceError" => "Exception",
+    "RuntimeError" => "Exception",
+    "NotImplementedError" => "RuntimeError",
+    "RecursionError" => "RuntimeError",
+    "SyntaxError" => "Exception",
+    "IndentationError" => "SyntaxError",
+    "TabError" => "IndentationError",
+    "SystemError" => "Exception",
+    "TypeError" => "Exception",
+    "ValueError" => "Exception",
+    "UnicodeError" => "ValueError",
+    "UnicodeDecodeError" => "UnicodeError",
+    "UnicodeEncodeError" => "UnicodeError",
+    "UnicodeTranslateError" => "UnicodeError",
+    "Warning" => "Exception",
+    "DeprecationWarning" => "Warning",
+    "PendingDeprecationWarning" => "Warning",
+    "RuntimeWarning" => "Warning",
+    "SyntaxWarning" => "Warning",
+    "UserWarning" => "Warning",
+    "FutureWarning" => "Warning",
+    "ImportWarning" => "Warning",
+    "UnicodeWarning" => "Warning",
+    "BytesWarning" => "Warning",
+    "ResourceWarning" => "Warning"
+  }
+
+  @doc """
+  Returns true when `class_name` is a built-in exception class whose
+  parent chain includes `target_name`, or when the two names are equal.
+  """
+  @spec subclass?(String.t(), String.t()) :: boolean()
+  def subclass?(name, name), do: true
+  def subclass?(name, target), do: Enum.member?(chain(name), target)
+
+  @doc """
+  Returns `true` when `name` is a registered built-in exception class.
+  """
+  @spec known?(String.t()) :: boolean()
+  def known?(name), do: Map.has_key?(@parents, name)
+
+  @doc """
+  Returns the direct parent of `name`, or `nil` if `name` is the root
+  (`BaseException`) or is not a registered exception class.
+  """
+  @spec parent(String.t()) :: String.t() | nil
+  def parent(name), do: Map.get(@parents, name)
+
+  @doc """
+  Returns the full ancestry chain for `name`, starting with the name
+  itself and walking to `BaseException`.  Returns `[]` for unknown
+  names.
+  """
+  @spec chain(String.t()) :: [String.t()]
+  def chain(name) do
+    case Map.fetch(@parents, name) do
+      {:ok, nil} -> [name]
+      {:ok, parent} -> [name | chain(parent)]
+      :error -> []
+    end
+  end
+
+  @doc """
+  Returns the list of all registered exception class names.
+  """
+  @spec all_names() :: [String.t()]
+  def all_names, do: Map.keys(@parents)
+end

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -83,6 +83,7 @@ defmodule Pyex.Interpreter do
           | {:lru_cached_function, pyvalue(), non_neg_integer()}
           | {:cached_property, pyvalue()}
           | {:ref, non_neg_integer()}
+          | {:exception_class, String.t()}
 
   @typep signal ::
            {:returned, pyvalue()}
@@ -347,14 +348,15 @@ defmodule Pyex.Interpreter do
             {:ok, {:class, _, _, _} = base} ->
               base
 
+            {:ok, {:exception_class, _} = exc} ->
+              # Reify to a real {:class, name, bases, attrs} so the MRO
+              # and super() paths find the builtin __init__ etc.
+              exception_instance_class(exc)
+
             _ ->
-              # Builtin exception types (Exception, ValueError, ...) are
-              # not bound as real classes in the env -- they're handled as
-              # tagged strings at raise/except time. To make
-              # `class MyError(Exception): super().__init__(...)` work,
-              # synthesize a stub class for any recognized exception base
-              # name. Other unknown base names still fall through to nil
-              # so we don't silently mask typos.
+              # Fallback: legacy stub for bases that aren't in env but
+              # happen to be registered exception names (for very old
+              # callsites that may predate the exception_class builtins).
               builtin_exception_base_stub(base_name)
           end
       end)
@@ -580,6 +582,10 @@ defmodule Pyex.Interpreter do
 
   def eval({:raise, meta, [expr]}, env, ctx) do
     Exceptions.eval_raise(expr, meta, env, ctx)
+  end
+
+  def eval({:raise, meta, [expr, cause_expr]}, env, ctx) do
+    Exceptions.eval_raise_from(expr, cause_expr, meta, env, ctx)
   end
 
   def eval({:assert, _, [condition, msg_expr]}, env, ctx) do
@@ -857,6 +863,15 @@ defmodule Pyex.Interpreter do
             case result do
               {:ok, {:function, _, _, _, _} = func, owner_class} ->
                 {{:bound_method, instance, func, owner_class}, env, ctx}
+
+              # Builtin attrs on a parent class should still receive
+              # `self` as first arg (matches Python's bound-method call
+              # semantics).
+              {:ok, {:builtin, _} = builtin, _owner} ->
+                {{:bound_method, instance, builtin}, env, ctx}
+
+              {:ok, {:builtin_kw, _} = builtin, _owner} ->
+                {{:bound_method, instance, builtin}, env, ctx}
 
               {:ok, value, _owner} ->
                 {value, env, ctx}
@@ -1639,6 +1654,13 @@ defmodule Pyex.Interpreter do
     call_function({:builtin, fun}, args, kwargs, env, ctx)
   end
 
+  # Calling a built-in exception class constructs an instance whose `args`
+  # tuple holds the positional arguments, matching CPython semantics.
+  def call_function({:exception_class, _name} = cls, args, _kwargs, env, ctx) do
+    instance = {:instance, exception_instance_class(cls), %{"args" => {:tuple, args}}}
+    {instance, env, ctx}
+  end
+
   def call_function({:builtin_kw, fun}, args, kwargs, env, ctx) do
     Invocation.call_builtin_kw(fun, args, kwargs, env, ctx)
   end
@@ -1727,6 +1749,39 @@ defmodule Pyex.Interpreter do
 
   def call_function(val, _args, _kwargs, env, ctx) do
     {{:exception, "TypeError: '#{Helpers.py_type(val)}' object is not callable"}, env, ctx}
+  end
+
+  @doc false
+  @spec exception_instance_class(pyvalue()) :: pyvalue()
+  def exception_instance_class({:exception_class, name}) do
+    # Represent a built-in exception class as {:class, name, bases, attrs}
+    # so the rest of the interpreter (attribute access, method dispatch,
+    # isinstance on user-defined subclasses) can treat it uniformly.
+    # The only method we expose is __init__, which replaces self.args
+    # with its positional arguments (matches CPython's BaseException).
+    bases =
+      case Pyex.ExceptionsHierarchy.parent(name) do
+        nil -> []
+        parent -> [{:exception_class, parent}]
+      end
+
+    attrs = %{
+      "__init__" =>
+        {:builtin,
+         fn
+           [{:instance, cls, inst_attrs} | rest] ->
+             # Replaces self.args with the positional args, matching
+             # BaseException.__init__.  Returned via {:mutate, ...} so
+             # the caller updates the heap cell backing `self`.
+             new_instance = {:instance, cls, Map.put(inst_attrs, "args", {:tuple, rest})}
+             {:mutate, new_instance, nil}
+
+           _ ->
+             nil
+         end}
+    }
+
+    {:class, name, bases, attrs}
   end
 
   @doc false

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -2109,13 +2109,39 @@ defmodule Pyex.Interpreter do
       {raw, env, ctx} ->
         val = Ctx.deref(ctx, raw)
 
-        case Pyex.Interpreter.FstringFormat.apply_format_spec(val, format_spec) do
-          {:exception, _} = signal ->
+        # Resolve nested expressions within the spec, e.g. `{w}d` -> `8d`.
+        case interpolate_format_spec(format_spec, env, ctx) do
+          {{:exception, _} = signal, env, ctx} ->
             {signal, env, ctx}
 
-          formatted ->
-            eval_fstring(rest, <<acc::binary, formatted::binary>>, env, ctx)
+          {resolved_spec, env, ctx} ->
+            case Pyex.Interpreter.FstringFormat.apply_format_spec(val, resolved_spec) do
+              {:exception, _} = signal ->
+                {signal, env, ctx}
+
+              formatted ->
+                eval_fstring(rest, <<acc::binary, formatted::binary>>, env, ctx)
+            end
         end
+    end
+  end
+
+  # Expands `{expr}` inside a format spec by evaluating and stringifying
+  # each expression.  Matches CPython's nested f-string spec semantics.
+  # Literal `{{` / `}}` still escape to single braces.
+  @spec interpolate_format_spec(String.t(), Env.t(), Ctx.t()) ::
+          {String.t(), Env.t(), Ctx.t()} | {{:exception, String.t()}, Env.t(), Ctx.t()}
+  defp interpolate_format_spec(spec, env, ctx) do
+    if String.contains?(spec, "{") do
+      case Parser.parse_fstring_template(spec) do
+        {:ok, parts} ->
+          eval_fstring(parts, <<>>, env, ctx)
+
+        {:error, msg} ->
+          {{:exception, "ValueError: invalid format spec: #{msg}"}, env, ctx}
+      end
+    else
+      {spec, env, ctx}
     end
   end
 

--- a/lib/pyex/interpreter/class_lookup.ex
+++ b/lib/pyex/interpreter/class_lookup.ex
@@ -41,9 +41,21 @@ defmodule Pyex.Interpreter.ClassLookup do
   def c3_linearize({:class, _, [], _} = class), do: [class]
 
   def c3_linearize({:class, _, bases, _} = class) do
-    parent_mros = Enum.map(bases, &c3_linearize/1)
-    [class | c3_merge(parent_mros ++ [bases])]
+    reified = Enum.map(bases, &reify_base/1)
+    parent_mros = Enum.map(reified, &c3_linearize/1)
+    [class | c3_merge(parent_mros ++ [reified])]
   end
+
+  # Built-in exception classes are represented as {:exception_class, name}
+  # in the environment but participate in class lookup as if they were
+  # {:class, name, [parent_exc], %{}} classes.  Reify on demand.
+  def c3_linearize({:exception_class, _} = exc) do
+    c3_linearize(Interpreter.exception_instance_class(exc))
+  end
+
+  @spec reify_base(Interpreter.pyvalue()) :: Interpreter.pyvalue()
+  defp reify_base({:exception_class, _} = exc), do: Interpreter.exception_instance_class(exc)
+  defp reify_base(other), do: other
 
   @spec c3_merge([[Interpreter.pyvalue()]]) :: [Interpreter.pyvalue()]
   defp c3_merge(lists) do

--- a/lib/pyex/interpreter/control_flow.ex
+++ b/lib/pyex/interpreter/control_flow.ex
@@ -464,7 +464,7 @@ defmodule Pyex.Interpreter.ControlFlow do
 
   defp class_is_subclass?(class_name, target_name, env, ctx) do
     cond do
-      builtin_exception_subclass?(class_name, target_name) ->
+      Pyex.ExceptionsHierarchy.subclass?(class_name, target_name) ->
         true
 
       true ->
@@ -495,92 +495,6 @@ defmodule Pyex.Interpreter.ControlFlow do
           _ ->
             false
         end
-    end
-  end
-
-  # Python's builtin exception hierarchy.  Each entry maps a concrete
-  # exception name to its direct parent (we walk the chain for subclass
-  # queries).  Sourced from:
-  # https://docs.python.org/3/library/exceptions.html#exception-hierarchy
-  @builtin_exception_parents %{
-    "BaseException" => nil,
-    "SystemExit" => "BaseException",
-    "KeyboardInterrupt" => "BaseException",
-    "GeneratorExit" => "BaseException",
-    "Exception" => "BaseException",
-    "StopIteration" => "Exception",
-    "StopAsyncIteration" => "Exception",
-    "ArithmeticError" => "Exception",
-    "FloatingPointError" => "ArithmeticError",
-    "OverflowError" => "ArithmeticError",
-    "ZeroDivisionError" => "ArithmeticError",
-    "AssertionError" => "Exception",
-    "AttributeError" => "Exception",
-    "BufferError" => "Exception",
-    "EOFError" => "Exception",
-    "ImportError" => "Exception",
-    "ModuleNotFoundError" => "ImportError",
-    "LookupError" => "Exception",
-    "IndexError" => "LookupError",
-    "KeyError" => "LookupError",
-    "MemoryError" => "Exception",
-    "NameError" => "Exception",
-    "UnboundLocalError" => "NameError",
-    "OSError" => "Exception",
-    "BlockingIOError" => "OSError",
-    "ChildProcessError" => "OSError",
-    "ConnectionError" => "OSError",
-    "BrokenPipeError" => "ConnectionError",
-    "ConnectionAbortedError" => "ConnectionError",
-    "ConnectionRefusedError" => "ConnectionError",
-    "ConnectionResetError" => "ConnectionError",
-    "FileExistsError" => "OSError",
-    "FileNotFoundError" => "OSError",
-    "InterruptedError" => "OSError",
-    "IsADirectoryError" => "OSError",
-    "NotADirectoryError" => "OSError",
-    "PermissionError" => "OSError",
-    "ProcessLookupError" => "OSError",
-    "TimeoutError" => "OSError",
-    "ReferenceError" => "Exception",
-    "RuntimeError" => "Exception",
-    "NotImplementedError" => "RuntimeError",
-    "RecursionError" => "RuntimeError",
-    "SyntaxError" => "Exception",
-    "IndentationError" => "SyntaxError",
-    "TabError" => "IndentationError",
-    "SystemError" => "Exception",
-    "TypeError" => "Exception",
-    "ValueError" => "Exception",
-    "UnicodeError" => "ValueError",
-    "UnicodeDecodeError" => "UnicodeError",
-    "UnicodeEncodeError" => "UnicodeError",
-    "UnicodeTranslateError" => "UnicodeError",
-    "Warning" => "Exception",
-    "DeprecationWarning" => "Warning",
-    "PendingDeprecationWarning" => "Warning",
-    "RuntimeWarning" => "Warning",
-    "SyntaxWarning" => "Warning",
-    "UserWarning" => "Warning",
-    "FutureWarning" => "Warning",
-    "ImportWarning" => "Warning",
-    "UnicodeWarning" => "Warning",
-    "BytesWarning" => "Warning",
-    "ResourceWarning" => "Warning"
-  }
-
-  @spec builtin_exception_subclass?(String.t(), String.t()) :: boolean()
-  defp builtin_exception_subclass?(class_name, target_name) do
-    builtin_exception_chain(class_name)
-    |> Enum.member?(target_name)
-  end
-
-  @spec builtin_exception_chain(String.t()) :: [String.t()]
-  defp builtin_exception_chain(name) do
-    case Map.fetch(@builtin_exception_parents, name) do
-      {:ok, nil} -> [name]
-      {:ok, parent} -> [name | builtin_exception_chain(parent)]
-      :error -> []
     end
   end
 end

--- a/lib/pyex/interpreter/exceptions.ex
+++ b/lib/pyex/interpreter/exceptions.ex
@@ -34,7 +34,29 @@ defmodule Pyex.Interpreter.Exceptions do
         eval_raise_exc_class(exc_name, args, kwargs, meta, env, ctx)
 
       {:var, _, [exc_name]} ->
-        {{:exception, exc_name}, env, ctx}
+        case Env.get(env, exc_name) do
+          {:ok, {:exception_class, name}} ->
+            instance =
+              {:instance, Interpreter.exception_instance_class({:exception_class, name}),
+               %{"args" => {:tuple, []}}}
+
+            ctx = %{ctx | exception_instance: instance}
+            {{:exception, name}, env, ctx}
+
+          # `raise some_var` where some_var holds an already-constructed
+          # exception instance: bubble it up as the active exception.
+          {:ok, raw} ->
+            case Ctx.deref(ctx, raw) do
+              {:instance, _, _} = inst ->
+                eval_raise_value(inst, env, ctx)
+
+              _ ->
+                {{:exception, exc_name}, env, ctx}
+            end
+
+          _ ->
+            {{:exception, exc_name}, env, ctx}
+        end
 
       _ ->
         case Interpreter.eval(expr, env, ctx) do
@@ -42,13 +64,96 @@ defmodule Pyex.Interpreter.Exceptions do
             {signal, env, ctx}
 
           {value, env, ctx} ->
-            msg =
-              case value do
-                msg when is_binary(msg) -> "Exception: #{msg}"
-                _ -> "Exception: #{inspect(value)}"
+            eval_raise_value(value, env, ctx)
+        end
+    end
+  end
+
+  @spec eval_raise_value(Interpreter.pyvalue(), Env.t(), Ctx.t()) :: eval_result()
+  defp eval_raise_value(value, env, ctx) do
+    case value do
+      # An already-constructed exception instance bubbles up with the
+      # class name as the error tag and the instance attached for
+      # `as e:` binding.
+      {:instance, {:class, name, _, _} = _cls, attrs} = inst ->
+        args = Map.get(attrs, "args", {:tuple, []})
+        msg = format_inst_msg(name, args)
+        ctx = %{ctx | exception_instance: inst}
+        {{:exception, msg}, env, ctx}
+
+      # `raise SomeExceptionClass` with no call: synthesize an empty instance.
+      {:exception_class, name} ->
+        instance =
+          {:instance, Interpreter.exception_instance_class({:exception_class, name}),
+           %{"args" => {:tuple, []}}}
+
+        ctx = %{ctx | exception_instance: instance}
+        {{:exception, name}, env, ctx}
+
+      msg when is_binary(msg) ->
+        {{:exception, "Exception: #{msg}"}, env, ctx}
+
+      _ ->
+        {{:exception, "Exception: #{inspect(value)}"}, env, ctx}
+    end
+  end
+
+  @spec format_inst_msg(String.t(), Interpreter.pyvalue()) :: String.t()
+  defp format_inst_msg(name, {:tuple, []}), do: name
+  defp format_inst_msg(name, {:tuple, [arg]}) when is_binary(arg), do: "#{name}: #{arg}"
+  defp format_inst_msg(name, {:tuple, [arg]}), do: "#{name}: #{Helpers.py_str(arg)}"
+
+  defp format_inst_msg(name, {:tuple, args}) do
+    tuple_repr = Pyex.Builtins.py_repr({:tuple, args})
+    "#{name}: #{tuple_repr}"
+  end
+
+  defp format_inst_msg(name, _), do: name
+
+  @doc """
+  Evaluates `raise expr from cause_expr`.
+
+  First resolves the cause expression (must be an exception instance,
+  None, or raise TypeError at runtime — we currently relax to accept any
+  value).  Then evaluates the main raise; if it produces an exception
+  instance, we attach the cause as `__cause__` on the instance.
+  """
+  @spec eval_raise_from(
+          Parser.ast_node(),
+          Parser.ast_node(),
+          Parser.meta(),
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def eval_raise_from(expr, cause_expr, meta, env, ctx) do
+    case Interpreter.eval(cause_expr, env, ctx) do
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {cause_val, env, ctx} ->
+        cause = Ctx.deref(ctx, cause_val)
+
+        {signal, env, ctx} = eval_raise(expr, meta, env, ctx)
+
+        case signal do
+          {:exception, _} ->
+            new_instance =
+              case ctx.exception_instance do
+                {:instance, cls, attrs} ->
+                  {:instance, cls, Map.put(attrs, "__cause__", cause)}
+
+                _ ->
+                  nil
               end
 
-            {{:exception, msg}, env, ctx}
+            ctx =
+              if new_instance do
+                %{ctx | exception_instance: new_instance}
+              else
+                ctx
+              end
+
+            {signal, env, ctx}
         end
     end
   end
@@ -102,6 +207,12 @@ defmodule Pyex.Interpreter.Exceptions do
                 ctx = %{ctx | exception_instance: derefed}
                 {{:exception, msg}, env, ctx}
             end
+
+          {:ok, {:exception_class, _} = exc_cls} ->
+            cls = Interpreter.exception_instance_class(exc_cls)
+            instance = {:instance, cls, %{"args" => {:tuple, values}}}
+            ctx = %{ctx | exception_instance: instance}
+            {{:exception, msg}, env, ctx}
 
           _ ->
             instance =

--- a/lib/pyex/interpreter/helpers.ex
+++ b/lib/pyex/interpreter/helpers.ex
@@ -56,6 +56,7 @@ defmodule Pyex.Interpreter.Helpers do
   def py_type({:partial, _, _, _}), do: "partial"
   def py_type({:lru_cached_function, _, _}), do: "function"
   def py_type({:ref, _}), do: "ref"
+  def py_type({:exception_class, name}), do: "<class '#{name}'>"
   def py_type(_), do: "object"
 
   @doc """
@@ -129,6 +130,7 @@ defmodule Pyex.Interpreter.Helpers do
 
   def py_str({:class, name, _, _}), do: "<class '#{name}'>"
   def py_str({:builtin_type, name, _}), do: "<class '#{name}'>"
+  def py_str({:exception_class, name}), do: "<class '#{name}'>"
 
   def py_str({:instance, {:class, "type", _, _}, %{"__name__" => type_name}}) do
     "<class '#{type_name}'>"

--- a/lib/pyex/interpreter/invocation.ex
+++ b/lib/pyex/interpreter/invocation.ex
@@ -293,6 +293,29 @@ defmodule Pyex.Interpreter.Invocation do
             {ref, env, ctx}
         end
 
+      # A builtin __init__ (e.g. the one synthesized for built-in
+      # exception classes) takes `self` as its first arg and may return
+      # {:mutate, new_instance, _} to replace the instance.
+      {:ok, {:builtin, fun}, _defining_class} ->
+        derefed_args = Enum.map(args, &Ctx.deep_deref(ctx, &1))
+
+        case fun.([instance | derefed_args]) do
+          {:mutate, new_instance, _ret} ->
+            {ref, ctx} = Ctx.heap_alloc(ctx, new_instance)
+            {ref, env, ctx}
+
+          {:instance, _, _} = updated_instance ->
+            {ref, ctx} = Ctx.heap_alloc(ctx, updated_instance)
+            {ref, env, ctx}
+
+          {:exception, _} = signal ->
+            {signal, env, ctx}
+
+          _ ->
+            {ref, ctx} = Ctx.heap_alloc(ctx, instance)
+            {ref, env, ctx}
+        end
+
       :error ->
         if args == [] do
           {ref, ctx} = Ctx.heap_alloc(ctx, instance)

--- a/lib/pyex/interpreter/iterables.ex
+++ b/lib/pyex/interpreter/iterables.ex
@@ -43,6 +43,7 @@ defmodule Pyex.Interpreter.Iterables do
   def to_iterable({:deque, items, _}, env, ctx), do: {:ok, items, env, ctx}
   def to_iterable({:generator, items}, env, ctx), do: {:ok, items, env, ctx}
   def to_iterable({:generator_error, items, _msg}, env, ctx), do: {:ok, items, env, ctx}
+
   def to_iterable({:iterator, id}, env, ctx), do: {:ok, Ctx.iter_items(ctx, id), env, ctx}
 
   def to_iterable({:instance, _, _} = inst, env, ctx) do

--- a/lib/pyex/parser.ex
+++ b/lib/pyex/parser.ex
@@ -1471,6 +1471,18 @@ defmodule Pyex.Parser do
     {:error, "unexpected token in lambda params at #{token_line(tokens)}"}
   end
 
+  @doc """
+  Parses the body of an f-string or f-string format spec into a list of
+  `{:lit, str}` / `{:expr, ast}` / `{:expr, ast, spec}` parts.
+
+  Exported so the interpreter can recursively resolve nested format
+  specs (`f"{x:{width}d}"`) without duplicating the tokenization logic.
+  """
+  @spec parse_fstring_template(String.t()) ::
+          {:ok, [{:lit, String.t()} | {:expr, ast_node()} | {:expr, ast_node(), String.t()}]}
+          | {:error, String.t()}
+  def parse_fstring_template(template), do: parse_fstring_parts(template, 1)
+
   @spec parse_fstring_parts(String.t(), pos_integer()) ::
           {:ok, [{:lit, String.t()} | {:expr, ast_node()}]} | {:error, String.t()}
   defp parse_fstring_parts(template, line) do

--- a/lib/pyex/parser.ex
+++ b/lib/pyex/parser.ex
@@ -212,8 +212,8 @@ defmodule Pyex.Parser do
         case parse_expression(rest) do
           {:ok, expr, [{:keyword, _, "from"} | rest]} ->
             case parse_expression(rest) do
-              {:ok, _cause, rest} ->
-                {:ok, {:raise, [line: line], [expr]}, drop_newline(rest)}
+              {:ok, cause, rest} ->
+                {:ok, {:raise, [line: line], [expr, cause]}, drop_newline(rest)}
 
               {:error, _} = error ->
                 error

--- a/lib/pyex/stdlib/csv.ex
+++ b/lib/pyex/stdlib/csv.ex
@@ -245,8 +245,118 @@ defmodule Pyex.Stdlib.Csv do
     build_writer(id, kwargs)
   end
 
+  defp do_writer([{:ref, id}], kwargs) do
+    # The argument must be deref'd by the interpreter before we see it,
+    # but in practice heap refs often slip through.  Treat as a StringIO
+    # backing ref: each writerow will heap_put the appended value.
+    build_stringio_writer(id, kwargs)
+  end
+
   defp do_writer(_, _kwargs) do
     {:exception, "TypeError: csv.writer() argument 1 must be a file object"}
+  end
+
+  # Builds a writer that targets a heap-allocated StringIO via its ref
+  # id.  writerow/writerows append their formatted line to the buffer
+  # stored in the heap cell and return nil.  Uses `:ctx_call` signals so
+  # the heap update happens within the interpreter's context update
+  # pipeline, keeping mutations visible to all aliases of the buffer.
+  @spec build_stringio_writer(non_neg_integer(), map()) :: map()
+  defp build_stringio_writer(ref_id, kwargs) do
+    delimiter = Map.get(kwargs, "delimiter", ",")
+    quotechar = Map.get(kwargs, "quotechar", "\"")
+    quoting = Map.get(kwargs, "quoting", @quote_minimal)
+    lineterminator = Map.get(kwargs, "lineterminator", "\r\n")
+
+    append = fn line ->
+      {:ctx_call,
+       fn env, ctx ->
+         case Pyex.Ctx.deref(ctx, {:ref, ref_id}) do
+           {:stringio, buf} ->
+             ctx = Pyex.Ctx.heap_put(ctx, ref_id, {:stringio, buf <> line})
+             {nil, env, ctx}
+
+           _ ->
+             {{:exception, "csv.Error: underlying StringIO was replaced"}, env, ctx}
+         end
+       end}
+    end
+
+    writerow_fn = fn
+      [{:py_list, reversed, _}] ->
+        line =
+          format_csv_row(Enum.reverse(reversed), delimiter, quotechar, quoting, lineterminator)
+
+        append.(line)
+
+      [row] when is_list(row) ->
+        line = format_csv_row(row, delimiter, quotechar, quoting, lineterminator)
+        append.(line)
+
+      [{:tuple, items}] ->
+        line = format_csv_row(items, delimiter, quotechar, quoting, lineterminator)
+        append.(line)
+
+      _ ->
+        {:exception, "csv.Error: iterable expected"}
+    end
+
+    writerows_fn = fn
+      [{:py_list, reversed, _}] ->
+        rows = Enum.reverse(reversed)
+
+        case collect_row_items(rows) do
+          {:ok, items_list} ->
+            combined =
+              Enum.map_join(items_list, fn items ->
+                format_csv_row(items, delimiter, quotechar, quoting, lineterminator)
+              end)
+
+            append.(combined)
+
+          :error ->
+            {:exception, "csv.Error: iterable expected"}
+        end
+
+      [rows] when is_list(rows) ->
+        case collect_row_items(rows) do
+          {:ok, items_list} ->
+            combined =
+              Enum.map_join(items_list, fn items ->
+                format_csv_row(items, delimiter, quotechar, quoting, lineterminator)
+              end)
+
+            append.(combined)
+
+          :error ->
+            {:exception, "csv.Error: iterable expected"}
+        end
+
+      _ ->
+        {:exception, "csv.Error: iterable expected"}
+    end
+
+    %{
+      "writerow" => {:builtin, writerow_fn},
+      "writerows" => {:builtin, writerows_fn}
+    }
+  end
+
+  @spec collect_row_items([Pyex.Interpreter.pyvalue()]) ::
+          {:ok, [[Pyex.Interpreter.pyvalue()]]} | :error
+  defp collect_row_items(rows) do
+    Enum.reduce_while(rows, {:ok, []}, fn row, {:ok, acc} ->
+      case row do
+        {:py_list, r, _} -> {:cont, {:ok, [Enum.reverse(r) | acc]}}
+        l when is_list(l) -> {:cont, {:ok, [l | acc]}}
+        {:tuple, items} -> {:cont, {:ok, [items | acc]}}
+        _ -> {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, reversed} -> {:ok, Enum.reverse(reversed)}
+      err -> err
+    end
   end
 
   @spec build_writer(non_neg_integer() | nil, %{

--- a/lib/pyex/stdlib/io.ex
+++ b/lib/pyex/stdlib/io.ex
@@ -46,10 +46,18 @@ defmodule Pyex.Stdlib.Io do
 
   def string_io(_), do: {:exception, "TypeError: StringIO() takes at most 1 argument"}
 
+  # StringIO values must round-trip through the heap so that mutations
+  # performed by held references (e.g. a `csv.writer(buf)` closure
+  # writing back to `buf`) propagate to every alias.  Returning a
+  # {:ctx_call, fn} signal lets the interpreter perform the allocation
+  # and bind the resulting ref to the calling variable.
   @spec make_string_io(String.t()) :: Interpreter.pyvalue()
   defp make_string_io(initial) do
-    # Store as a special tagged struct; Methods handles attribute access
-    {:stringio, initial}
+    {:ctx_call,
+     fn env, ctx ->
+       {ref, ctx} = Pyex.Ctx.heap_alloc(ctx, {:stringio, initial})
+       {ref, env, ctx}
+     end}
   end
 
   @doc false

--- a/test/pyex/conformance/csv_conformance_test.exs
+++ b/test/pyex/conformance/csv_conformance_test.exs
@@ -125,4 +125,68 @@ defmodule Pyex.Conformance.CsvTest do
       """)
     end
   end
+
+  describe "writer with io.StringIO" do
+    test "simple writerow" do
+      check!("""
+      import csv, io
+      buf = io.StringIO()
+      w = csv.writer(buf)
+      w.writerow(["a", "b", "c"])
+      print(repr(buf.getvalue()))
+      """)
+    end
+
+    test "multiple writerows" do
+      check!("""
+      import csv, io
+      buf = io.StringIO()
+      w = csv.writer(buf)
+      w.writerow(["header1", "header2"])
+      w.writerow([1, 2])
+      w.writerow([3, 4])
+      print(repr(buf.getvalue()))
+      """)
+    end
+
+    test "writerows" do
+      check!("""
+      import csv, io
+      buf = io.StringIO()
+      w = csv.writer(buf)
+      w.writerows([["a", "b"], [1, 2], [3, 4]])
+      print(repr(buf.getvalue()))
+      """)
+    end
+
+    test "quotes field with embedded comma" do
+      check!(~S"""
+      import csv, io
+      buf = io.StringIO()
+      w = csv.writer(buf)
+      w.writerow(["hello, world", "foo"])
+      print(repr(buf.getvalue()))
+      """)
+    end
+
+    test "doubles embedded quote" do
+      check!(~S"""
+      import csv, io
+      buf = io.StringIO()
+      w = csv.writer(buf)
+      w.writerow(['he said "hi"', "foo"])
+      print(repr(buf.getvalue()))
+      """)
+    end
+
+    test "custom delimiter" do
+      check!(~S"""
+      import csv, io
+      buf = io.StringIO()
+      w = csv.writer(buf, delimiter=";")
+      w.writerow(["a", "b", "c"])
+      print(repr(buf.getvalue()))
+      """)
+    end
+  end
 end

--- a/test/pyex/conformance/exception_conformance_test.exs
+++ b/test/pyex/conformance/exception_conformance_test.exs
@@ -41,8 +41,7 @@ defmodule Pyex.Conformance.ExceptionTest do
       """)
     end
 
-    @tag :skip
-    test "except tuple of types (exception classes not first-class values)" do
+    test "except tuple of types" do
       check!("""
       for exc in [ValueError("v"), TypeError("t"), KeyError("k")]:
           try:
@@ -200,8 +199,7 @@ defmodule Pyex.Conformance.ExceptionTest do
       """)
     end
 
-    @tag :skip
-    test "exception with custom __init__ (super() dispatch issue)" do
+    test "exception with custom __init__" do
       check!("""
       class MyError(Exception):
           def __init__(self, code, msg):
@@ -229,8 +227,7 @@ defmodule Pyex.Conformance.ExceptionTest do
       """)
     end
 
-    @tag :skip
-    test "raise from (__cause__ not yet set)" do
+    test "raise from sets __cause__" do
       check!("""
       try:
           try:
@@ -283,8 +280,7 @@ defmodule Pyex.Conformance.ExceptionTest do
   end
 
   describe "KeyboardInterrupt and SystemExit (special)" do
-    @tag :skip
-    test "KeyboardInterrupt / BaseException (not defined as values)" do
+    test "Exception does NOT catch KeyboardInterrupt" do
       check!("""
       print(issubclass(KeyboardInterrupt, Exception))
       print(issubclass(KeyboardInterrupt, BaseException))
@@ -293,8 +289,7 @@ defmodule Pyex.Conformance.ExceptionTest do
   end
 
   describe "exception in generator" do
-    @tag :skip
-    test "exception bubbles from generator (consumer TypeError)" do
+    test "exception bubbles from generator consumer list()" do
       check!("""
       def gen():
           yield 1

--- a/test/pyex/conformance/fstring_conformance_test.exs
+++ b/test/pyex/conformance/fstring_conformance_test.exs
@@ -97,10 +97,6 @@ defmodule Pyex.Conformance.FstringTest do
   end
 
   describe "nested format specs" do
-    # Nested format spec braces (like f"{42:{w}d}") require the spec to
-    # itself be parsed as an f-string.  Pyex doesn't support this yet;
-    # see TODO.txt.  Tests live here as a future target.
-    @tag :skip
     test "dynamic width" do
       check!(~S"""
       w = 8
@@ -108,11 +104,17 @@ defmodule Pyex.Conformance.FstringTest do
       """)
     end
 
-    @tag :skip
     test "dynamic precision" do
       check!(~S"""
       p = 3
       print(f"{3.14159:.{p}f}")
+      """)
+    end
+
+    test "nested width and fill" do
+      check!(~S"""
+      w, f = 6, "*"
+      print(f"{42:{f}>{w}}")
       """)
     end
   end


### PR DESCRIPTION
Addresses all five known limitations from PR #39's TODO.txt by elevating
several parts of Pyex's Python semantics to full CPython conformance.
No new tests fail; 5 previously-skipped tests now pass.

## Changes

### 1. Exception classes as first-class runtime values

Every built-in Python exception (`ValueError`, `TypeError`,
`KeyboardInterrupt`, `BaseException`, ~60 total) is now bound in the
runtime env as `{:exception_class, name}`.

```python
isinstance(x, ValueError)                    # works
issubclass(KeyError, LookupError)            # works
except (ValueError, TypeError) as e:         # works
for exc in [ValueError("a"), TypeError("b")]: ...   # works
class MyError(Exception): ...                # uses real parent class
```

Extracted the hierarchy into `Pyex.ExceptionsHierarchy` as the single
source of truth for `except` matching, `isinstance`, `issubclass`,
class inheritance, and C3 linearization.

### 2. `raise X from Y` sets `__cause__`

Parser now retains the cause expression; `eval_raise_from/5` attaches
the cause as `__cause__` on the raised instance.

### 3. Generator exceptions propagate through `list()`

`builtin_list` now surfaces `{:generator_error, _, msg}` as an
exception instead of dropping it.  `list(gen_that_raises())` now
correctly propagates the inner `ValueError` rather than a bogus
`TypeError`.

### 4. `super().__init__(...)` in exception subclasses

Three small interpreter fixes:
- Super-proxy attr lookup wraps builtin functions as bound methods
  (passing `self`).
- `call_class` dispatches `{:builtin, fn}` `__init__` and applies
  `{:mutate, ...}` return values.
- `eval_class_def` reifies `{:exception_class, _}` bases to real
  `{:class, ...}` values so MRO and super() lookup find the
  inherited `__init__`.

### 5. F-string nested format specs

`f"{x:{width}d}"` / `f"{val:.{precision}f}"` now evaluate expressions
inside the spec.  Exposed `Parser.parse_fstring_template/1` so the
interpreter can recursively resolve specs.

### 6. Heap-allocated StringIO + `csv.writer(io.StringIO())`

`io.StringIO()` returns a heap ref now; `Ctx.deep_deref` preserves
StringIO refs so `csv.writer(buf)` can close over the ref and write
back via `{:ctx_call, fn}` into the same heap cell.  Writes propagate
to all aliases.

## Test count

| | Before | After |
|---|---|---|
| Tests | 4511 | 4518 |
| Skipped | 8 | 1 |

The 7 tests that now pass:
- `except (ValueError, TypeError) as e:`
- `Exception does NOT catch KeyboardInterrupt`
- `raise X from Y` sets `__cause__`
- `list(gen_that_raises())` propagates inner exception
- `class MyError(Exception): def __init__(self, ...): super().__init__(...)` args line up
- F-string `f"{42:{w}d}"` dynamic width
- F-string `f"{3.14:.{p}f}"` dynamic precision

Plus 6 new csv-via-StringIO tests and 1 new f-string fill+width test.

## Verification

- `mix compile --warnings-as-errors`: clean
- `mix format --check-formatted`: clean
- `mix test`: 4518 tests, 0 failures, 1 skipped
- `mix dialyzer`: 39 total (unchanged from main)

## TODO.txt

Removed all 5 limitation entries addressed here.