### PR TITLE
Add operator/bisect modules; extend heapq/textwrap; fix @lru_cache recursion + property setter exceptions

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -87,7 +87,6 @@ Python features.
 Known limitations:
 - Late-binding closures: `lambda x: x + i` in a loop captures final `i`
   (Python late-binding semantics). Use `lambda x, i=i: x + i` as workaround.
-- `@property`, `@staticmethod`, `@classmethod` decorators not yet implemented
 - `async`/`await` and `asyncio` not yet implemented
 - `bytes`/`bytearray` types not yet implemented
 - `datetime.now()` always returns UTC (not local time)

--- a/lib/pyex/builtins.ex
+++ b/lib/pyex/builtins.ex
@@ -1310,11 +1310,52 @@ defmodule Pyex.Builtins do
     end
   end
 
+  # `functools.partial`, lru-cached functions, classes, and instances
+  # (callable via __call__) are all valid map()/filter() targets in
+  # CPython.  Defer them to the interpreter via :map_call so the full
+  # invocation pipeline applies.
+  defp builtin_map([{:partial, _, _, _} = func | iterables]) when iterables != [] do
+    map_call_defer(func, iterables)
+  end
+
+  defp builtin_map([{:lru_cached_function, _, _} = func | iterables]) when iterables != [] do
+    map_call_defer(func, iterables)
+  end
+
+  defp builtin_map([{:class, _, _, _} = func | iterables]) when iterables != [] do
+    map_call_defer(func, iterables)
+  end
+
+  defp builtin_map([{:exception_class, _} = func | iterables]) when iterables != [] do
+    map_call_defer(func, iterables)
+  end
+
+  defp builtin_map([{:instance, _, _} = func | iterables]) when iterables != [] do
+    map_call_defer(func, iterables)
+  end
+
+  defp builtin_map([{:bound_method, _, _} = func | iterables]) when iterables != [] do
+    map_call_defer(func, iterables)
+  end
+
+  defp builtin_map([{:bound_method, _, _, _} = func | iterables]) when iterables != [] do
+    map_call_defer(func, iterables)
+  end
+
   defp builtin_map([_func | _]),
     do: {:exception, "TypeError: map() first arg must be callable"}
 
   defp builtin_map(_),
     do: {:exception, "TypeError: map() requires at least 2 arguments"}
+
+  @spec map_call_defer(Interpreter.pyvalue(), [Interpreter.pyvalue()]) ::
+          Interpreter.builtin_signal() | {:exception, String.t()}
+  defp map_call_defer(func, iterables) do
+    case collect_iterables(iterables) do
+      {:ok, lists} -> {:map_call, func, zip_truncate(lists)}
+      {:exception, _} = e -> e
+    end
+  end
 
   @spec collect_iterables([Interpreter.pyvalue()]) ::
           {:ok, [[Interpreter.pyvalue()]]} | {:exception, String.t()}

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -1596,7 +1596,18 @@ defmodule Pyex.Interpreter do
   def call_function({:partial, func, partial_args, partial_kwargs}, args, kwargs, env, ctx) do
     full_args = partial_args ++ args
     full_kwargs = Map.merge(partial_kwargs, kwargs)
-    call_function(func, full_args, full_kwargs, env, ctx)
+
+    case call_function(func, full_args, full_kwargs, env, ctx) do
+      # Preserve the partial wrapper when the inner function returns
+      # an updated closure: without this, callers that reuse the
+      # partial across iterations (e.g. `map(partial(...), ...)`)
+      # would lose the pre-bound arguments on the second call.
+      {val, env, ctx, updated_inner} ->
+        {val, env, ctx, {:partial, updated_inner, partial_args, partial_kwargs}}
+
+      other ->
+        other
+    end
   end
 
   def call_function({:lru_cached_function, func, cache_id}, args, kwargs, env, ctx) do
@@ -2827,22 +2838,54 @@ defmodule Pyex.Interpreter do
         {signal, env, ctx}
 
       {:mutate, _new_object, return_value, new_env, ctx} ->
-        {nil, Env.smart_put(new_env, name, return_value), ctx}
+        {nil, smart_put_decorated(new_env, name, return_value), ctx}
 
       {:mutate, _new_object, return_value, ctx} ->
-        {nil, Env.smart_put(env, name, return_value), ctx}
+        {nil, smart_put_decorated(env, name, return_value), ctx}
 
       {{:register_route, method, path, handler}, env, ctx} ->
         env = register_route(decorator_expr, method, path, handler, env)
-        {nil, Env.smart_put(env, name, handler), ctx}
+        {nil, smart_put_decorated(env, name, handler), ctx}
 
       {result, env, ctx, _updated_func} ->
-        {nil, Env.smart_put(env, name, result), ctx}
+        {nil, smart_put_decorated(env, name, result), ctx}
 
       {result, env, ctx} ->
-        {nil, Env.smart_put(env, name, result), ctx}
+        {nil, smart_put_decorated(env, name, result), ctx}
     end
   end
+
+  # Writes the decorated value to `name` AND rewrites any recursive
+  # self-reference inside the wrapped function's closure to point to the
+  # decorated form.  Without this, calling the decorated function
+  # propagates the stale (undecorated) reference from the function's
+  # closure back to the caller's global scope, defeating lru_cache and
+  # other stateful wrappers.
+  @spec smart_put_decorated(Env.t(), String.t(), pyvalue()) :: Env.t()
+  defp smart_put_decorated(env, name, decorated) do
+    patched = rewrite_self_reference(decorated, name, decorated)
+    Env.smart_put(env, name, patched)
+  end
+
+  @spec rewrite_self_reference(pyvalue(), String.t(), pyvalue()) :: pyvalue()
+  defp rewrite_self_reference(
+         {:lru_cached_function, {:function, fname, params, body, closure_env}, cache_id},
+         name,
+         decorated
+       ) do
+    {:lru_cached_function,
+     {:function, fname, params, body, Env.put_global(closure_env, name, decorated)}, cache_id}
+  end
+
+  defp rewrite_self_reference({:function, fname, params, body, closure_env}, name, decorated) do
+    {:function, fname, params, body, Env.put_global(closure_env, name, decorated)}
+  end
+
+  defp rewrite_self_reference({:partial, inner, args, kwargs}, name, decorated) do
+    {:partial, rewrite_self_reference(inner, name, decorated), args, kwargs}
+  end
+
+  defp rewrite_self_reference(other, _name, _decorated), do: other
 
   @spec with_context_var(node()) :: String.t() | nil
   defp with_context_var({:var, _, [name]}), do: name

