### PR TITLE
Fix requests.post(json=...) crash on nested list values

### DIFF
--- a/lib/pyex/stdlib/requests.ex
+++ b/lib/pyex/stdlib/requests.ex
@@ -402,6 +402,10 @@ defmodule Pyex.Stdlib.Requests do
 
   @spec to_jason_compatible(Pyex.Interpreter.pyvalue()) :: term()
   defp to_jason_compatible({:tuple, items}), do: Enum.map(items, &to_jason_compatible/1)
+
+  defp to_jason_compatible({:py_list, reversed, _len}),
+    do: reversed |> Enum.reverse() |> Enum.map(&to_jason_compatible/1)
+
   defp to_jason_compatible(list) when is_list(list), do: Enum.map(list, &to_jason_compatible/1)
 
   defp to_jason_compatible({:py_dict, _, _} = dict) do

--- a/test/pyex/stdlib/requests_test.exs
+++ b/test/pyex/stdlib/requests_test.exs
@@ -187,6 +187,41 @@ defmodule Pyex.Stdlib.RequestsTest do
       assert result == [201, true]
     end
 
+    test "posts JSON body containing nested py_list values", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "POST", "/api/nested", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        payload = Jason.decode!(body)
+
+        assert payload == %{
+                 "items" => [%{"key" => "value"}],
+                 "tags" => ["a", "b"],
+                 "nested" => %{"nums" => [1, 2, 3]}
+               }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, ~s({"ok": true}))
+      end)
+
+      port = bypass.port
+
+      result =
+        Pyex.run!(
+          """
+          import requests
+          response = requests.post("http://localhost:#{port}/api/nested", json={
+              "items": [{"key": "value"}],
+              "tags": ["a", "b"],
+              "nested": {"nums": [1, 2, 3]}
+          })
+          response.status_code
+          """,
+          network: @network
+        )
+
+      assert result == 200
+    end
+
     test "posts with custom headers", %{bypass: bypass} do
       Bypass.expect_once(bypass, "POST", "/api/auth", fn conn ->
         [auth] = Plug.Conn.get_req_header(conn, "x-api-key")


### PR DESCRIPTION
## Summary

- `to_jason_compatible/1` did not handle `{:py_list, reversed, len}` tuples, so Python lists nested inside dicts (e.g. `{"items": [{"key": "value"}]}`) passed through to Jason as raw tuples and raised `Protocol.UndefinedError`
- Added a clause that reverses the internal storage order and recursively converts items
- Added test covering nested lists-of-dicts, lists-of-scalars, and dicts-containing-lists

## Test plan

- [x] `mix test test/pyex/stdlib/requests_test.exs` — 37 tests, 0 failures
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)