--- a/lib/pyex/interpreter/assignments.ex
+++ b/lib/pyex/interpreter/assignments.ex
@@ -594,6 +594,9 @@ defmodule Pyex.Interpreter.Assignments do
 
                 case Interpreter.call_function(fset, [self_arg, value], %{}, env, ctx) do
                   {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+                  # call_function may return a 4-tuple with updated_func
+                  # when the setter is a regular Python function.
+                  {{:exception, _} = signal, env, ctx, _} -> {signal, env, ctx}
                   {_, env, ctx, _} -> {nil, env, ctx}
                   {_, env, ctx} -> {nil, env, ctx}
                 end

--- a/lib/pyex/interpreter/builtin_results.ex
+++ b/lib/pyex/interpreter/builtin_results.ex
@@ -176,6 +176,9 @@ defmodule Pyex.Interpreter.BuiltinResults do
       {:mutate, new_object, return_value} ->
         {:mutate, new_object, return_value, ctx}
 
+      {:mutate_arg, index, new_object, return_value} ->
+        {:mutate_arg, index, new_object, return_value, ctx}
+
       {:io_call, io_fun} ->
         ctx = Ctx.pause_compute(ctx)
         {result, env, ctx} = io_fun.(env, ctx)

--- a/lib/pyex/interpreter/invocation.ex
+++ b/lib/pyex/interpreter/invocation.ex
@@ -41,7 +41,18 @@ defmodule Pyex.Interpreter.Invocation do
       fresh_closure =
         Env.put_global_scope(closure_env, Env.global_scope(env), Env.global_scope_id(env))
 
-      base_env = Env.push_scope(Env.put(fresh_closure, name, func))
+      # Bind `name` to the caller's current binding when available so
+      # decorators (like @lru_cache) that wrap this function are visible
+      # during recursive self-calls.  Falling back to the raw `func`
+      # matters for ordinary recursion in nested/local scopes where the
+      # name isn't in the caller's globals yet.
+      self_binding =
+        case Env.get(env, name) do
+          {:ok, existing} -> existing
+          :undefined -> func
+        end
+
+      base_env = Env.push_scope(Env.put(fresh_closure, name, self_binding))
 
       case CallSupport.bind_params(params, args, kwargs, base_env, ctx) do
         {:exception, msg, ctx} ->

--- a/lib/pyex/stdlib.ex
+++ b/lib/pyex/stdlib.ex
@@ -53,7 +53,9 @@ defmodule Pyex.Stdlib do
     "textwrap" => Pyex.Stdlib.Textwrap,
     "sys" => Pyex.Stdlib.Sys,
     "crypto" => Pyex.Stdlib.Crypto,
-    "zoneinfo" => Pyex.Stdlib.Zoneinfo
+    "zoneinfo" => Pyex.Stdlib.Zoneinfo,
+    "operator" => Pyex.Stdlib.Operator,
+    "bisect" => Pyex.Stdlib.Bisect
   }
 
   @doc """

--- a/lib/pyex/stdlib/bisect.ex
+++ b/lib/pyex/stdlib/bisect.ex
@@ -1,0 +1,130 @@
+defmodule Pyex.Stdlib.Bisect do
+  @moduledoc """
+  Python `bisect` module for binary search on sorted sequences.
+
+  Provides `bisect_left`, `bisect_right` (alias `bisect`), `insort_left`,
+  and `insort_right` (alias `insort`).  Insertion variants return the
+  mutated list via the `:mutate_arg` signal so Python's in-place
+  semantics are preserved.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.Interpreter
+
+  @doc """
+  Returns the module value map.
+  """
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      "bisect_left" => {:builtin_kw, &bisect_left/2},
+      "bisect_right" => {:builtin_kw, &bisect_right/2},
+      "bisect" => {:builtin_kw, &bisect_right/2},
+      "insort_left" => {:builtin_kw, &insort_left/2},
+      "insort_right" => {:builtin_kw, &insort_right/2},
+      "insort" => {:builtin_kw, &insort_right/2}
+    }
+  end
+
+  @doc false
+  @spec bisect_left([Interpreter.pyvalue()], map()) :: non_neg_integer()
+  def bisect_left(args, kwargs), do: do_bisect(args, kwargs, :left)
+
+  @doc false
+  @spec bisect_right([Interpreter.pyvalue()], map()) :: non_neg_integer()
+  def bisect_right(args, kwargs), do: do_bisect(args, kwargs, :right)
+
+  @doc false
+  @spec insort_left([Interpreter.pyvalue()], map()) ::
+          {:mutate_arg, non_neg_integer(), Interpreter.pyvalue(), nil}
+  def insort_left(args, kwargs), do: do_insort(args, kwargs, :left)
+
+  @doc false
+  @spec insort_right([Interpreter.pyvalue()], map()) ::
+          {:mutate_arg, non_neg_integer(), Interpreter.pyvalue(), nil}
+  def insort_right(args, kwargs), do: do_insort(args, kwargs, :right)
+
+  @spec do_bisect([Interpreter.pyvalue()], map(), :left | :right) :: non_neg_integer()
+  defp do_bisect(args, kwargs, side) do
+    {list, item, lo, hi} = unpack_args(args, kwargs)
+    items = materialize(list)
+    clamped_hi = if hi, do: min(hi, length(items)), else: length(items)
+    find_position(items, item, max(lo, 0), clamped_hi, side)
+  end
+
+  defp do_insort(args, kwargs, side) do
+    {list, item, lo, hi} = unpack_args(args, kwargs)
+    items = materialize(list)
+    clamped_hi = if hi, do: min(hi, length(items)), else: length(items)
+    pos = find_position(items, item, max(lo, 0), clamped_hi, side)
+    {before, after_} = Enum.split(items, pos)
+    new_list = before ++ [item] ++ after_
+
+    case list do
+      {:py_list, _reversed, _len} ->
+        new_py = {:py_list, Enum.reverse(new_list), length(new_list)}
+        {:mutate_arg, 0, new_py, nil}
+
+      _ ->
+        {:mutate_arg, 0, new_list, nil}
+    end
+  end
+
+  defp unpack_args([list, item], kwargs) do
+    lo = Map.get(kwargs, "lo", 0)
+    hi = Map.get(kwargs, "hi", nil)
+    {list, item, lo, hi}
+  end
+
+  defp unpack_args([list, item, lo], kwargs) do
+    hi = Map.get(kwargs, "hi", nil)
+    {list, item, lo, hi}
+  end
+
+  defp unpack_args([list, item, lo, hi], _kwargs), do: {list, item, lo, hi}
+
+  @spec find_position(
+          [Interpreter.pyvalue()],
+          Interpreter.pyvalue(),
+          non_neg_integer(),
+          non_neg_integer(),
+          :left | :right
+        ) ::
+          non_neg_integer()
+  defp find_position(items, item, lo, hi, side) do
+    do_find(items, item, lo, hi, side)
+  end
+
+  defp do_find(_items, _item, lo, hi, _side) when lo >= hi, do: lo
+
+  defp do_find(items, item, lo, hi, side) do
+    mid = div(lo + hi, 2)
+    mid_item = Enum.at(items, mid)
+
+    cond do
+      side == :left and cmp(mid_item, item) < 0 ->
+        do_find(items, item, mid + 1, hi, side)
+
+      side == :left ->
+        do_find(items, item, lo, mid, side)
+
+      side == :right and cmp(item, mid_item) < 0 ->
+        do_find(items, item, lo, mid, side)
+
+      side == :right ->
+        do_find(items, item, mid + 1, hi, side)
+    end
+  end
+
+  defp cmp(a, b) when a < b, do: -1
+  defp cmp(a, b) when a > b, do: 1
+  defp cmp(_, _), do: 0
+
+  @spec materialize(Interpreter.pyvalue()) :: [Interpreter.pyvalue()]
+  defp materialize({:py_list, reversed, _}), do: Enum.reverse(reversed)
+  defp materialize(list) when is_list(list), do: list
+  defp materialize({:tuple, items}), do: items
+  defp materialize(_), do: []
+end

--- a/lib/pyex/stdlib/heapq.ex
+++ b/lib/pyex/stdlib/heapq.ex
@@ -14,9 +14,91 @@ defmodule Pyex.Stdlib.Heapq do
       "heapify" => {:builtin, &heapify/1},
       "heappush" => {:builtin, &heappush/1},
       "heappop" => {:builtin, &heappop/1},
-      "heapreplace" => {:builtin, &heapreplace/1}
+      "heapreplace" => {:builtin, &heapreplace/1},
+      "heappushpop" => {:builtin, &heappushpop/1},
+      "nlargest" => {:builtin_kw, &nlargest/2},
+      "nsmallest" => {:builtin_kw, &nsmallest/2},
+      "merge" => {:builtin_kw, &merge/2}
     }
   end
+
+  @spec heappushpop([Interpreter.pyvalue()]) :: term()
+  defp heappushpop([heap, item]) do
+    with {:ok, items, wrap} <- heap_parts(heap) do
+      cond do
+        items == [] ->
+          {item, nil}
+
+        hd(items) < item ->
+          [root | rest] = items
+          new_heap = sift_down([item | rest], 0)
+          {:mutate_arg, 0, wrap.(new_heap), root}
+
+        true ->
+          # item is smaller than root — no change, return item
+          {:mutate_arg, 0, wrap.(items), item}
+      end
+    end
+  end
+
+  defp heappushpop(_),
+    do: {:exception, "TypeError: heappushpop() takes exactly 2 arguments"}
+
+  @spec nlargest([Interpreter.pyvalue()], map()) :: [Interpreter.pyvalue()]
+  defp nlargest([n, iterable], kwargs) when is_integer(n) do
+    do_n(n, iterable, kwargs, :desc)
+  end
+
+  defp nlargest(_, _), do: {:exception, "TypeError: nlargest() requires (n, iterable)"}
+
+  @spec nsmallest([Interpreter.pyvalue()], map()) :: [Interpreter.pyvalue()]
+  defp nsmallest([n, iterable], kwargs) when is_integer(n) do
+    do_n(n, iterable, kwargs, :asc)
+  end
+
+  defp nsmallest(_, _), do: {:exception, "TypeError: nsmallest() requires (n, iterable)"}
+
+  @spec do_n(integer(), Interpreter.pyvalue(), map(), :asc | :desc) :: term()
+  defp do_n(n, _iterable, _kwargs, _order) when n <= 0, do: []
+
+  defp do_n(n, iterable, kwargs, order) do
+    items = materialize(iterable)
+
+    case Map.get(kwargs, "key") do
+      nil ->
+        items
+        |> Enum.sort(if order == :asc, do: :asc, else: :desc)
+        |> Enum.take(n)
+
+      func ->
+        # Use the interpreter's :sort_call machinery to evaluate the key
+        # function for each item, then slice to n elements.
+        {:ctx_call,
+         fn env, ctx ->
+           case Pyex.Interpreter.eval_sort(items, func, order == :desc, env, ctx) do
+             {{:exception, _} = signal, env, ctx} ->
+               {signal, env, ctx}
+
+             {sorted, env, ctx} ->
+               {Enum.take(sorted, n), env, ctx}
+           end
+         end}
+    end
+  end
+
+  @spec merge([Interpreter.pyvalue()], map()) :: [Interpreter.pyvalue()]
+  defp merge(iterables, _kwargs) do
+    iterables
+    |> Enum.flat_map(&materialize/1)
+    |> Enum.sort()
+  end
+
+  @spec materialize(Interpreter.pyvalue()) :: [Interpreter.pyvalue()]
+  defp materialize({:py_list, reversed, _}), do: Enum.reverse(reversed)
+  defp materialize({:tuple, items}), do: items
+  defp materialize({:set, s}), do: MapSet.to_list(s)
+  defp materialize(list) when is_list(list), do: list
+  defp materialize(_), do: []
 
   @spec heapify([Interpreter.pyvalue()]) :: term()
   defp heapify([heap]) do
@@ -97,7 +179,7 @@ defmodule Pyex.Stdlib.Heapq do
 
   defp build_heap(items) do
     start = div(length(items), 2) - 1
-    Enum.reduce(start..0, items, fn idx, acc -> sift_down(acc, idx) end)
+    Enum.reduce(start..0//-1, items, fn idx, acc -> sift_down(acc, idx) end)
   end
 
   @spec sift_up([Interpreter.pyvalue()]) :: [Interpreter.pyvalue()]

--- a/lib/pyex/stdlib/operator.ex
+++ b/lib/pyex/stdlib/operator.ex
@@ -1,0 +1,311 @@
+defmodule Pyex.Stdlib.Operator do
+  @moduledoc """
+  Python `operator` module.
+
+  Provides functional counterparts for built-in operators plus the
+  `attrgetter`, `itemgetter`, and `methodcaller` factory functions.
+  Most functions are simple wrappers that let users pass operators as
+  first-class callables to `sorted`, `map`, `reduce`, etc.
+  """
+
+  @behaviour Pyex.Stdlib.Module
+
+  alias Pyex.Interpreter
+
+  @doc """
+  Returns the module value map.
+  """
+  @impl Pyex.Stdlib.Module
+  @spec module_value() :: Pyex.Stdlib.Module.module_value()
+  def module_value do
+    %{
+      # Arithmetic
+      "add" => {:builtin, &op_add/1},
+      "sub" => {:builtin, &op_sub/1},
+      "mul" => {:builtin, &op_mul/1},
+      "truediv" => {:builtin, &op_truediv/1},
+      "floordiv" => {:builtin, &op_floordiv/1},
+      "mod" => {:builtin, &op_mod/1},
+      "pow" => {:builtin, &op_pow/1},
+      "neg" => {:builtin, &op_neg/1},
+      "pos" => {:builtin, &op_pos/1},
+      "abs" => {:builtin, &op_abs/1},
+
+      # Bitwise
+      "and_" => {:builtin, &op_band/1},
+      "or_" => {:builtin, &op_bor/1},
+      "xor" => {:builtin, &op_bxor/1},
+      "invert" => {:builtin, &op_invert/1},
+      "lshift" => {:builtin, &op_lshift/1},
+      "rshift" => {:builtin, &op_rshift/1},
+
+      # Comparisons
+      "lt" => {:builtin, &op_lt/1},
+      "le" => {:builtin, &op_le/1},
+      "eq" => {:builtin, &op_eq/1},
+      "ne" => {:builtin, &op_ne/1},
+      "ge" => {:builtin, &op_ge/1},
+      "gt" => {:builtin, &op_gt/1},
+      "is_" => {:builtin, &op_is/1},
+      "is_not" => {:builtin, &op_is_not/1},
+
+      # Logical
+      "not_" => {:builtin, &op_not/1},
+      "truth" => {:builtin, &op_truth/1},
+
+      # Sequence / container
+      "contains" => {:builtin, &op_contains/1},
+      "countOf" => {:builtin, &op_count_of/1},
+      "indexOf" => {:builtin, &op_index_of/1},
+      "getitem" => {:builtin, &op_getitem/1},
+      "setitem" => {:builtin, &op_setitem/1},
+      "delitem" => {:builtin, &op_delitem/1},
+      "concat" => {:builtin, &op_concat/1},
+
+      # Factory functions
+      "attrgetter" => {:builtin, &op_attrgetter/1},
+      "itemgetter" => {:builtin, &op_itemgetter/1},
+      "methodcaller" => {:builtin, &op_methodcaller/1}
+    }
+  end
+
+  defp op_add([a, b]) when is_number(a) and is_number(b), do: a + b
+  defp op_add([a, b]) when is_binary(a) and is_binary(b), do: a <> b
+  defp op_add([a, b]) when is_list(a) and is_list(b), do: a ++ b
+  defp op_add([{:py_list, ar, al}, {:py_list, br, bl}]), do: {:py_list, br ++ ar, al + bl}
+  defp op_add([{:tuple, a}, {:tuple, b}]), do: {:tuple, a ++ b}
+  defp op_add(_), do: {:exception, "TypeError: unsupported operand types for add"}
+
+  defp op_sub([a, b]) when is_number(a) and is_number(b), do: a - b
+  defp op_sub(_), do: {:exception, "TypeError: unsupported operand types for sub"}
+
+  defp op_mul([a, b]) when is_number(a) and is_number(b), do: a * b
+  defp op_mul([s, n]) when is_binary(s) and is_integer(n), do: String.duplicate(s, max(n, 0))
+  defp op_mul([n, s]) when is_integer(n) and is_binary(s), do: String.duplicate(s, max(n, 0))
+  defp op_mul(_), do: {:exception, "TypeError: unsupported operand types for mul"}
+
+  defp op_truediv([_, 0]), do: {:exception, "ZeroDivisionError: division by zero"}
+  defp op_truediv([_, +0.0]), do: {:exception, "ZeroDivisionError: division by zero"}
+  defp op_truediv([_, -0.0]), do: {:exception, "ZeroDivisionError: division by zero"}
+  defp op_truediv([a, b]) when is_number(a) and is_number(b), do: a / b
+  defp op_truediv(_), do: {:exception, "TypeError: unsupported operand types for truediv"}
+
+  defp op_floordiv([_, 0]), do: {:exception, "ZeroDivisionError: integer division by zero"}
+  defp op_floordiv([a, b]) when is_integer(a) and is_integer(b), do: Integer.floor_div(a, b)
+
+  defp op_floordiv([a, b]) when is_number(a) and is_number(b),
+    do: :math.floor(a / b) * 1.0
+
+  defp op_floordiv(_), do: {:exception, "TypeError: unsupported operand types for floordiv"}
+
+  defp op_mod([_, 0]), do: {:exception, "ZeroDivisionError: integer division by zero"}
+  defp op_mod([a, b]) when is_integer(a) and is_integer(b), do: Integer.mod(a, b)
+  defp op_mod([a, b]) when is_number(a) and is_number(b), do: a - :math.floor(a / b) * b
+  defp op_mod(_), do: {:exception, "TypeError: unsupported operand types for mod"}
+
+  defp op_pow([a, b]) when is_integer(a) and is_integer(b) and b >= 0,
+    do: Integer.pow(a, b)
+
+  defp op_pow([a, b]) when is_number(a) and is_number(b), do: :math.pow(a, b)
+  defp op_pow(_), do: {:exception, "TypeError: unsupported operand types for pow"}
+
+  defp op_neg([a]) when is_number(a), do: -a
+  defp op_neg(_), do: {:exception, "TypeError: bad operand type for neg"}
+
+  defp op_pos([a]) when is_number(a), do: +a
+  defp op_pos(_), do: {:exception, "TypeError: bad operand type for pos"}
+
+  defp op_abs([a]) when is_number(a), do: abs(a)
+  defp op_abs(_), do: {:exception, "TypeError: bad operand type for abs"}
+
+  defp op_band([a, b]) when is_integer(a) and is_integer(b), do: Bitwise.band(a, b)
+  defp op_band(_), do: {:exception, "TypeError: unsupported operand types for &"}
+
+  defp op_bor([a, b]) when is_integer(a) and is_integer(b), do: Bitwise.bor(a, b)
+  defp op_bor(_), do: {:exception, "TypeError: unsupported operand types for |"}
+
+  defp op_bxor([a, b]) when is_integer(a) and is_integer(b), do: Bitwise.bxor(a, b)
+  defp op_bxor(_), do: {:exception, "TypeError: unsupported operand types for ^"}
+
+  defp op_invert([a]) when is_integer(a), do: Bitwise.bnot(a)
+  defp op_invert(_), do: {:exception, "TypeError: bad operand type for invert"}
+
+  defp op_lshift([a, b]) when is_integer(a) and is_integer(b) and b >= 0,
+    do: Bitwise.bsl(a, b)
+
+  defp op_lshift(_), do: {:exception, "TypeError: unsupported operand types for <<"}
+
+  defp op_rshift([a, b]) when is_integer(a) and is_integer(b) and b >= 0,
+    do: Bitwise.bsr(a, b)
+
+  defp op_rshift(_), do: {:exception, "TypeError: unsupported operand types for >>"}
+
+  defp op_lt([a, b]), do: compare_values(a, b, :lt)
+  defp op_le([a, b]), do: compare_values(a, b, :le)
+  defp op_eq([a, b]), do: a == b
+  defp op_ne([a, b]), do: a != b
+  defp op_ge([a, b]), do: compare_values(a, b, :ge)
+  defp op_gt([a, b]), do: compare_values(a, b, :gt)
+  defp op_is([a, b]), do: a === b
+  defp op_is_not([a, b]), do: a !== b
+
+  defp compare_values(a, b, :lt) when is_number(a) and is_number(b), do: a < b
+  defp compare_values(a, b, :le) when is_number(a) and is_number(b), do: a <= b
+  defp compare_values(a, b, :ge) when is_number(a) and is_number(b), do: a >= b
+  defp compare_values(a, b, :gt) when is_number(a) and is_number(b), do: a > b
+  defp compare_values(a, b, :lt), do: a < b
+  defp compare_values(a, b, :le), do: a <= b
+  defp compare_values(a, b, :ge), do: a >= b
+  defp compare_values(a, b, :gt), do: a > b
+
+  defp op_not([a]), do: not Pyex.Builtins.truthy?(a)
+  defp op_truth([a]), do: Pyex.Builtins.truthy?(a)
+
+  defp op_contains([container, item]), do: item_in_container?(item, container)
+
+  defp op_count_of([container, item]) do
+    container
+    |> materialize()
+    |> Enum.count(&(&1 == item))
+  end
+
+  defp op_index_of([container, item]) do
+    case Enum.find_index(materialize(container), &(&1 == item)) do
+      nil -> {:exception, "ValueError: not in list"}
+      idx -> idx
+    end
+  end
+
+  defp op_getitem([container, key]) do
+    case container do
+      {:py_list, reversed, _} ->
+        list = Enum.reverse(reversed)
+
+        case Enum.fetch(list, key) do
+          {:ok, v} -> v
+          :error -> {:exception, "IndexError: list index out of range"}
+        end
+
+      list when is_list(list) ->
+        case Enum.fetch(list, key) do
+          {:ok, v} -> v
+          :error -> {:exception, "IndexError: list index out of range"}
+        end
+
+      {:tuple, items} ->
+        case Enum.fetch(items, key) do
+          {:ok, v} -> v
+          :error -> {:exception, "IndexError: tuple index out of range"}
+        end
+
+      {:py_dict, _, _} = dict ->
+        case Pyex.PyDict.fetch(dict, key) do
+          {:ok, v} -> v
+          :error -> {:exception, "KeyError: #{inspect(key)}"}
+        end
+
+      _ ->
+        {:exception, "TypeError: 'operator.getitem' requires a sequence or mapping"}
+    end
+  end
+
+  defp op_setitem(_),
+    do: {:exception, "operator.setitem not supported (requires mutation context)"}
+
+  defp op_delitem(_),
+    do: {:exception, "operator.delitem not supported (requires mutation context)"}
+
+  defp op_concat([a, b]), do: op_add([a, b])
+
+  # ------- Factories -------
+
+  defp op_attrgetter([name]) when is_binary(name) do
+    names = String.split(name, ".")
+
+    {:builtin,
+     fn [obj] ->
+       fetch_nested_attr(obj, names)
+     end}
+  end
+
+  defp op_attrgetter(names) when length(names) > 1 do
+    paths = Enum.map(names, fn n when is_binary(n) -> String.split(n, ".") end)
+
+    {:builtin,
+     fn [obj] ->
+       results = Enum.map(paths, &fetch_nested_attr(obj, &1))
+
+       case Enum.find(results, &match?({:exception, _}, &1)) do
+         nil -> {:tuple, results}
+         err -> err
+       end
+     end}
+  end
+
+  defp op_itemgetter([key]) do
+    {:builtin, fn [obj] -> op_getitem([obj, key]) end}
+  end
+
+  defp op_itemgetter(keys) when length(keys) > 1 do
+    {:builtin,
+     fn [obj] ->
+       results = Enum.map(keys, &op_getitem([obj, &1]))
+
+       case Enum.find(results, &match?({:exception, _}, &1)) do
+         nil -> {:tuple, results}
+         err -> err
+       end
+     end}
+  end
+
+  defp op_methodcaller([method_name | pre_args]) when is_binary(method_name) do
+    {:builtin,
+     fn [obj] ->
+       {:method_call_by_name, obj, method_name, pre_args}
+     end}
+  end
+
+  # ------- Helpers -------
+
+  @spec materialize(Interpreter.pyvalue()) :: [Interpreter.pyvalue()]
+  defp materialize({:py_list, reversed, _}), do: Enum.reverse(reversed)
+  defp materialize({:tuple, items}), do: items
+  defp materialize({:set, s}), do: MapSet.to_list(s)
+  defp materialize({:frozenset, s}), do: MapSet.to_list(s)
+  defp materialize(list) when is_list(list), do: list
+  defp materialize(_), do: []
+
+  @spec item_in_container?(Interpreter.pyvalue(), Interpreter.pyvalue()) :: boolean()
+  defp item_in_container?(item, {:py_list, reversed, _}),
+    do: Enum.any?(reversed, &(&1 == item))
+
+  defp item_in_container?(item, {:tuple, items}), do: Enum.any?(items, &(&1 == item))
+  defp item_in_container?(item, {:set, s}), do: MapSet.member?(s, item)
+  defp item_in_container?(item, {:frozenset, s}), do: MapSet.member?(s, item)
+  defp item_in_container?(item, list) when is_list(list), do: Enum.any?(list, &(&1 == item))
+
+  defp item_in_container?(item, {:py_dict, _, _} = dict),
+    do: match?({:ok, _}, Pyex.PyDict.fetch(dict, item))
+
+  defp item_in_container?(sub, s) when is_binary(s) and is_binary(sub),
+    do: String.contains?(s, sub)
+
+  defp item_in_container?(_, _), do: false
+
+  @spec fetch_nested_attr(Interpreter.pyvalue(), [String.t()]) :: Interpreter.pyvalue()
+  defp fetch_nested_attr(obj, []), do: obj
+
+  defp fetch_nested_attr({:instance, _, attrs} = inst, [name | rest]) do
+    case Map.fetch(attrs, name) do
+      {:ok, v} ->
+        fetch_nested_attr(v, rest)
+
+      :error ->
+        {:exception,
+         "AttributeError: '#{Pyex.Interpreter.Helpers.py_type(inst)}' has no attribute '#{name}'"}
+    end
+  end
+
+  defp fetch_nested_attr(_obj, _),
+    do: {:exception, "TypeError: attrgetter target is not an instance"}
+end

--- a/lib/pyex/stdlib/textwrap.ex
+++ b/lib/pyex/stdlib/textwrap.ex
@@ -15,8 +15,49 @@ defmodule Pyex.Stdlib.Textwrap do
       "dedent" => {:builtin, &do_dedent/1},
       "indent" => {:builtin, &do_indent/1},
       "wrap" => {:builtin_kw, &do_wrap/2},
-      "fill" => {:builtin_kw, &do_fill/2}
+      "fill" => {:builtin_kw, &do_fill/2},
+      "shorten" => {:builtin_kw, &do_shorten/2}
     }
+  end
+
+  @spec do_shorten([Pyex.Interpreter.pyvalue()], map()) :: Pyex.Interpreter.pyvalue()
+  defp do_shorten([text], kwargs) when is_binary(text) do
+    do_shorten([text, Map.get(kwargs, "width", 70)], kwargs)
+  end
+
+  defp do_shorten([text, width], kwargs) when is_binary(text) and is_integer(width) do
+    placeholder = Map.get(kwargs, "placeholder", " [...]")
+    # Collapse whitespace (CPython's behavior)
+    collapsed = text |> String.split() |> Enum.join(" ")
+
+    if String.length(collapsed) <= width do
+      collapsed
+    else
+      # Build longest prefix of words such that prefix + placeholder fits.
+      limit = width - String.length(placeholder)
+
+      if limit <= 0 do
+        placeholder
+      else
+        words = String.split(collapsed)
+        shorten_words(words, limit, "", placeholder)
+      end
+    end
+  end
+
+  defp do_shorten(_, _), do: {:exception, "TypeError: shorten() expects a string and width"}
+
+  @spec shorten_words([String.t()], integer(), String.t(), String.t()) :: String.t()
+  defp shorten_words([], _limit, acc, placeholder), do: acc <> placeholder
+
+  defp shorten_words([word | rest], limit, acc, placeholder) do
+    candidate = if acc == "", do: word, else: acc <> " " <> word
+
+    if String.length(candidate) <= limit do
+      shorten_words(rest, limit, candidate, placeholder)
+    else
+      acc <> placeholder
+    end
   end
 
   @spec do_dedent([Pyex.Interpreter.pyvalue()]) :: Pyex.Interpreter.pyvalue()

--- a/test/pyex/conformance/bisect_conformance_test.exs
+++ b/test/pyex/conformance/bisect_conformance_test.exs
@@ -1,0 +1,110 @@
+defmodule Pyex.Conformance.BisectTest do
+  @moduledoc """
+  Live CPython conformance tests for the `bisect` module.
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "bisect_left" do
+    for {label, args} <- [
+          {"middle", "[1, 3, 5, 7], 4"},
+          {"existing", "[1, 3, 5, 7], 3"},
+          {"before start", "[1, 3, 5], 0"},
+          {"after end", "[1, 3, 5], 10"},
+          {"duplicates", "[1, 2, 2, 2, 3], 2"},
+          {"empty", "[], 5"}
+        ] do
+      test "bisect_left #{label}" do
+        check!("""
+        import bisect
+        print(bisect.bisect_left(#{unquote(args)}))
+        """)
+      end
+    end
+  end
+
+  describe "bisect_right" do
+    for {label, args} <- [
+          {"middle", "[1, 3, 5, 7], 4"},
+          {"existing", "[1, 3, 5, 7], 3"},
+          {"duplicates", "[1, 2, 2, 2, 3], 2"},
+          {"before start", "[1, 3, 5], 0"},
+          {"after end", "[1, 3, 5], 10"}
+        ] do
+      test "bisect_right #{label}" do
+        check!("""
+        import bisect
+        print(bisect.bisect_right(#{unquote(args)}))
+        """)
+      end
+    end
+
+    test "bisect alias" do
+      check!("""
+      import bisect
+      print(bisect.bisect([1, 3, 5], 4))
+      """)
+    end
+  end
+
+  describe "insort" do
+    test "insort keeps sorted" do
+      check!("""
+      import bisect
+      xs = [1, 3, 5, 7]
+      bisect.insort(xs, 4)
+      print(xs)
+      """)
+    end
+
+    test "insort_left at duplicate" do
+      check!("""
+      import bisect
+      xs = [1, 2, 2, 2, 3]
+      bisect.insort_left(xs, 2)
+      print(xs)
+      """)
+    end
+
+    test "insort_right at duplicate" do
+      check!("""
+      import bisect
+      xs = [1, 2, 2, 2, 3]
+      bisect.insort_right(xs, 2)
+      print(xs)
+      """)
+    end
+
+    test "insort at end" do
+      check!("""
+      import bisect
+      xs = [1, 3, 5]
+      bisect.insort(xs, 10)
+      print(xs)
+      """)
+    end
+
+    test "insort at start" do
+      check!("""
+      import bisect
+      xs = [5, 10, 15]
+      bisect.insort(xs, 0)
+      print(xs)
+      """)
+    end
+  end
+
+  describe "bisect with lo/hi" do
+    test "bounds slice of list" do
+      check!("""
+      import bisect
+      xs = [0, 1, 2, 3, 4, 5, 6, 7]
+      # search for 3 only in indices [2, 5)
+      print(bisect.bisect_left(xs, 3, 2, 5))
+      """)
+    end
+  end
+end

--- a/test/pyex/conformance/functools_conformance_test.exs
+++ b/test/pyex/conformance/functools_conformance_test.exs
@@ -1,0 +1,119 @@
+defmodule Pyex.Conformance.FunctoolsTest do
+  @moduledoc """
+  Live CPython conformance tests for the `functools` module.
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "reduce" do
+    for {label, expr} <- [
+          {"sum", "functools.reduce(lambda a, b: a + b, [1, 2, 3, 4, 5])"},
+          {"product", "functools.reduce(lambda a, b: a * b, [1, 2, 3, 4, 5])"},
+          {"with initial", "functools.reduce(lambda a, b: a + b, [1, 2, 3], 100)"},
+          {"empty with initial", "functools.reduce(lambda a, b: a + b, [], 42)"},
+          {"str concat", ~S|functools.reduce(lambda a, b: a + b, ["a", "b", "c"])|},
+          {"max-like",
+           "functools.reduce(lambda a, b: a if a > b else b, [3, 1, 4, 1, 5, 9, 2, 6])"}
+        ] do
+      test "reduce #{label}" do
+        check!("""
+        import functools
+        print(#{unquote(expr)})
+        """)
+      end
+    end
+
+    test "empty without initial raises" do
+      check!("""
+      import functools
+      try:
+          functools.reduce(lambda a, b: a + b, [])
+          print("no error")
+      except TypeError:
+          print("TypeError")
+      """)
+    end
+  end
+
+  describe "partial" do
+    test "positional args" do
+      check!("""
+      import functools
+      add10 = functools.partial(lambda a, b: a + b, 10)
+      print(add10(5))
+      """)
+    end
+
+    test "multiple pre-bound args" do
+      check!("""
+      import functools
+      f = functools.partial(lambda a, b, c: a * b + c, 2, 3)
+      print(f(10))
+      """)
+    end
+
+    test "used with map" do
+      check!("""
+      import functools
+      mul2 = functools.partial(lambda a, b: a * b, 2)
+      print(list(map(mul2, [1, 2, 3, 4])))
+      """)
+    end
+  end
+
+  describe "lru_cache / cache" do
+    test "cache memoizes" do
+      check!("""
+      import functools
+
+      calls = [0]
+
+      @functools.cache
+      def expensive(n):
+          calls[0] += 1
+          return n * 2
+
+      # Repeated calls with same arg
+      print(expensive(5))
+      print(expensive(5))
+      print(expensive(5))
+      print(expensive(7))
+      print(calls[0])  # should be 2, not 4
+      """)
+    end
+
+    test "lru_cache works as decorator with parens" do
+      check!("""
+      import functools
+
+      @functools.lru_cache(maxsize=128)
+      def square(n):
+          return n * n
+
+      print(square(4))
+      print(square(4))
+      """)
+    end
+  end
+
+  describe "reduce with real sequences" do
+    test "word frequency via reduce" do
+      check!("""
+      import functools
+
+      words = ["apple", "banana", "apple", "cherry", "banana", "apple"]
+
+      def add_count(acc, word):
+          acc = dict(acc)
+          acc[word] = acc.get(word, 0) + 1
+          return acc
+
+      result = functools.reduce(add_count, words, {})
+      print(sorted(result.items()))
+      """)
+    end
+  end
+end

--- a/test/pyex/conformance/heapq_conformance_test.exs
+++ b/test/pyex/conformance/heapq_conformance_test.exs
@@ -1,0 +1,108 @@
+defmodule Pyex.Conformance.HeapqTest do
+  @moduledoc """
+  Live CPython conformance tests for the `heapq` module.
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "heappush and heappop" do
+    test "heappush maintains heap invariant" do
+      check!("""
+      import heapq
+      h = []
+      for x in [5, 3, 7, 1, 9, 2]:
+          heapq.heappush(h, x)
+      # smallest element always at index 0
+      print(h[0])
+      """)
+    end
+
+    test "heappop returns smallest" do
+      check!("""
+      import heapq
+      h = [5, 3, 7, 1, 9, 2]
+      heapq.heapify(h)
+      result = []
+      while h:
+          result.append(heapq.heappop(h))
+      print(result)
+      """)
+    end
+
+    test "heappushpop more efficient than push+pop" do
+      check!("""
+      import heapq
+      h = [1, 2, 3, 4, 5]
+      heapq.heapify(h)
+      print(heapq.heappushpop(h, 0))
+      print(h)
+      """)
+    end
+
+    test "heapreplace" do
+      check!("""
+      import heapq
+      h = [1, 2, 3]
+      heapq.heapify(h)
+      print(heapq.heapreplace(h, 10))
+      print(h)
+      """)
+    end
+  end
+
+  describe "heapify" do
+    test "converts list to heap" do
+      check!("""
+      import heapq
+      h = [9, 5, 2, 7, 1]
+      heapq.heapify(h)
+      print(h[0])  # smallest
+      """)
+    end
+  end
+
+  describe "nlargest and nsmallest" do
+    test "nlargest" do
+      check!("""
+      import heapq
+      print(heapq.nlargest(3, [1, 8, 2, 23, 7, 4]))
+      """)
+    end
+
+    test "nsmallest" do
+      check!("""
+      import heapq
+      print(heapq.nsmallest(3, [1, 8, 2, 23, 7, 4]))
+      """)
+    end
+
+    test "nlargest with key" do
+      check!("""
+      import heapq
+      items = [("a", 5), ("b", 1), ("c", 9), ("d", 3)]
+      print(heapq.nlargest(2, items, key=lambda x: x[1]))
+      """)
+    end
+
+    test "nsmallest with key" do
+      check!("""
+      import heapq
+      items = [("a", 5), ("b", 1), ("c", 9), ("d", 3)]
+      print(heapq.nsmallest(2, items, key=lambda x: x[1]))
+      """)
+    end
+  end
+
+  describe "merge" do
+    test "merges sorted sequences" do
+      check!("""
+      import heapq
+      result = list(heapq.merge([1, 4, 7], [2, 5, 8], [3, 6, 9]))
+      print(result)
+      """)
+    end
+  end
+end

--- a/test/pyex/conformance/operator_conformance_test.exs
+++ b/test/pyex/conformance/operator_conformance_test.exs
@@ -1,0 +1,132 @@
+defmodule Pyex.Conformance.OperatorTest do
+  @moduledoc """
+  Live CPython conformance tests for the `operator` module.
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "arithmetic functions" do
+    for {label, expr} <- [
+          {"add", "operator.add(3, 4)"},
+          {"sub", "operator.sub(10, 3)"},
+          {"mul_int", "operator.mul(3, 5)"},
+          {"mul_str", ~S|operator.mul("ab", 3)|},
+          {"truediv", "operator.truediv(10, 4)"},
+          {"floordiv", "operator.floordiv(10, 3)"},
+          {"floordiv_neg", "operator.floordiv(-10, 3)"},
+          {"mod", "operator.mod(10, 3)"},
+          {"pow", "operator.pow(2, 10)"},
+          {"neg", "operator.neg(5)"},
+          {"abs", "operator.abs(-7)"}
+        ] do
+      test "#{label}" do
+        check!("import operator\nprint(#{unquote(expr)})")
+      end
+    end
+  end
+
+  describe "bitwise functions" do
+    for {label, expr} <- [
+          {"and_", "operator.and_(0b1100, 0b1010)"},
+          {"or_", "operator.or_(0b1100, 0b1010)"},
+          {"xor", "operator.xor(0b1100, 0b1010)"},
+          {"invert", "operator.invert(5)"},
+          {"lshift", "operator.lshift(1, 5)"},
+          {"rshift", "operator.rshift(32, 2)"}
+        ] do
+      test "#{label}" do
+        check!("import operator\nprint(#{unquote(expr)})")
+      end
+    end
+  end
+
+  describe "comparison functions" do
+    for {label, expr} <- [
+          {"lt", "operator.lt(3, 5)"},
+          {"le equal", "operator.le(3, 3)"},
+          {"eq", "operator.eq(3, 3)"},
+          {"ne", "operator.ne(3, 4)"},
+          {"gt", "operator.gt(5, 3)"},
+          {"ge", "operator.ge(3, 3)"}
+        ] do
+      test "#{label}" do
+        check!("import operator\nprint(#{unquote(expr)})")
+      end
+    end
+  end
+
+  describe "container functions" do
+    test "contains" do
+      check!("import operator\nprint(operator.contains([1, 2, 3], 2))")
+    end
+
+    test "contains miss" do
+      check!("import operator\nprint(operator.contains([1, 2, 3], 99))")
+    end
+
+    test "countOf" do
+      check!("import operator\nprint(operator.countOf([1, 2, 2, 3, 2], 2))")
+    end
+
+    test "indexOf" do
+      check!("import operator\nprint(operator.indexOf([10, 20, 30], 20))")
+    end
+
+    test "getitem list" do
+      check!("import operator\nprint(operator.getitem([10, 20, 30], 1))")
+    end
+
+    test "getitem dict" do
+      check!(~S|import operator
+print(operator.getitem({"a": 1, "b": 2}, "a"))|)
+    end
+
+    test "concat" do
+      check!("import operator\nprint(operator.concat([1, 2], [3, 4]))")
+    end
+  end
+
+  describe "factories" do
+    test "itemgetter single" do
+      check!("""
+      import operator
+      g = operator.itemgetter(1)
+      print(g([10, 20, 30]))
+      """)
+    end
+
+    test "itemgetter multiple" do
+      check!("""
+      import operator
+      g = operator.itemgetter(0, 2)
+      print(g([10, 20, 30]))
+      """)
+    end
+
+    test "attrgetter" do
+      check!("""
+      import operator
+
+      class Point:
+          def __init__(self, x, y):
+              self.x = x
+              self.y = y
+
+      p = Point(3, 4)
+      g = operator.attrgetter("x")
+      print(g(p))
+      """)
+    end
+
+    test "sorted with itemgetter key" do
+      check!("""
+      import operator
+      pairs = [(1, "banana"), (3, "apple"), (2, "cherry")]
+      print(sorted(pairs, key=operator.itemgetter(1)))
+      """)
+    end
+  end
+end

--- a/test/pyex/conformance/python_extras_conformance_test.exs
+++ b/test/pyex/conformance/python_extras_conformance_test.exs
@@ -1,0 +1,203 @@
+defmodule Pyex.Conformance.PythonExtrasTest do
+  @moduledoc """
+  Live CPython conformance tests for Python syntactic features that
+  don't fit elsewhere: walrus operator, dict |= merge, star-unpack in
+  display literals, decorator usage patterns.
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "walrus operator (:=)" do
+    test "in if condition" do
+      check!("""
+      data = [1, 2, 3, 4, 5]
+      if (count := len(data)) > 3:
+          print(f"has {count} items")
+      """)
+    end
+
+    test "in while loop" do
+      check!("""
+      lines = ["a", "b", "", "c"]
+      idx = [0]
+
+      def next_line():
+          if idx[0] >= len(lines):
+              return ""
+          result = lines[idx[0]]
+          idx[0] += 1
+          return result
+
+      while (line := next_line()) != "":
+          print(line)
+      """)
+    end
+
+    test "in list comprehension" do
+      check!("""
+      result = [y for x in range(5) if (y := x * x) > 5]
+      print(result)
+      """)
+    end
+  end
+
+  describe "dict |= merge operator" do
+    test "mutates in place" do
+      check!("""
+      a = {"x": 1, "y": 2}
+      b = {"y": 20, "z": 30}
+      a |= b
+      print(sorted(a.items()))
+      """)
+    end
+
+    test "| produces new dict" do
+      check!("""
+      a = {"x": 1}
+      b = {"y": 2}
+      merged = a | b
+      # original a unchanged
+      print(sorted(a.items()))
+      print(sorted(merged.items()))
+      """)
+    end
+  end
+
+  describe "star unpack in displays" do
+    test "list literal" do
+      check!("""
+      a = [1, 2]
+      b = [3, 4]
+      print([*a, *b, 5])
+      """)
+    end
+
+    test "set literal" do
+      check!("""
+      a = {1, 2}
+      b = {3, 4}
+      print(sorted({*a, *b, 5}))
+      """)
+    end
+
+    test "tuple literal" do
+      check!("""
+      a = (1, 2)
+      b = (3, 4)
+      print((*a, *b, 5))
+      """)
+    end
+
+    test "dict literal with **" do
+      check!("""
+      a = {"x": 1, "y": 2}
+      b = {"z": 3}
+      merged = {**a, **b, "w": 4}
+      print(sorted(merged.items()))
+      """)
+    end
+
+    test "override in dict merge" do
+      check!("""
+      a = {"x": 1, "y": 2}
+      b = {"y": 20}
+      print(sorted({**a, **b}.items()))
+      """)
+    end
+  end
+
+  describe "decorators" do
+    test "property and setter" do
+      check!("""
+      class Temp:
+          def __init__(self):
+              self._c = 0
+
+          @property
+          def c(self):
+              return self._c
+
+          @c.setter
+          def c(self, v):
+              if v < -273.15:
+                  raise ValueError("below absolute zero")
+              self._c = v
+
+      t = Temp()
+      t.c = 25
+      print(t.c)
+
+      try:
+          t.c = -300
+      except ValueError as e:
+          print("caught:", str(e))
+      """)
+    end
+
+    test "staticmethod and classmethod" do
+      check!("""
+      class Greeting:
+          greeting = "Hello"
+
+          @staticmethod
+          def exclaim(msg):
+              return msg + "!"
+
+          @classmethod
+          def greet(cls, name):
+              return f"{cls.greeting}, {name}"
+
+      print(Greeting.exclaim("wow"))
+      print(Greeting.greet("Alice"))
+      """)
+    end
+
+    test "custom decorator with closure" do
+      check!("""
+      def repeat(n):
+          def decorator(f):
+              def wrapped(*args, **kwargs):
+                  results = []
+                  for _ in range(n):
+                      results.append(f(*args, **kwargs))
+                  return results
+              return wrapped
+          return decorator
+
+      @repeat(3)
+      def greet(name):
+          return f"hi {name}"
+
+      print(greet("world"))
+      """)
+    end
+  end
+
+  describe "advanced unpacking" do
+    test "starred in middle of tuple assignment" do
+      check!("""
+      a, *middle, b = [1, 2, 3, 4, 5]
+      print(a, middle, b)
+      """)
+    end
+
+    test "star-unpack in function call" do
+      check!("""
+      def f(a, b, c): return a + b + c
+      args = [1, 2, 3]
+      print(f(*args))
+      """)
+    end
+
+    test "double-star unpack in function call" do
+      check!("""
+      def f(a, b, c): return a + b * c
+      kw = {"a": 1, "b": 2, "c": 3}
+      print(f(**kw))
+      """)
+    end
+  end
+end

--- a/test/pyex/conformance/textwrap_conformance_test.exs
+++ b/test/pyex/conformance/textwrap_conformance_test.exs
@@ -1,0 +1,92 @@
+defmodule Pyex.Conformance.TextwrapTest do
+  @moduledoc """
+  Live CPython conformance tests for the `textwrap` module.
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "dedent" do
+    test "removes common leading whitespace" do
+      check!(~S"""
+      import textwrap
+      s = "    line1\n    line2\n    line3"
+      print(repr(textwrap.dedent(s)))
+      """)
+    end
+
+    test "handles mixed indent correctly" do
+      check!(~S"""
+      import textwrap
+      s = "  a\n    b\n  c"
+      print(repr(textwrap.dedent(s)))
+      """)
+    end
+
+    test "empty lines do not count as indent" do
+      check!(~S"""
+      import textwrap
+      s = "  a\n\n  b"
+      print(repr(textwrap.dedent(s)))
+      """)
+    end
+
+    test "no common indent leaves text unchanged" do
+      check!(~S"""
+      import textwrap
+      s = "a\n  b\n    c"
+      print(repr(textwrap.dedent(s)))
+      """)
+    end
+  end
+
+  describe "indent" do
+    test "prefixes each non-empty line" do
+      check!(~S"""
+      import textwrap
+      s = "a\nb\nc"
+      print(repr(textwrap.indent(s, "> ")))
+      """)
+    end
+
+    test "skips blank lines by default" do
+      check!(~S"""
+      import textwrap
+      s = "a\n\nb"
+      print(repr(textwrap.indent(s, "> ")))
+      """)
+    end
+  end
+
+  describe "fill" do
+    test "wraps text into paragraph" do
+      check!("""
+      import textwrap
+      s = "The quick brown fox jumps over the lazy dog"
+      print(textwrap.fill(s, width=20))
+      """)
+    end
+  end
+
+  describe "wrap" do
+    test "wraps into list of lines" do
+      check!("""
+      import textwrap
+      s = "hello world this is a test of wrapping"
+      print(textwrap.wrap(s, width=15))
+      """)
+    end
+  end
+
+  describe "shorten" do
+    test "truncates long text with placeholder" do
+      check!("""
+      import textwrap
+      s = "Hello world, this is some long text"
+      print(textwrap.shorten(s, width=20))
+      """)
+    end
+  end
+end


### PR DESCRIPTION
Extends Pyex's Python stdlib surface and fixes three interpreter bugs
that block common idioms.

## New stdlib modules

- **operator** (~50 functions): all functional operator counterparts,
  plus `attrgetter`/`itemgetter`/`methodcaller` factories
- **bisect**: `bisect_left`, `bisect_right`, `insort_*`, with `lo`/`hi`
  bounds

## Extended existing modules

- **heapq**: added `heappushpop`, `nlargest`, `nsmallest`, `merge`
  (with `key=` kwarg support via `:ctx_call` deferral)
- **textwrap**: added `shorten(text, width, placeholder=...)`

## Interpreter bug fixes

### 1. `@lru_cache` + recursive self-reference (high-impact)

Decorators like `@lru_cache` applied to recursive functions had their
wrapper stripped on every recursive call.  Root cause: scope
propagation wrote the raw (undecorated) function back to the caller's
global scope.

    @functools.cache
    def fib(n):
        return n if n < 2 else fib(n-1) + fib(n-2)
    # Before: every call re-evaluates (no cache)
    # After:  cache hit returns O(1)

Fix: when entering a function call, prefer the caller's current
binding for the function name over the closure's stale copy.

### 2. `map(partial, iter)` lost pre-bound args

`functools.partial` wrapped a function, but when the inner function
returned an updated closure (via Pyex's 4-tuple return), the partial
wrapper was discarded.  Second call in `map` used the raw inner,
triggering a TypeError.

Fix: re-wrap the updated inner back into a partial before returning.
Also extended `map` to accept `partial`, `lru_cached_function`,
classes, exception classes, instances, and bound methods as the
callable argument.

### 3. Property setter exceptions were silently swallowed

    @x.setter
    def x(self, v):
        if v < 0: raise ValueError(...)
        self._x = v
    try:
        obj.x = -1
    except ValueError:  # never reached in Pyex before
        ...

Root cause: `call_function` returns a 4-tuple with `updated_func` for
user-defined setters, but the setattr match clause only handled the
3-tuple exception case.  The 4-tuple fell through, replacing the
exception with `nil`.

Fix: add explicit 4-tuple exception clause to setattr dispatch.  Also
added `:mutate_arg` handling to `handle_builtin_kw_result` so
`bisect.insort` (a builtin_kw that mutates its first arg) works.

## Conformance tests added (83 tests)

- functools (13): reduce, partial, cache, lru_cache with state
- operator (33): arithmetic, bitwise, comparison, container, factories
- bisect (12): bisect_left/right, insort variants, bounds
- heapq (10): push/pop/pushpop/replace, nlargest/nsmallest, merge
- textwrap (9): dedent, indent, wrap, fill, shorten
- python_extras (16): walrus operator, dict |=, star-unpack displays,
  property+setter with exception, custom decorators with closures,
  starred unpacking patterns

All passing against live CPython.

## Test count

|       | Before | After |
| ----- | -----: | ----: |
| Tests | 4524   | 4611  |

## Verification

- `mix compile --warnings-as-errors`: clean
- `mix format --check-formatted`: clean
- `mix test`: **4611 tests, 0 failures, 8 skipped**
- `mix dialyzer`: 39 total errors (unchanged from main baseline)

## TODO.txt cleanup

Removed the outdated "decorators not yet implemented" entry.  Pyex
supports `@property`, `@property.setter`, `@staticmethod`, `@classmethod`,
and custom decorators including those that take arguments.