### PR TITLE
Correctness: closure scopes, aug-subscript heap writes, parser `;`, lazy generators

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -12,6 +12,12 @@
   # Dialyzer cannot see {:exception, _} in the pyvalue() type since it is a
   # control-flow signal, not a Python value. The pattern match is reachable at runtime.
   {"lib/pyex/lambda.ex", :pattern_match},
+  # drain_streaming_chunks receives the response body as term(), pattern-matches
+  # {:iterator, id}, and passes id to drain_generator_iter(non_neg_integer(), ...).
+  # Dialyzer cannot narrow id from any() to non_neg_integer() through the pattern
+  # match alone; at runtime id is always a non_neg_integer() as produced by the
+  # iterator pool. This is a false positive.
+  {"lib/pyex/lambda.ex", :call},
   # MapSet is an opaque type. Dialyzer complains when it appears in struct fields
   # because it cannot see through the opaque boundary. The capabilities MapSet is
   # used correctly via MapSet.member?/2 and MapSet.new/1 -- these are false positives.

--- a/lib/pyex/builtins.ex
+++ b/lib/pyex/builtins.ex
@@ -95,6 +95,29 @@ defmodule Pyex.Builtins do
   @spec exception_class_names() :: [String.t()]
   def exception_class_names, do: Pyex.ExceptionsHierarchy.all_names()
 
+  @doc """
+  Set of builtin function captures that must receive a generator
+  iterator *as itself* — not its drained contents. Anything that
+  reflects on identity, type, or treats the iterator as opaque
+  (`iter`, `next`, `type`, `isinstance`, `id`, `repr`, `len`).
+
+  Used by the builtin call path to suppress eager drain for these.
+  """
+  @spec no_drain_builtin_funcs() :: MapSet.t(function())
+  def no_drain_builtin_funcs do
+    names = ~w(iter next type isinstance id repr len)
+
+    captures =
+      for {name, fun} <- all(), name in names do
+        case fun do
+          {:kw, f} -> f
+          f -> f
+        end
+      end
+
+    MapSet.new(captures)
+  end
+
   @spec all() :: [{String.t(), ([Interpreter.pyvalue()] -> Interpreter.pyvalue())}]
   defp all do
     [
@@ -966,6 +989,15 @@ defmodule Pyex.Builtins do
 
     {:ok,
      Enum.reduce(list, PyDict.new(), fn
+       {:tuple, [k, v]}, acc -> PyDict.put(acc, k, v)
+       [k, v], acc -> PyDict.put(acc, k, v)
+       _, acc -> acc
+     end)}
+  end
+
+  defp builtin_dict_positional([{:generator, items}]) do
+    {:ok,
+     Enum.reduce(items, PyDict.new(), fn
        {:tuple, [k, v]}, acc -> PyDict.put(acc, k, v)
        [k, v], acc -> PyDict.put(acc, k, v)
        _, acc -> acc

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -49,7 +49,7 @@ defmodule Pyex.Ctx do
 
   @type capability :: :boto3 | :sql | atom()
 
-  @type generator_mode :: :accumulate | :defer | :defer_inner | nil
+  @type generator_mode :: :accumulate | :defer | :defer_inner | :lazy_iter | nil
 
   @type t :: %__MODULE__{
           filesystem: term(),
@@ -98,7 +98,7 @@ defmodule Pyex.Ctx do
             file_ops: 0,
             compute_started_at: nil,
             profile: nil,
-            generator_mode: nil,
+            generator_mode: :lazy_iter,
             generator_acc: nil,
             iterators: %{},
             next_iterator_id: 0,
@@ -942,10 +942,64 @@ defmodule Pyex.Ctx do
   end
 
   @doc """
+  Creates a new generator iterator, returning the iterator token and
+  updated context.
+
+  The generator has been pre-run to its first yield. The pool entry
+  carries the *queued* yield value (returned by the first `next` /
+  first for-loop iteration without resuming) plus the continuation
+  needed to advance to subsequent yields.
+  """
+  @spec new_generator_iterator(t(), term(), [term()], term()) ::
+          {{:iterator, non_neg_integer()}, t()}
+  def new_generator_iterator(
+        %__MODULE__{iterators: iters, next_iterator_id: id} = ctx,
+        first_val,
+        cont,
+        gen_env
+      ) do
+    entry = {:gen_pending, first_val, cont, gen_env}
+    ctx = %{ctx | iterators: Map.put(iters, id, entry), next_iterator_id: id + 1}
+    {{:iterator, id}, ctx}
+  end
+
+  @doc """
+  Inspects an iterator's stored entry without mutating state.
+  Returns `nil` for unknown ids.
+  """
+  @spec iter_entry(t(), non_neg_integer()) :: term() | nil
+  def iter_entry(%__MODULE__{iterators: iters}, id), do: Map.get(iters, id)
+
+  @doc """
+  Marks a generator iterator as exhausted.
+  """
+  @spec mark_iter_exhausted(t(), non_neg_integer()) :: t()
+  def mark_iter_exhausted(%__MODULE__{iterators: iters} = ctx, id) do
+    %{ctx | iterators: Map.put(iters, id, :gen_done)}
+  end
+
+  @doc """
+  Updates a generator iterator's pending entry after a successful resume.
+  """
+  @spec set_gen_pending(t(), non_neg_integer(), term(), [term()], term()) :: t()
+  def set_gen_pending(%__MODULE__{iterators: iters} = ctx, id, val, cont, gen_env) do
+    %{ctx | iterators: Map.put(iters, id, {:gen_pending, val, cont, gen_env})}
+  end
+
+  @doc """
   Advances a plain list iterator, returning the next item
   or `:exhausted` if the iterator is empty.
+
+  For generator iterators, returns the queued yield value plus the
+  continuation needed to advance further. The caller resumes the
+  generator (using `Pyex.Interpreter.resume_generator/3`) and updates
+  the pool via `set_gen_pending/5` or `mark_iter_exhausted/2`.
   """
-  @spec iter_next(t(), non_neg_integer()) :: {:ok, term(), t()} | :exhausted | {:instance, term()}
+  @spec iter_next(t(), non_neg_integer()) ::
+          {:ok, term(), t()}
+          | :exhausted
+          | {:instance, term()}
+          | {:gen_pending, term(), [term()], term()}
   def iter_next(%__MODULE__{iterators: iters} = ctx, id) do
     case Map.get(iters, id) do
       {:list, [item | rest]} ->
@@ -957,6 +1011,12 @@ defmodule Pyex.Ctx do
 
       {:instance, inst} ->
         {:instance, inst}
+
+      {:gen_pending, val, cont, gen_env} ->
+        {:gen_pending, val, cont, gen_env}
+
+      :gen_done ->
+        :exhausted
 
       nil ->
         :exhausted

--- a/lib/pyex/env.ex
+++ b/lib/pyex/env.ex
@@ -143,26 +143,48 @@ defmodule Pyex.Env do
   end
 
   @doc """
-  Replaces the bottom (module-level) scope with `new_bottom`.
-  """
-  @spec put_global_scope(t(), scope(), reference()) :: t()
-  def put_global_scope(%__MODULE__{scopes: [_]} = env, new_bottom, new_bottom_id) do
-    %{env | scopes: [new_bottom], scope_ids: [new_bottom_id], global: new_bottom}
-  end
+  Builds a fresh environment for a closure call: every captured scope
+  whose ID matches a scope in the caller is replaced with the caller's
+  *current* version of that scope. Captured scopes that no longer
+  appear in the caller (e.g. a closure returned from a function that
+  has already exited) are left as their original snapshots.
 
-  def put_global_scope(
-        %__MODULE__{scopes: scopes, scope_ids: scope_ids} = env,
-        new_bottom,
-        new_bottom_id
+  The bottom (module-level) scope is always replaced with the caller's
+  current global, even if the IDs differ — globals are conceptually
+  shared, and the caller's view is always the source of truth.
+
+  Without this, calling a closure from inside a loop or any post-`def`
+  mutation in the enclosing function would propagate a *stale* snapshot
+  of the enclosing scope back to the caller after the call, wiping any
+  bindings the caller had added since `def` (e.g. for-loop variables).
+  """
+  @spec refresh_from_caller(t(), t()) :: t()
+  def refresh_from_caller(
+        %__MODULE__{scopes: closure_scopes, scope_ids: closure_scope_ids} = closure_env,
+        %__MODULE__{} = caller_env
       ) do
-    upper = Enum.drop(scopes, -1)
-    upper_ids = Enum.drop(scope_ids, -1)
+    caller_global = global_scope(caller_env)
+    caller_global_id = global_scope_id(caller_env)
+
+    caller_by_id =
+      caller_env.scope_ids
+      |> Enum.zip(caller_env.scopes)
+      |> Map.new()
+
+    upper_pairs =
+      closure_scope_ids
+      |> Enum.zip(closure_scopes)
+      |> Enum.drop(-1)
+      |> Enum.map(fn {id, scope} -> {id, Map.get(caller_by_id, id, scope)} end)
+
+    {refreshed_ids, refreshed_scopes} =
+      Enum.unzip(upper_pairs ++ [{caller_global_id, caller_global}])
 
     %{
-      env
-      | scopes: upper ++ [new_bottom],
-        scope_ids: upper_ids ++ [new_bottom_id],
-        global: new_bottom
+      closure_env
+      | scopes: refreshed_scopes,
+        scope_ids: refreshed_ids,
+        global: caller_global
     }
   end
 

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -572,24 +572,20 @@ defmodule Pyex.Interpreter do
             {{:exception, "SyntaxError: 'yield from' outside function"}, env, ctx}
         end
 
-      {iterable, env, ctx} ->
-        case to_iterable(iterable, env, ctx) do
-          {:ok, items, env, ctx} ->
-            case ctx.generator_mode do
-              mode when mode in [:defer, :defer_inner] ->
-                yield_from_deferred(items, env, ctx)
+      {{:iterator, id} = iter, env, ctx} ->
+        case Pyex.Ctx.iter_entry(ctx, id) do
+          {:gen_pending, _, _, _} when ctx.generator_mode in [:defer, :defer_inner] ->
+            yield_from_gen_iter(id, env, ctx)
 
-              :accumulate ->
-                ctx = %{ctx | generator_acc: Enum.reverse(items) ++ ctx.generator_acc}
-                {nil, env, ctx}
+          :gen_done when ctx.generator_mode in [:defer, :defer_inner] ->
+            {nil, env, ctx}
 
-              nil ->
-                {{:exception, "SyntaxError: 'yield from' outside function"}, env, ctx}
-            end
-
-          {:exception, msg} ->
-            {{:exception, msg}, env, ctx}
+          _ ->
+            yield_from_general(iter, env, ctx)
         end
+
+      {iterable, env, ctx} ->
+        yield_from_general(iterable, env, ctx)
     end
   end
 
@@ -3431,6 +3427,47 @@ defmodule Pyex.Interpreter do
     {{:yielded, item, [{:cont_yield_from, rest}]}, env, ctx}
   end
 
+  @spec yield_from_general(pyvalue(), Env.t(), Ctx.t()) :: eval_result()
+  defp yield_from_general(iterable, env, ctx) do
+    case to_iterable(iterable, env, ctx) do
+      {:ok, items, env, ctx} ->
+        case ctx.generator_mode do
+          mode when mode in [:defer, :defer_inner] ->
+            yield_from_deferred(items, env, ctx)
+
+          :accumulate ->
+            ctx = %{ctx | generator_acc: Enum.reverse(items) ++ ctx.generator_acc}
+            {nil, env, ctx}
+
+          nil ->
+            {{:exception, "SyntaxError: 'yield from' outside function"}, env, ctx}
+        end
+
+      {:exception, msg} ->
+        {{:exception, msg}, env, ctx}
+    end
+  end
+
+  @doc """
+  Lazy `yield from` over a generator iterator. Yields the first
+  pending value, then attaches a `:cont_yield_from_iter` frame so the
+  generator advances one step at a time on resumption — preserving
+  side-effect ordering and partial-yield-then-error semantics.
+  """
+  @spec yield_from_gen_iter(non_neg_integer(), Env.t(), Ctx.t()) :: eval_result()
+  def yield_from_gen_iter(id, env, ctx) do
+    case Pyex.Ctx.iter_entry(ctx, id) do
+      {:gen_pending, val, _cont, _gen_env} ->
+        {{:yielded, val, [{:cont_yield_from_iter, id}]}, env, ctx}
+
+      :gen_done ->
+        {nil, env, ctx}
+
+      _ ->
+        {nil, env, ctx}
+    end
+  end
+
   @type cont_frame ::
           {:cont_stmts, [Parser.ast_node()]}
           | {:cont_for, String.t() | [String.t()], [pyvalue()], [Parser.ast_node()],
@@ -3507,6 +3544,61 @@ defmodule Pyex.Interpreter do
         {{:yielded, val, inner_cont ++ rest}, env, ctx}
 
       {_, env, ctx} ->
+        resume_generator(rest, env, ctx)
+    end
+  end
+
+  def resume_generator(
+        [{:cont_for_gen_iter, var_name, id, body, else_body} | rest],
+        env,
+        ctx
+      ) do
+    case ControlFlow.resume_for_gen_iter(var_name, id, body, else_body, env, ctx) do
+      {{:yielded, val, inner_cont}, env, ctx} ->
+        {{:yielded, val, inner_cont ++ rest}, env, ctx}
+
+      {{:returned, _}, env, ctx} ->
+        {:done, env, ctx}
+
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {_, env, ctx} ->
+        resume_generator(rest, env, ctx)
+    end
+  end
+
+  def resume_generator([{:cont_yield_from_iter, id} | rest], env, ctx) do
+    # Advance the source generator one step. On yield, propagate. On
+    # done, fall through to the rest of the outer continuation. On
+    # exception, surface it (this is how `yield from gen()` exposes
+    # exceptions raised mid-stream).
+    saved_mode = ctx.generator_mode
+    inner_ctx = %{ctx | generator_mode: :defer_inner}
+
+    case Pyex.Ctx.iter_entry(ctx, id) do
+      {:gen_pending, _val, cont, gen_env} ->
+        case resume_generator(cont, gen_env, inner_ctx) do
+          {{:yielded, val, next_cont}, next_gen_env, ctx} ->
+            ctx = %{ctx | generator_mode: saved_mode}
+            ctx = Pyex.Ctx.set_gen_pending(ctx, id, val, next_cont, next_gen_env)
+            {{:yielded, val, [{:cont_yield_from_iter, id}] ++ rest}, env, ctx}
+
+          {:done, _gen_env, ctx} ->
+            ctx = %{ctx | generator_mode: saved_mode}
+            ctx = Pyex.Ctx.mark_iter_exhausted(ctx, id)
+            resume_generator(rest, env, ctx)
+
+          {{:exception, _} = signal, _gen_env, ctx} ->
+            ctx = %{ctx | generator_mode: saved_mode}
+            ctx = Pyex.Ctx.mark_iter_exhausted(ctx, id)
+            {signal, env, ctx}
+        end
+
+      :gen_done ->
+        resume_generator(rest, env, ctx)
+
+      _ ->
         resume_generator(rest, env, ctx)
     end
   end

--- a/lib/pyex/interpreter/assignments.ex
+++ b/lib/pyex/interpreter/assignments.ex
@@ -540,10 +540,10 @@ defmodule Pyex.Interpreter.Assignments do
                   {signal, env, ctx}
 
                 {default_val, env, ctx, _updated_func} ->
-                  do_aug_subscript(obj, key, op, val, default_val, var_name, env, ctx)
+                  do_aug_subscript(raw_obj, obj, key, op, val, default_val, var_name, env, ctx)
 
                 {default_val, env, ctx} ->
-                  do_aug_subscript(obj, key, op, val, default_val, var_name, env, ctx)
+                  do_aug_subscript(raw_obj, obj, key, op, val, default_val, var_name, env, ctx)
               end
 
             current_val ->
@@ -553,7 +553,8 @@ defmodule Pyex.Interpreter.Assignments do
 
                 new_val ->
                   new_obj = set_subscript_value(obj, key, new_val)
-                  {new_val, Env.put_at_source(env, var_name, new_obj), ctx}
+                  {env, ctx} = ref_write_back(raw_obj, new_obj, var_name, env, ctx)
+                  {new_val, env, ctx}
               end
           end
         else
@@ -565,7 +566,7 @@ defmodule Pyex.Interpreter.Assignments do
     end
   end
 
-  defp do_aug_subscript(obj, key, op, val, default_val, var_name, env, ctx) do
+  defp do_aug_subscript(raw_obj, obj, key, op, val, default_val, var_name, env, ctx) do
     # Insert default into dict first (auto-insert), then apply aug op
     obj = set_subscript_value(obj, key, default_val)
 
@@ -575,7 +576,8 @@ defmodule Pyex.Interpreter.Assignments do
 
       new_val ->
         new_obj = set_subscript_value(obj, key, new_val)
-        {new_val, Env.put_at_source(env, var_name, new_obj), ctx}
+        {env, ctx} = ref_write_back(raw_obj, new_obj, var_name, env, ctx)
+        {new_val, env, ctx}
     end
   end
 

--- a/lib/pyex/interpreter/builtin_results.ex
+++ b/lib/pyex/interpreter/builtin_results.ex
@@ -69,6 +69,7 @@ defmodule Pyex.Interpreter.BuiltinResults do
           {:ok, item, ctx} -> {item, env, ctx}
           :exhausted -> {{:exception, "StopIteration"}, env, ctx}
           {:instance, inst} -> Interpreter.eval_instance_next(inst, id, :no_default, env, ctx)
+          {:gen_pending, val, cont, gen_env} -> step_generator(id, val, cont, gen_env, env, ctx)
         end
 
       {:iter_next_default, id, default} ->
@@ -81,6 +82,12 @@ defmodule Pyex.Interpreter.BuiltinResults do
 
           {:instance, inst} ->
             Interpreter.eval_instance_next(inst, id, {:default, default}, env, ctx)
+
+          {:gen_pending, val, cont, gen_env} ->
+            case step_generator(id, val, cont, gen_env, env, ctx) do
+              {{:exception, "StopIteration"}, env, ctx} -> {default, env, ctx}
+              other -> other
+            end
         end
 
       {:next_instance_iter, id, default_opt} ->
@@ -310,4 +317,32 @@ defmodule Pyex.Interpreter.BuiltinResults do
   defp sum_step(x, acc) when is_list(x) and is_list(acc), do: acc ++ x
   defp sum_step({:tuple, x}, {:tuple, acc}), do: {:tuple, acc ++ x}
   defp sum_step(x, acc) when is_binary(x) and is_binary(acc), do: acc <> x
+
+  # Pop the queued yield value, then resume the generator (with the
+  # interpreter back in `:defer_inner` mode) so the next `next()` call
+  # finds the new pending value. Mirrors what `eval_for_generator_iter`
+  # does for the for-loop path.
+  @spec step_generator(non_neg_integer(), term(), [term()], Env.t(), Env.t(), Ctx.t()) ::
+          eval_result()
+  defp step_generator(id, val, cont, gen_env, env, ctx) do
+    saved_mode = ctx.generator_mode
+    inner_ctx = %{ctx | generator_mode: :defer_inner}
+
+    case Interpreter.resume_generator(cont, gen_env, inner_ctx) do
+      {{:yielded, next_val, next_cont}, next_gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Ctx.set_gen_pending(ctx, id, next_val, next_cont, next_gen_env)
+        {val, env, ctx}
+
+      {:done, _gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Ctx.mark_iter_exhausted(ctx, id)
+        {val, env, ctx}
+
+      {{:exception, _} = signal, _gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Ctx.mark_iter_exhausted(ctx, id)
+        {signal, env, ctx}
+    end
+  end
 end

--- a/lib/pyex/interpreter/control_flow.ex
+++ b/lib/pyex/interpreter/control_flow.ex
@@ -71,14 +71,225 @@ defmodule Pyex.Interpreter.ControlFlow do
           {_, env, ctx} -> {{:exception, exception_msg}, env, ctx}
         end
 
-      {iterable, env, ctx} ->
-        case Interpreter.to_iterable(iterable, env, ctx) do
-          {:ok, items, env, ctx} ->
-            eval_for_items(var_name, items, body, else_body, env, ctx, source_var)
+      {{:iterator, id}, env, ctx} ->
+        # Lazy path: when the iterable is a generator iterator, step
+        # one yield at a time and execute the for body between yields.
+        # This is the difference between observing CPython-conformant
+        # interleaving (gen-before, body, gen-after, gen-before, ...)
+        # and eager materialisation (which mis-orders side effects).
+        case Pyex.Ctx.iter_entry(ctx, id) do
+          {:gen_pending, _val, _cont, _gen_env} ->
+            eval_for_generator_iter(var_name, id, body, else_body, env, ctx)
 
-          {:exception, msg} ->
-            {{:exception, msg}, env, ctx}
+          :gen_done ->
+            eval_loop_else(else_body, env, ctx)
+
+          _ ->
+            iterable_to_for({:iterator, id}, var_name, body, else_body, env, ctx, source_var)
         end
+
+      {iterable, env, ctx} ->
+        iterable_to_for(iterable, var_name, body, else_body, env, ctx, source_var)
+    end
+  end
+
+  @spec iterable_to_for(
+          Interpreter.pyvalue(),
+          String.t() | [String.t()],
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t(),
+          String.t() | nil
+        ) :: eval_result()
+  defp iterable_to_for(iterable, var_name, body, else_body, env, ctx, source_var) do
+    case Interpreter.to_iterable(iterable, env, ctx) do
+      {:ok, items, env, ctx} ->
+        eval_for_items(var_name, items, body, else_body, env, ctx, source_var)
+
+      {:exception, msg} ->
+        {{:exception, msg}, env, ctx}
+    end
+  end
+
+  @spec eval_for_generator_iter(
+          String.t() | [String.t()],
+          non_neg_integer(),
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  defp eval_for_generator_iter(var_name, id, body, else_body, env, ctx) do
+    case Pyex.Ctx.iter_entry(ctx, id) do
+      {:gen_pending, val, cont, gen_env} ->
+        case Pyex.Ctx.check_step(ctx) do
+          {:exceeded, msg} ->
+            {{:exception, msg}, env, ctx}
+
+          {:ok, ctx} ->
+            ctx = Pyex.Ctx.record(ctx, :loop, nil)
+            env = bind_loop_var(var_name, val, env)
+
+            case env do
+              {:exception, _} = signal ->
+                {signal, env, ctx}
+
+              env ->
+                step_generator_body(var_name, id, cont, gen_env, body, else_body, env, ctx)
+            end
+        end
+
+      :gen_done ->
+        eval_loop_else(else_body, env, ctx)
+
+      _ ->
+        eval_loop_else(else_body, env, ctx)
+    end
+  end
+
+  @spec step_generator_body(
+          String.t() | [String.t()],
+          non_neg_integer(),
+          [term()],
+          Env.t(),
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  defp step_generator_body(var_name, id, cont, gen_env, body, else_body, env, ctx) do
+    # `cont` and `gen_env` are the *generator's* current continuation
+    # state; we hold them so that on resume we keep stepping. They
+    # don't change between yields of the *for-loop body* itself.
+    _ = cont
+    _ = gen_env
+
+    case Interpreter.eval_statements(body, env, ctx) do
+      {{:returned, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {{:break}, env, ctx} ->
+        ctx = Pyex.Ctx.mark_iter_exhausted(ctx, id)
+        {nil, env, ctx}
+
+      {{:exception, _} = signal, env, ctx} ->
+        ctx = Pyex.Ctx.mark_iter_exhausted(ctx, id)
+        {signal, env, ctx}
+
+      {{:yielded, val, inner_cont}, env, ctx} ->
+        # Body yielded — we are inside a generator whose body is itself
+        # a `for x in gen():` loop. Defer the rest of *this* loop into
+        # a continuation frame so the outer consumer can advance us
+        # through `resume_generator`.
+        cont_frame = {:cont_for_gen_iter, var_name, id, body, else_body}
+        {{:yielded, val, inner_cont ++ [cont_frame]}, env, ctx}
+
+      {{:continue}, env, ctx} ->
+        advance_generator_iter(var_name, id, cont, gen_env, body, else_body, env, ctx)
+
+      {_, env, ctx} ->
+        advance_generator_iter(var_name, id, cont, gen_env, body, else_body, env, ctx)
+    end
+  end
+
+  @doc """
+  Resumes a `for x in gen_iter:` loop inside a generator after a
+  body yield. Called by `Pyex.Interpreter.resume_generator/3` when
+  it sees a `:cont_for_gen_iter` frame.
+  """
+  @spec resume_for_gen_iter(
+          String.t() | [String.t()],
+          non_neg_integer(),
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  def resume_for_gen_iter(var_name, id, body, else_body, env, ctx) do
+    case Pyex.Ctx.iter_entry(ctx, id) do
+      {:gen_pending, _, _, _} ->
+        case Pyex.Ctx.iter_next(ctx, id) do
+          {:gen_pending, val, cont, gen_env} ->
+            advance_after_body_yield(var_name, id, val, cont, gen_env, body, else_body, env, ctx)
+        end
+
+      :gen_done ->
+        eval_loop_else(else_body, env, ctx)
+
+      _ ->
+        eval_loop_else(else_body, env, ctx)
+    end
+  end
+
+  # After the for-body yielded, we still hold the *current* iterator
+  # value (already consumed by the previous body invocation). Resume by
+  # advancing one step, then re-entering the loop body.
+  @spec advance_after_body_yield(
+          String.t() | [String.t()],
+          non_neg_integer(),
+          term(),
+          [term()],
+          Env.t(),
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  defp advance_after_body_yield(var_name, id, _val, cont, gen_env, body, else_body, env, ctx) do
+    saved_mode = ctx.generator_mode
+    inner_ctx = %{ctx | generator_mode: :defer_inner}
+
+    case Interpreter.resume_generator(cont, gen_env, inner_ctx) do
+      {{:yielded, next_val, next_cont}, next_gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Pyex.Ctx.set_gen_pending(ctx, id, next_val, next_cont, next_gen_env)
+        eval_for_generator_iter(var_name, id, body, else_body, env, ctx)
+
+      {:done, _gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Pyex.Ctx.mark_iter_exhausted(ctx, id)
+        eval_loop_else(else_body, env, ctx)
+
+      {{:exception, _} = signal, _gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Pyex.Ctx.mark_iter_exhausted(ctx, id)
+        {signal, env, ctx}
+    end
+  end
+
+  @spec advance_generator_iter(
+          String.t() | [String.t()],
+          non_neg_integer(),
+          [term()],
+          Env.t(),
+          [Parser.ast_node()],
+          [Parser.ast_node()] | nil,
+          Env.t(),
+          Ctx.t()
+        ) :: eval_result()
+  defp advance_generator_iter(var_name, id, cont, gen_env, body, else_body, env, ctx) do
+    # `resume_generator` re-enters the generator's body, so `yield`
+    # must reach its `:defer_inner` handler — not the outer caller's
+    # `:lazy_iter` mode (which would treat yield as a syntax error).
+    saved_mode = ctx.generator_mode
+    inner_ctx = %{ctx | generator_mode: :defer_inner}
+
+    case Interpreter.resume_generator(cont, gen_env, inner_ctx) do
+      {{:yielded, val, next_cont}, next_gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Pyex.Ctx.set_gen_pending(ctx, id, val, next_cont, next_gen_env)
+        eval_for_generator_iter(var_name, id, body, else_body, env, ctx)
+
+      {:done, _gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Pyex.Ctx.mark_iter_exhausted(ctx, id)
+        eval_loop_else(else_body, env, ctx)
+
+      {{:exception, _} = signal, _gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        ctx = Pyex.Ctx.mark_iter_exhausted(ctx, id)
+        {signal, env, ctx}
     end
   end
 

--- a/lib/pyex/interpreter/invocation.ex
+++ b/lib/pyex/interpreter/invocation.ex
@@ -38,8 +38,7 @@ defmodule Pyex.Interpreter.Invocation do
     else
       ctx = %{ctx | call_depth: ctx.call_depth + 1}
 
-      fresh_closure =
-        Env.put_global_scope(closure_env, Env.global_scope(env), Env.global_scope_id(env))
+      fresh_closure = Env.refresh_from_caller(closure_env, env)
 
       # Bind `name` to the caller's current binding when available so
       # decorators (like @lru_cache) that wrap this function are visible
@@ -96,8 +95,7 @@ defmodule Pyex.Interpreter.Invocation do
       ) do
     method_args = [instance | args]
 
-    fresh_closure =
-      Env.put_global_scope(closure_env, Env.global_scope(env), Env.global_scope_id(env))
+    fresh_closure = Env.refresh_from_caller(closure_env, env)
 
     func = {:function, fname, params, body, closure_env}
     base_env = Env.push_scope(Env.put(fresh_closure, fname, func))
@@ -130,25 +128,92 @@ defmodule Pyex.Interpreter.Invocation do
     end
   end
 
+  defp no_drain_builtins do
+    case :persistent_term.get({__MODULE__, :no_drain_builtins}, nil) do
+      nil ->
+        set = Pyex.Builtins.no_drain_builtin_funcs()
+        :persistent_term.put({__MODULE__, :no_drain_builtins}, set)
+        set
+
+      set ->
+        set
+    end
+  end
+
   @doc false
   @spec call_builtin((list() -> term()), [Interpreter.pyvalue()], Env.t(), Ctx.t()) ::
           Interpreter.call_result()
   def call_builtin(fun, args, env, ctx) do
-    derefed_args = Enum.map(args, &Ctx.deep_deref(ctx, &1))
+    case maybe_drain_args(fun, args, env, ctx) do
+      {:exception, _} = signal ->
+        {signal, env, ctx}
 
-    result =
-      try do
-        fun.(derefed_args)
-      rescue
-        FunctionClauseError ->
-          {:exception, "TypeError: invalid arguments"}
+      {drained_args, env, ctx} ->
+        derefed_args = Enum.map(drained_args, &Ctx.deep_deref(ctx, &1))
 
-        e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
-          {:exception, "TypeError: #{Exception.message(e)}"}
-      end
+        result =
+          try do
+            fun.(derefed_args)
+          rescue
+            FunctionClauseError ->
+              {:exception, "TypeError: invalid arguments"}
 
-    BuiltinResults.handle_builtin_result(result, env, ctx)
+            e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
+              {:exception, "TypeError: #{Exception.message(e)}"}
+          end
+
+        BuiltinResults.handle_builtin_result(result, env, ctx)
+    end
   end
+
+  @spec maybe_drain_args(
+          (list() -> term()),
+          [Interpreter.pyvalue()],
+          Env.t(),
+          Ctx.t()
+        ) :: {[Interpreter.pyvalue()], Env.t(), Ctx.t()} | {:exception, String.t()}
+  defp maybe_drain_args(fun, args, env, ctx) do
+    if MapSet.member?(no_drain_builtins(), fun) do
+      {args, env, ctx}
+    else
+      drain_gen_args(args, env, ctx)
+    end
+  end
+
+  @spec drain_gen_args([Interpreter.pyvalue()], Env.t(), Ctx.t()) ::
+          {[Interpreter.pyvalue()], Env.t(), Ctx.t()} | {:exception, String.t()}
+  defp drain_gen_args(args, env, ctx) do
+    Enum.reduce_while(args, {[], env, ctx}, fn arg, {acc, env, ctx} ->
+      case maybe_drain_gen_iter(arg, env, ctx) do
+        {:exception, _} = signal -> {:halt, signal}
+        {coerced, env, ctx} -> {:cont, {[coerced | acc], env, ctx}}
+      end
+    end)
+    |> case do
+      {:exception, _} = signal -> signal
+      {acc, env, ctx} -> {Enum.reverse(acc), env, ctx}
+    end
+  end
+
+  @spec maybe_drain_gen_iter(Interpreter.pyvalue(), Env.t(), Ctx.t()) ::
+          {Interpreter.pyvalue(), Env.t(), Ctx.t()} | {:exception, String.t()}
+  defp maybe_drain_gen_iter({:iterator, id} = iter, env, ctx) do
+    case Ctx.iter_entry(ctx, id) do
+      {:gen_pending, _, _, _} ->
+        case Pyex.Interpreter.Iterables.drain_generator_iter(id, env, ctx) do
+          {:ok, items, env, ctx} -> {{:generator, items}, env, ctx}
+          {:exception, _} = signal -> signal
+        end
+
+      :gen_done ->
+        {{:generator, []}, env, ctx}
+
+      _ ->
+        {iter, env, ctx}
+    end
+  end
+
+  defp maybe_drain_gen_iter(arg, env, ctx), do: {arg, env, ctx}
 
   @doc false
   @spec call_builtin_raw((list() -> term()), [Interpreter.pyvalue()], Env.t(), Ctx.t()) ::
@@ -177,21 +242,27 @@ defmodule Pyex.Interpreter.Invocation do
           Ctx.t()
         ) :: Interpreter.call_result()
   def call_builtin_kw(fun, args, kwargs, env, ctx) do
-    derefed_args = Enum.map(args, &Ctx.deep_deref(ctx, &1))
-    derefed_kwargs = Map.new(kwargs, fn {k, v} -> {k, Ctx.deep_deref(ctx, v)} end)
+    case drain_gen_args(args, env, ctx) do
+      {:exception, _} = signal ->
+        {signal, env, ctx}
 
-    result =
-      try do
-        fun.(derefed_args, derefed_kwargs)
-      rescue
-        FunctionClauseError ->
-          {:exception, "TypeError: invalid arguments"}
+      {drained_args, env, ctx} ->
+        derefed_args = Enum.map(drained_args, &Ctx.deep_deref(ctx, &1))
+        derefed_kwargs = Map.new(kwargs, fn {k, v} -> {k, Ctx.deep_deref(ctx, v)} end)
 
-        e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
-          {:exception, "TypeError: #{Exception.message(e)}"}
-      end
+        result =
+          try do
+            fun.(derefed_args, derefed_kwargs)
+          rescue
+            FunctionClauseError ->
+              {:exception, "TypeError: invalid arguments"}
 
-    BuiltinResults.handle_builtin_kw_result(result, env, ctx)
+            e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
+              {:exception, "TypeError: #{Exception.message(e)}"}
+          end
+
+        BuiltinResults.handle_builtin_kw_result(result, env, ctx)
+    end
   end
 
   @doc false
@@ -454,6 +525,37 @@ defmodule Pyex.Interpreter.Invocation do
             {{:generator, []}, env, ctx}
         end
 
+      mode when mode in [:lazy_iter, :defer_inner] ->
+        # Wrap the suspended generator into an iterator-pool entry so
+        # `g = gen()` produces a stateful, identity-preserving handle —
+        # the same way CPython returns a generator object. Subsequent
+        # `next(g)` / `for x in g` calls advance the same state.
+        #
+        # `:defer_inner` callers are themselves generator bodies: when
+        # an outer generator calls `inner()`, that inner *must* also
+        # behave lazily so `yield from inner()` interleaves yields
+        # rather than running inner to completion eagerly.
+        gen_ctx = %{ctx | generator_mode: :defer_inner}
+
+        case Interpreter.eval_statements(body, call_env, gen_ctx) do
+          {{:yielded, val, cont}, gen_env, gen_ctx} ->
+            ctx = sync_generator_ctx(ctx, gen_ctx)
+            {iter_token, ctx} = Ctx.new_generator_iterator(ctx, val, cont, gen_env)
+            {iter_token, env, ctx}
+
+          {{:exception, _} = signal, _post_env, gen_ctx} ->
+            ctx = sync_generator_ctx(ctx, gen_ctx)
+            {signal, env, ctx}
+
+          {_, _post_env, gen_ctx} ->
+            ctx = sync_generator_ctx(ctx, gen_ctx)
+            # Generator that never yields — return an exhausted iterator
+            # so consumers see zero items via the same code path.
+            {iter_token, ctx} = Ctx.new_generator_iterator(ctx, nil, [], call_env)
+            ctx = Ctx.mark_iter_exhausted(ctx, elem(iter_token, 1))
+            {iter_token, env, ctx}
+        end
+
       _ ->
         prev_acc = ctx.generator_acc
         gen_ctx = %{ctx | generator_mode: :accumulate, generator_acc: []}
@@ -529,7 +631,14 @@ defmodule Pyex.Interpreter.Invocation do
         file_ops: gen_ctx.file_ops,
         heap: gen_ctx.heap,
         next_heap_id: gen_ctx.next_heap_id,
-        output_buffer: gen_ctx.output_buffer
+        output_buffer: gen_ctx.output_buffer,
+        # Propagate iterator-pool mutations: a generator running in
+        # `:defer_inner` may have allocated nested generator iterators
+        # (e.g. `yield from inner()` — inner gets a pool slot before
+        # this generator wraps itself). Without copying these back, the
+        # next allocation collides with inner's id and overwrites it.
+        iterators: gen_ctx.iterators,
+        next_iterator_id: gen_ctx.next_iterator_id
     }
   end
 
@@ -559,8 +668,7 @@ defmodule Pyex.Interpreter.Invocation do
        ) do
     init_args = [instance | args]
 
-    fresh_closure =
-      Env.put_global_scope(closure_env, Env.global_scope(env), Env.global_scope_id(env))
+    fresh_closure = Env.refresh_from_caller(closure_env, env)
 
     init_fn = {:function, init_name, params, body, closure_env}
     base_env = Env.push_scope(Env.put(fresh_closure, init_name, init_fn))

--- a/lib/pyex/interpreter/iterables.ex
+++ b/lib/pyex/interpreter/iterables.ex
@@ -50,7 +50,26 @@ defmodule Pyex.Interpreter.Iterables do
 
   def to_iterable({:generator_error, items, _msg}, env, ctx), do: {:ok, items, env, ctx}
 
-  def to_iterable({:iterator, id}, env, ctx), do: {:ok, Ctx.iter_items(ctx, id), env, ctx}
+  def to_iterable({:iterator, id}, env, ctx) do
+    case Ctx.iter_entry(ctx, id) do
+      {:gen_pending, _val, _cont, _gen_env} ->
+        drain_generator_iter(id, env, ctx)
+
+      :gen_done ->
+        {:ok, [], env, ctx}
+
+      _ ->
+        {:ok, Ctx.iter_items(ctx, id), env, ctx}
+    end
+  end
+
+  def to_iterable({:generator_suspended, val, cont, gen_env}, env, ctx) do
+    # An unbound suspended generator (legacy `:defer` mode result, or
+    # a generator passed through internal paths). Drain by stepping
+    # `resume_generator` until done. Used by materialisers like
+    # `list(gen())`.
+    drain_generator(val, cont, gen_env, [val], env, ctx)
+  end
 
   def to_iterable({:instance, _, attrs} = inst, env, ctx) do
     case Dunder.call_dunder(inst, "__iter__", [], env, ctx) do
@@ -80,6 +99,50 @@ defmodule Pyex.Interpreter.Iterables do
 
   def to_iterable(val, _env, _ctx) do
     {:exception, "TypeError: '#{Helpers.py_type(val)}' object is not iterable"}
+  end
+
+  @doc false
+  @spec drain_generator_iter(non_neg_integer(), Env.t(), Ctx.t()) ::
+          {:ok, [Interpreter.pyvalue()], Env.t(), Ctx.t()} | {:exception, String.t()}
+  def drain_generator_iter(id, env, ctx) do
+    case Ctx.iter_entry(ctx, id) do
+      {:gen_pending, val, cont, gen_env} ->
+        ctx = Ctx.mark_iter_exhausted(ctx, id)
+        drain_generator(val, cont, gen_env, [val], env, ctx)
+
+      :gen_done ->
+        {:ok, [], env, ctx}
+
+      nil ->
+        {:ok, [], env, ctx}
+    end
+  end
+
+  @spec drain_generator(
+          Interpreter.pyvalue(),
+          [term()],
+          Env.t(),
+          [Interpreter.pyvalue()],
+          Env.t(),
+          Ctx.t()
+        ) :: {:ok, [Interpreter.pyvalue()], Env.t(), Ctx.t()} | {:exception, String.t()}
+  defp drain_generator(_first_val, cont, gen_env, acc, env, ctx) do
+    # Resume must run with `:defer_inner` so internal `yield` reaches
+    # its proper handler. The outer mode is restored after.
+    saved_mode = ctx.generator_mode
+    inner_ctx = %{ctx | generator_mode: :defer_inner}
+
+    case Interpreter.resume_generator(cont, gen_env, inner_ctx) do
+      {{:yielded, val, next_cont}, next_env, ctx} ->
+        drain_generator(val, next_cont, next_env, [val | acc], env, ctx)
+
+      {:done, _gen_env, ctx} ->
+        ctx = %{ctx | generator_mode: saved_mode}
+        {:ok, Enum.reverse(acc), env, ctx}
+
+      {{:exception, _} = signal, _gen_env, _ctx} ->
+        signal
+    end
   end
 
   @doc false

--- a/lib/pyex/lambda.ex
+++ b/lib/pyex/lambda.ex
@@ -388,8 +388,8 @@ defmodule Pyex.Lambda do
   end
 
   @spec unwrap_response(Interpreter.pyvalue(), Ctx.t()) :: response()
-  defp unwrap_response(%{"__response__" => true, "__streaming__" => true} = resp, _ctx) do
-    chunks = Map.get(resp, "body", [])
+  defp unwrap_response(%{"__response__" => true, "__streaming__" => true} = resp, ctx) do
+    chunks = drain_streaming_chunks(Map.get(resp, "body", []), ctx)
 
     %{
       status: Map.get(resp, "status_code", 200),
@@ -417,6 +417,20 @@ defmodule Pyex.Lambda do
       body: Interpreter.Helpers.to_python_view(derefed)
     }
   end
+
+  # In `Lambda.handle/2` (non-streaming), the response body may be a
+  # generator iterator (lazy-mode generators are now the default). Drain
+  # it here so the chunks are concrete strings ready to concatenate.
+  @spec drain_streaming_chunks(term(), Ctx.t()) :: [String.t()]
+  defp drain_streaming_chunks({:iterator, id}, ctx) do
+    case Pyex.Interpreter.Iterables.drain_generator_iter(id, %Pyex.Env{}, ctx) do
+      {:ok, items, _env, _ctx} -> Enum.map(items, &to_string/1)
+      {:exception, _} -> []
+    end
+  end
+
+  defp drain_streaming_chunks(chunks, _ctx) when is_list(chunks), do: chunks
+  defp drain_streaming_chunks(chunks, _ctx), do: List.wrap(chunks)
 
   @spec unwrap_stream_response(Interpreter.pyvalue(), Ctx.t()) :: stream_response()
   defp unwrap_stream_response(%{"__response__" => true, "__streaming__" => true} = resp, _ctx) do

--- a/lib/pyex/lexer.ex
+++ b/lib/pyex/lexer.ex
@@ -55,6 +55,7 @@ defmodule Pyex.Lexer do
           | :caret_assign
           | :lshift_assign
           | :rshift_assign
+          | :semicolon
 
   @type line :: pos_integer()
 
@@ -386,6 +387,7 @@ defmodule Pyex.Lexer do
   tilde = string("~") |> replace(:tilde)
   assign = string("=") |> replace(:assign)
   at = string("@") |> replace(:at)
+  semicolon = string(";") |> replace(:semicolon)
 
   operator =
     choice([
@@ -432,7 +434,8 @@ defmodule Pyex.Lexer do
       ellipsis,
       dot,
       assign,
-      at
+      at,
+      semicolon
     ])
     |> unwrap_and_tag(:op)
 
@@ -480,7 +483,6 @@ defmodule Pyex.Lexer do
 
       with {:ok, source} <- strip_comments(source),
            source = join_continued_lines(source),
-           {:ok, source} <- replace_semicolons(source),
            source = String.trim_trailing(source) do
         case tokenize_raw(source) do
           {:ok, raw_tokens, "", _, _, _} ->
@@ -515,143 +517,6 @@ defmodule Pyex.Lexer do
   defp join_continued_lines(source) do
     String.replace(source, "\\\n", "")
   end
-
-  @spec replace_semicolons(String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  defp replace_semicolons(source), do: replace_semicolons(source, <<>>)
-
-  @spec replace_semicolons(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  defp replace_semicolons(<<>>, acc), do: {:ok, acc}
-
-  defp replace_semicolons(<<"r\"", rest::binary>>, acc) do
-    case consume_string(rest, ?") do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, "r\"", content::binary, ?">>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<"r'", rest::binary>>, acc) do
-    case consume_string(rest, ?') do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, "r'", content::binary, ?'>>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<"f\"\"\"", rest::binary>>, acc) do
-    case consume_triple(rest, ?") do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, "f\"\"\"", content::binary, "\"\"\"">>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated triple-quoted string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<"f'''", rest::binary>>, acc) do
-    case consume_triple(rest, ?') do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, "f'''", content::binary, "'''">>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated triple-quoted string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<"f\"", rest::binary>>, acc) do
-    case consume_string(rest, ?") do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, "f\"", content::binary, ?">>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<"f'", rest::binary>>, acc) do
-    case consume_string(rest, ?') do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, "f'", content::binary, ?'>>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<"\"\"\"", rest::binary>>, acc) do
-    case consume_triple(rest, ?") do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, "\"\"\"", content::binary, "\"\"\"">>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated triple-quoted string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<"'''", rest::binary>>, acc) do
-    case consume_triple(rest, ?') do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, "'''", content::binary, "'''">>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated triple-quoted string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<?", rest::binary>>, acc) do
-    case consume_string(rest, ?") do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, ?", content::binary, ?">>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<?', rest::binary>>, acc) do
-    case consume_string(rest, ?') do
-      {:ok, rest, content} ->
-        replace_semicolons(rest, <<acc::binary, ?', content::binary, ?'>>)
-
-      {:error, :unterminated} ->
-        {:error, "SyntaxError: unterminated string literal"}
-    end
-  end
-
-  defp replace_semicolons(<<?;, rest::binary>>, acc) do
-    indent = current_line_indent(acc)
-    replace_semicolons(skip_horizontal_whitespace(rest), <<acc::binary, ?\n, indent::binary>>)
-  end
-
-  defp replace_semicolons(<<ch, rest::binary>>, acc) do
-    replace_semicolons(rest, <<acc::binary, ch>>)
-  end
-
-  @spec current_line_indent(String.t()) :: String.t()
-  defp current_line_indent(acc) do
-    acc
-    |> String.split("\n")
-    |> List.last("")
-    |> extract_leading_whitespace()
-  end
-
-  @spec extract_leading_whitespace(String.t()) :: String.t()
-  defp extract_leading_whitespace(<<?\s, rest::binary>>),
-    do: <<?\s, extract_leading_whitespace(rest)::binary>>
-
-  defp extract_leading_whitespace(<<?\t, rest::binary>>),
-    do: <<?\t, extract_leading_whitespace(rest)::binary>>
-
-  defp extract_leading_whitespace(_), do: <<>>
-
-  @spec skip_horizontal_whitespace(String.t()) :: String.t()
-  defp skip_horizontal_whitespace(<<?\s, rest::binary>>), do: skip_horizontal_whitespace(rest)
-  defp skip_horizontal_whitespace(<<?\t, rest::binary>>), do: skip_horizontal_whitespace(rest)
-  defp skip_horizontal_whitespace(rest), do: rest
 
   @spec strip_comments(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   defp strip_comments(source) do

--- a/lib/pyex/parser.ex
+++ b/lib/pyex/parser.ex
@@ -114,6 +114,7 @@ defmodule Pyex.Parser do
   defp parse_block([], acc), do: {:ok, Enum.reverse(acc), []}
   defp parse_block([:dedent | rest], acc), do: {:ok, Enum.reverse(acc), rest}
   defp parse_block([:newline | rest], acc), do: parse_block(rest, acc)
+  defp parse_block([{:op, _, :semicolon} | rest], acc), do: parse_block(rest, acc)
 
   defp parse_block(tokens, acc) do
     case parse_statement(tokens) do
@@ -756,11 +757,51 @@ defmodule Pyex.Parser do
     {:error, "expected ':' after #{ctx} at #{token_line(tokens)}"}
   end
 
-  @doc false
-  @spec parse_inline_body([Lexer.token()]) :: parse_result()
+  @doc """
+  Parses the inline body of a compound statement (e.g. the part after
+  `:` on the same line in `def f(): a; b; c` or `if cond: a`).
+
+  Consumes one or more `;`-separated small statements. Terminates at
+  the first non-`;` token following a parsed statement. Returns a
+  *list* of statements so `def f(): a; b` and the multi-line form
+  share an AST shape.
+
+  Statement parsers internally strip a trailing `:newline` via
+  `drop_newline`, so we cannot use the absence of a newline to detect
+  end-of-line. Instead, we rely on `;` being the only valid separator
+  *between* small statements on a single physical line.
+  """
+  @spec parse_inline_body([Lexer.token()]) ::
+          {:ok, [ast_node()], [Lexer.token()]} | {:error, String.t()}
   def parse_inline_body(tokens) do
-    parse_statement(tokens)
+    case parse_statement(tokens) do
+      {:ok, stmt, rest} -> parse_inline_body_rest(rest, [stmt])
+      {:error, _} = error -> error
+    end
   end
+
+  @spec parse_inline_body_rest([Lexer.token()], [ast_node()]) ::
+          {:ok, [ast_node()], [Lexer.token()]} | {:error, String.t()}
+  defp parse_inline_body_rest([{:op, _, :semicolon} | rest], acc) do
+    case rest do
+      [:newline | _] ->
+        {:ok, Enum.reverse(acc), rest}
+
+      [:dedent | _] ->
+        {:ok, Enum.reverse(acc), rest}
+
+      [] ->
+        {:ok, Enum.reverse(acc), []}
+
+      _ ->
+        case parse_statement(rest) do
+          {:ok, stmt, rest} -> parse_inline_body_rest(rest, [stmt | acc])
+          {:error, _} = error -> error
+        end
+    end
+  end
+
+  defp parse_inline_body_rest(rest, acc), do: {:ok, Enum.reverse(acc), rest}
 
   @doc false
   @spec parse_or([Lexer.token()]) :: parse_result()

--- a/lib/pyex/parser/control_flow.ex
+++ b/lib/pyex/parser/control_flow.ex
@@ -27,10 +27,10 @@ defmodule Pyex.Parser.ControlFlow do
           end
 
         [{:op, _, :colon} | inline_rest] ->
-          with {:ok, stmt, rest} <- Parser.parse_inline_body(inline_rest),
+          with {:ok, stmts, rest} <- Parser.parse_inline_body(inline_rest),
                {:ok, else_clauses, rest} <- parse_elif_else(rest) do
             line = Parser.node_line(condition)
-            {:ok, {:if, [line: line], [{condition, [stmt]} | else_clauses]}, drop_newline(rest)}
+            {:ok, {:if, [line: line], [{condition, stmts} | else_clauses]}, drop_newline(rest)}
           end
 
         _ ->
@@ -109,9 +109,9 @@ defmodule Pyex.Parser.ControlFlow do
           end
 
         [{:op, _, :colon} | inline_rest] ->
-          with {:ok, stmt, rest} <- Parser.parse_inline_body(inline_rest),
+          with {:ok, stmts, rest} <- Parser.parse_inline_body(inline_rest),
                {:ok, more, rest} <- parse_elif_else(rest) do
-            {:ok, [{condition, [stmt]} | more], rest}
+            {:ok, [{condition, stmts} | more], rest}
           end
 
         _ ->
@@ -129,7 +129,7 @@ defmodule Pyex.Parser.ControlFlow do
 
   defp parse_elif_else([{:keyword, _, "else"}, {:op, _, :colon} | rest]) do
     case Parser.parse_inline_body(rest) do
-      {:ok, stmt, rest} -> {:ok, [{:else, [stmt]}], rest}
+      {:ok, stmts, rest} -> {:ok, [{:else, stmts}], rest}
       {:error, _} = error -> error
     end
   end
@@ -147,7 +147,7 @@ defmodule Pyex.Parser.ControlFlow do
 
   defp parse_loop_else([{:keyword, _, "else"}, {:op, _, :colon} | rest]) do
     case Parser.parse_inline_body(rest) do
-      {:ok, stmt, rest} -> {:ok, [stmt], rest}
+      {:ok, stmts, rest} -> {:ok, stmts, rest}
       {:error, _} = error -> error
     end
   end
@@ -162,7 +162,7 @@ defmodule Pyex.Parser.ControlFlow do
 
   defp parse_loop_body([{:op, _, :colon} | rest], _context) do
     case Parser.parse_inline_body(rest) do
-      {:ok, stmt, rest} -> {:ok, [stmt], rest}
+      {:ok, stmts, rest} -> {:ok, stmts, rest}
       {:error, _} = error -> error
     end
   end

--- a/lib/pyex/parser/definitions.ex
+++ b/lib/pyex/parser/definitions.ex
@@ -34,8 +34,8 @@ defmodule Pyex.Parser.Definitions do
 
           [{:op, _, :colon} | inline_rest] ->
             case Parser.parse_inline_body(inline_rest) do
-              {:ok, stmt, rest} ->
-                {:ok, {:def, [line: line], [name, params, [stmt]]}, drop_newline(rest)}
+              {:ok, stmts, rest} ->
+                {:ok, {:def, [line: line], [name, params, stmts]}, drop_newline(rest)}
 
               {:error, _} = error ->
                 error
@@ -139,8 +139,8 @@ defmodule Pyex.Parser.Definitions do
 
           [{:op, _, :colon} | inline_rest] ->
             case Parser.parse_inline_body(inline_rest) do
-              {:ok, stmt, rest} ->
-                {:ok, {:class, [line: line], [name, bases, [stmt]]}, drop_newline(rest)}
+              {:ok, stmts, rest} ->
+                {:ok, {:class, [line: line], [name, bases, stmts]}, drop_newline(rest)}
 
               {:error, _} = error ->
                 error
@@ -167,8 +167,8 @@ defmodule Pyex.Parser.Definitions do
 
   def parse_class_def([{:name, line, name}, {:op, _, :colon} | inline_rest]) do
     case Parser.parse_inline_body(inline_rest) do
-      {:ok, stmt, rest} ->
-        {:ok, {:class, [line: line], [name, [], [stmt]]}, drop_newline(rest)}
+      {:ok, stmts, rest} ->
+        {:ok, {:class, [line: line], [name, [], stmts]}, drop_newline(rest)}
 
       {:error, _} = error ->
         error

--- a/lib/pyex/parser/match.ex
+++ b/lib/pyex/parser/match.ex
@@ -51,8 +51,8 @@ defmodule Pyex.Parser.Match do
 
         [{:op, _, :colon} | inline_rest] ->
           # Single-line `case p: expr` (matches CPython).
-          with {:ok, stmt, rest} <- Parser.parse_inline_body(inline_rest) do
-            parse_match_cases(rest, [{pattern, guard, [stmt]} | acc])
+          with {:ok, stmts, rest} <- Parser.parse_inline_body(inline_rest) do
+            parse_match_cases(rest, [{pattern, guard, stmts} | acc])
           end
 
         _ ->

--- a/lib/pyex/stdlib/fastapi.ex
+++ b/lib/pyex/stdlib/fastapi.ex
@@ -117,8 +117,13 @@ defmodule Pyex.Stdlib.FastAPI do
   end
 
   @spec extract_chunks(Interpreter.pyvalue()) ::
-          [String.t()] | {:generator_suspended, term(), term(), Pyex.Env.t()}
+          [String.t()]
+          | {:generator_suspended, term(), term(), Pyex.Env.t()}
+          | {:iterator, non_neg_integer()}
   defp extract_chunks({:generator_suspended, _, _, _} = suspended), do: suspended
+  # Lazy-mode generator iterators pass through; the consumer drains
+  # them when finalising the response (in `Lambda.handle/2`).
+  defp extract_chunks({:iterator, _id} = iter), do: iter
   defp extract_chunks({:generator, items}), do: Enum.map(items, &to_string/1)
 
   defp extract_chunks({:py_list, reversed, _}),

--- a/test/pyex/conformance/closure_composition_conformance_test.exs
+++ b/test/pyex/conformance/closure_composition_conformance_test.exs
@@ -1,0 +1,354 @@
+defmodule Pyex.Conformance.ClosureCompositionTest do
+  @moduledoc """
+  Conformance tests for the *composition* of user-function calls with
+  caller-side state mutation.
+
+  The motivating bug: a closure call refreshed only the bottom (global)
+  scope of the captured env, so middle scopes were stale snapshots from
+  `def` time. Calling the closure from inside a nested for-loop in the
+  enclosing function then propagated the stale snapshot back to the
+  caller — wiping every binding the loop had added (e.g. `i`, `x`).
+
+  Per-axis tests for closures, loops, and mutation each passed in
+  isolation. The bug only appeared when all three were combined. These
+  tests deliberately *cross* the axes:
+
+    closure / class method / __init__ / generator / recursion
+                                ×
+    for / while / list comp / dict comp / gen comp / with / try
+                                ×
+    "caller's locals must still be intact after the call returns"
+
+  Slow axis at the top (kind of callable), fast axis at the bottom
+  (call-site context). Any divergence from CPython is a real bug.
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "closure called inside caller-side iteration" do
+    test "nested for-loop with f-string after closure call" do
+      check!("""
+      def outer():
+          captured = 1
+          def inner(): return captured
+          for i in [1, 2]:
+              for x in ['a', 'b']:
+                  r = inner()
+                  print(f"{i}:{x}:{r}")
+      outer()
+      """)
+    end
+
+    test "while loop with closure call" do
+      check!("""
+      def outer():
+          val = 10
+          def get(): return val
+          n = 0
+          while n < 3:
+              y = get()
+              print((n, y))
+              n += 1
+      outer()
+      """)
+    end
+
+    test "list comprehension calling closure" do
+      check!("""
+      def outer():
+          val = 10
+          def get(): return val
+          out = [(i, get()) for i in range(3)]
+          print(out)
+      outer()
+      """)
+    end
+
+    test "dict comprehension calling closure" do
+      check!("""
+      def outer():
+          val = 10
+          def get(): return val
+          out = {i: get() for i in range(3)}
+          print(sorted(out.items()))
+      outer()
+      """)
+    end
+
+    test "generator expression calling closure" do
+      check!("""
+      def outer():
+          val = 10
+          def get(): return val
+          out = list(get() + i for i in range(3))
+          print(out)
+      outer()
+      """)
+    end
+
+    test "three levels of nested loops with closure call" do
+      check!("""
+      def outer():
+          cap = 7
+          def inner(): return cap
+          for i in range(2):
+              for j in range(2):
+                  for k in range(2):
+                      print((i, j, k, inner()))
+      outer()
+      """)
+    end
+  end
+
+  describe "caller's local state mutates between closure calls" do
+    test "captured list mutates while caller iterates" do
+      check!("""
+      def outer():
+          val = [1]
+          def get(): return val[0]
+          acc = []
+          for i in range(3):
+              acc.append((i, get()))
+              val[0] += 10
+          print(acc)
+      outer()
+      """)
+    end
+
+    test "closure mutates captured list across nested loops" do
+      check!("""
+      def outer():
+          items = [0]
+          def push(v): items.append(v)
+          for i in range(3):
+              push(i)
+              for j in range(2):
+                  push(i * 10 + j)
+          print(items)
+      outer()
+      """)
+    end
+
+    test "nonlocal write from closure called in nested loop" do
+      check!("""
+      def outer():
+          total = 0
+          def add(n):
+              nonlocal total
+              total += n
+          for i in range(3):
+              for j in range(2):
+                  add(i * 10 + j)
+          print(total)
+      outer()
+      """)
+    end
+  end
+
+  describe "closure call wrapped in caller-side control flow" do
+    test "try/except around closure call in loop" do
+      check!("""
+      def outer():
+          val = 10
+          def get(): return val
+          for i in range(2):
+              try:
+                  y = get()
+              except Exception:
+                  y = -1
+              print((i, y))
+      outer()
+      """)
+    end
+
+    test "with block around closure call in loop" do
+      check!("""
+      class Ctx:
+          def __enter__(self): return self
+          def __exit__(self, *a): return False
+      def outer():
+          val = 10
+          def get(): return val
+          for i in range(2):
+              with Ctx() as c:
+                  y = get()
+              print((i, y))
+      outer()
+      """)
+    end
+  end
+
+  describe "non-closure callables also exercise the same scope path" do
+    test "class method called in nested loop preserves caller locals" do
+      check!("""
+      class Bag:
+          def __init__(self): self.items = []
+          def add(self, x): self.items.append(x)
+      def outer():
+          b = Bag()
+          for i in [1, 2]:
+              for x in ['a', 'b']:
+                  b.add((i, x))
+          print(b.items)
+      outer()
+      """)
+    end
+
+    test "__init__ called in nested loop preserves caller locals" do
+      check!("""
+      class Thing:
+          def __init__(self, n):
+              self.n = n
+      def outer():
+          things = []
+          for i in range(2):
+              for x in ['a', 'b']:
+                  things.append((i, x, Thing(i).n))
+          print(things)
+      outer()
+      """)
+    end
+
+    test "recursive function called from loop preserves loop var" do
+      check!("""
+      def outer():
+          def fact(n):
+              if n <= 1: return 1
+              return n * fact(n - 1)
+          for i in range(1, 5):
+              print((i, fact(i)))
+      outer()
+      """)
+    end
+
+    test "generator function iterated in nested loop preserves outer loop var" do
+      check!("""
+      def outer():
+          base = 100
+          def gen():
+              yield base
+              yield base + 1
+          for i in range(2):
+              for x in gen():
+                  print((i, x))
+      outer()
+      """)
+    end
+  end
+
+  describe "captured mutable state shared across method calls" do
+    test "class method aug-subscript-assigns shared captured list" do
+      # Regression: `counter[0] += 1` inside a class method went through
+      # `Env.put_at_source` on the *name* `counter` instead of writing
+      # back to the heap. For regular closures this was masked by
+      # `update_closure_env` patching the function's stored closure_env;
+      # class methods have no such patch path, so every method call saw
+      # a fresh `counter = [0]` from the def-time snapshot.
+      check!("""
+      def outer():
+          counter = [0]
+          class C:
+              def tick(self):
+                  counter[0] += 1
+                  return counter[0]
+          return C
+      C = outer()
+      a = C()
+      b = C()
+      print(a.tick())
+      print(b.tick())
+      print(a.tick())
+      """)
+    end
+
+    test "two classes from same factory have independent captured state" do
+      check!("""
+      def make_cls(label):
+          counter = [0]
+          class C:
+              def __init__(self, name):
+                  self.name = name
+              def tick(self):
+                  counter[0] += 1
+                  return (label, self.name, counter[0])
+          return C
+
+      CA = make_cls("A")
+      CB = make_cls("B")
+      a1 = CA("a1")
+      a2 = CA("a2")
+      b1 = CB("b1")
+      out = [a1.tick(), b1.tick(), a2.tick(), a1.tick(), b1.tick()]
+      print(out)
+      """)
+    end
+
+    test "method aug-assigns captured dict counter" do
+      check!("""
+      def outer():
+          counts = {"hits": 0}
+          class C:
+              def hit(self):
+                  counts["hits"] += 1
+                  return counts["hits"]
+          return C
+      C = outer()
+      a = C()
+      print(a.hit())
+      print(a.hit())
+      print(a.hit())
+      """)
+    end
+  end
+
+  describe "closure scope isolation under loop pressure" do
+    test "closure shadows loop variable without leaking" do
+      check!("""
+      def outer():
+          captured = 1
+          def inner():
+              i = 999
+              return captured + i
+          for i in [10, 20]:
+              y = inner()
+              print((i, y))
+      outer()
+      """)
+    end
+
+    test "closure's local does not leak into caller scope" do
+      check!("""
+      def outer():
+          def inner():
+              new_local = 42
+              return new_local
+          for i in range(2):
+              y = inner()
+              try:
+                  _ = new_local
+                  print("BUG: leaked")
+              except NameError:
+                  print((i, y, "ok"))
+      outer()
+      """)
+    end
+
+    test "closure returned from already-exited function called in loop" do
+      check!("""
+      def make():
+          captured = 99
+          def f(): return captured
+          return f
+      def outer():
+          g = make()
+          for i in range(2):
+              for x in range(2):
+                  print((i, x, g()))
+      outer()
+      """)
+    end
+  end
+end

--- a/test/pyex/conformance/lazy_generator_conformance_test.exs
+++ b/test/pyex/conformance/lazy_generator_conformance_test.exs
@@ -1,0 +1,334 @@
+defmodule Pyex.Conformance.LazyGeneratorTest do
+  @moduledoc """
+  Conformance tests for **lazy** generator semantics.
+
+  Pyex used to materialise generators eagerly: `for x in gen():`
+  would run the entire generator first, accumulating yields into a
+  list, *then* iterate the list. Programs that relied on yield-time
+  side-effect ordering, mutation visibility across yields, or
+  infinite generators with `break` got wrong answers (or hung).
+
+  CPython generators are lazy iterators: each `next()` (whether
+  driven by a `for` loop, `next()` builtin, `list()`, comprehension,
+  or `yield from`) advances the generator one yield at a time. These
+  tests cross every observable laziness signal:
+
+    side-effect interleaving
+    mutation across yield
+    infinite + break
+    next() identity (`g = gen(); next(g); next(g)`)
+    interleaved iteration of two generators
+    yield from with mid-stream exception
+    nested generator delegation
+    StopIteration on exhaustion
+    materialisation via list/tuple/dict/sum/any/all
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "side-effect ordering" do
+    test "before/after-yield prints interleave with consumer" do
+      check!("""
+      def gen():
+          for i in range(3):
+              print("before", i)
+              yield i
+              print("after", i)
+      for x in gen():
+          print("got", x)
+      """)
+    end
+
+    test "consumer mutation observed across yields" do
+      check!("""
+      def outer():
+          val = [0]
+          def gen():
+              for i in range(3):
+                  yield (i, val[0])
+          for tup in gen():
+              print(tup)
+              val[0] += 100
+      outer()
+      """)
+    end
+
+    test "generator side effects in two distinct phases" do
+      check!("""
+      log = []
+      def gen():
+          log.append("a")
+          yield 1
+          log.append("b")
+          yield 2
+          log.append("c")
+
+      for x in gen():
+          log.append(("got", x))
+      print(log)
+      """)
+    end
+  end
+
+  describe "next() and iter() identity" do
+    test "next(g) advances state across calls" do
+      check!("""
+      def gen():
+          yield 10
+          yield 20
+          yield 30
+      g = gen()
+      print(next(g), next(g), next(g))
+      """)
+    end
+
+    test "next() past exhaustion raises StopIteration" do
+      check!("""
+      def gen():
+          yield 1
+      g = gen()
+      print(next(g))
+      try:
+          next(g)
+          print("no-stop")
+      except StopIteration:
+          print("stopped")
+      """)
+    end
+
+    test "next(g, default) returns default on exhaustion" do
+      check!("""
+      def gen():
+          yield 1
+      g = gen()
+      print(next(g, -1), next(g, -1), next(g, -1))
+      """)
+    end
+
+    test "iter() on a generator returns the generator itself" do
+      check!("""
+      def gen():
+          yield 1
+          yield 2
+      g = gen()
+      g2 = iter(g)
+      print(next(g2))
+      print(next(g))
+      """)
+    end
+  end
+
+  describe "infinite generators + break" do
+    test "while True yield + break in for loop" do
+      check!("""
+      def naturals():
+          i = 0
+          while True:
+              yield i
+              i += 1
+      out = []
+      for x in naturals():
+          if x >= 5: break
+          out.append(x)
+      print(out)
+      """)
+    end
+
+    test "infinite generator drained by next() with manual break" do
+      check!("""
+      def naturals():
+          i = 0
+          while True:
+              yield i
+              i += 1
+      g = naturals()
+      out = []
+      for _ in range(4):
+          out.append(next(g))
+      print(out)
+      """)
+    end
+  end
+
+  describe "interleaved iteration" do
+    test "two generators stepped alternately" do
+      check!("""
+      def make():
+          counter = [0]
+          def gen():
+              for _ in range(3):
+                  counter[0] += 1
+                  yield counter[0]
+          return gen
+      g1 = make()()
+      g2 = make()()
+      print([next(g1), next(g2), next(g1), next(g2), next(g1), next(g2)])
+      """)
+    end
+
+    test "zip over two generators yields paired values" do
+      check!("""
+      def g1():
+          yield 1; yield 2; yield 3
+      def g2():
+          yield "a"; yield "b"; yield "c"
+      print(list(zip(g1(), g2())))
+      """)
+    end
+  end
+
+  describe "yield from delegation" do
+    test "nested yield from chains values in order" do
+      check!("""
+      def inner(n):
+          for j in range(2):
+              yield n * 10 + j
+      def outer():
+          for i in range(3):
+              yield from inner(i)
+      print(list(outer()))
+      """)
+    end
+
+    test "yield from surfaces exception mid-stream" do
+      check!("""
+      def inner():
+          yield "a"
+          raise RuntimeError("fail")
+          yield "b"
+
+      def outer():
+          yield "start"
+          yield from inner()
+          yield "end"
+
+      results = []
+      try:
+          for x in outer():
+              results.append(x)
+      except RuntimeError as e:
+          results.append("caught: " + str(e))
+      print(results)
+      """)
+    end
+
+    test "yield from a list yields each element" do
+      check!("""
+      def gen():
+          yield from [1, 2, 3]
+          yield from "ab"
+      print(list(gen()))
+      """)
+    end
+  end
+
+  describe "generator pipeline (chained transforms)" do
+    test "filter -> map style chain via yield from" do
+      check!("""
+      def src():
+          for i in range(10):
+              yield i
+      def even(it):
+          for x in it:
+              if x % 2 == 0:
+                  yield x
+      def square(it):
+          for x in it:
+              yield x * x
+      print(list(square(even(src()))))
+      """)
+    end
+  end
+
+  describe "materialisation builtins drain lazily" do
+    test "list(gen())" do
+      check!("""
+      def gen():
+          for i in range(4):
+              yield i * i
+      print(list(gen()))
+      """)
+    end
+
+    test "tuple(gen())" do
+      check!("""
+      def gen():
+          yield "a"; yield "b"; yield "c"
+      print(tuple(gen()))
+      """)
+    end
+
+    test "dict from generator of pairs" do
+      check!("""
+      def pairs():
+          yield ("x", 1)
+          yield ("y", 2)
+      print(sorted(dict(pairs()).items()))
+      """)
+    end
+
+    test "sum/any/all over generator" do
+      check!("""
+      def gen():
+          for i in range(5):
+              yield i
+      print(sum(gen()))
+      print(any(gen() for _ in range(1) for x in range(0)))
+      print(all(x > -1 for x in gen()))
+      """)
+    end
+
+    test "min/max over generator" do
+      check!("""
+      def gen():
+          yield 3; yield 1; yield 4; yield 1; yield 5; yield 9
+      print(min(gen()))
+      print(max(gen()))
+      """)
+    end
+
+    test "sorted over generator" do
+      check!("""
+      def gen():
+          yield 3; yield 1; yield 4; yield 1; yield 5
+      print(sorted(gen()))
+      """)
+    end
+  end
+
+  describe "captured state across yields" do
+    test "generator updates outer-captured list across yields" do
+      check!("""
+      def outer():
+          base = [0]
+          def gen():
+              for i in range(3):
+                  base[0] += 1
+                  yield (i, base[0])
+          for tup in gen():
+              print(tup)
+          print("final", base[0])
+      outer()
+      """)
+    end
+
+    test "two instances of the same generator factory don't share state" do
+      check!("""
+      def make():
+          n = [0]
+          def gen():
+              for _ in range(3):
+                  n[0] += 1
+                  yield n[0]
+          return gen
+      g1 = make()()
+      g2 = make()()
+      print(list(g1))
+      print(list(g2))
+      """)
+    end
+  end
+end

--- a/test/pyex/conformance/semicolon_conformance_test.exs
+++ b/test/pyex/conformance/semicolon_conformance_test.exs
@@ -1,0 +1,203 @@
+defmodule Pyex.Conformance.SemicolonTest do
+  @moduledoc """
+  Conformance tests for `;` as a small-statement separator.
+
+  Python permits `;` to chain small statements on a single physical
+  line, both at the top level (`a = 1; b = 2`) and as the inline body
+  of any compound statement (`def f(): a; b`, `if cond: a; b`, etc.).
+
+  Pyex's lexer used to rewrite `;` to `\\n + current-line-indent`,
+  which silently broke compound statements: `def f(): return 1;
+  print("never")` parsed `print("never")` as a *sibling* of `def f`,
+  so the `return 1` exited early and `print("never")` ran at the
+  surrounding scope. Lethal because programs ran without error but
+  produced wrong answers.
+
+  These tests cross every compound statement that accepts an inline
+  body with multi-statement `;` chaining.
+  """
+
+  use ExUnit.Case, async: true
+  @moduletag :requires_python3
+
+  import Pyex.Test.Oracle
+
+  describe "semicolons at module level" do
+    test "two small stmts on one line" do
+      check!("a = 1; b = 2; print(a, b)\n")
+    end
+
+    test "trailing semicolon" do
+      check!("a = 1; b = 2;\nprint(a, b)\n")
+    end
+
+    test "many stmts, mixed kinds" do
+      check!("""
+      x = 0; x += 1; x *= 3; x -= 2
+      print(x)
+      """)
+    end
+  end
+
+  describe "semicolons inside multi-line block" do
+    test "in if body" do
+      check!("""
+      if True:
+          a = 1; b = 2
+          print(a, b)
+      """)
+    end
+
+    test "in def body" do
+      check!("""
+      def f():
+          a = 1; b = 2
+          return a + b
+      print(f())
+      """)
+    end
+  end
+
+  describe "single-line compound statements" do
+    test "def with two-stmt inline body" do
+      check!("""
+      def f(): a = 1; return a + 10
+      print(f())
+      """)
+    end
+
+    test "def whose inline body is return-then-unreachable" do
+      # The bug: Pyex used to lift `print("never")` out of the def's
+      # body into the surrounding block. CPython treats it as part of
+      # f's body — unreachable after `return`.
+      check!("""
+      def f(): return 1; print("never")
+      print(f())
+      """)
+    end
+
+    test "def with mutating closure body across two stmts" do
+      check!("""
+      def outer():
+          base = [0]
+          def bump(): base[0] += 1; return base[0]
+          print(bump())
+          print(bump())
+          print(bump())
+      outer()
+      """)
+    end
+
+    test "if with two-stmt inline body, condition true" do
+      check!("if True: a = 1; b = 2; print(a, b)\n")
+    end
+
+    test "if with two-stmt inline body, condition false" do
+      check!("""
+      if False: a = 1; b = 2; print("nope")
+      print("after")
+      """)
+    end
+
+    test "if/else inline both branches multi-stmt" do
+      check!("""
+      x = 5
+      if x > 0: a = "pos"; b = x
+      else: a = "neg"; b = -x
+      print(a, b)
+      """)
+    end
+
+    test "elif inline multi-stmt" do
+      check!("""
+      def classify(n):
+          if n < 0: kind = "neg"; mag = -n
+          elif n == 0: kind = "zero"; mag = 0
+          else: kind = "pos"; mag = n
+          return (kind, mag)
+      print(classify(-5))
+      print(classify(0))
+      print(classify(7))
+      """)
+    end
+
+    test "for inline multi-stmt body" do
+      check!("for i in range(3): a = i*10; print(a)\n")
+    end
+
+    test "while inline multi-stmt body" do
+      check!("""
+      n = 0
+      while n < 3: x = n*n; print(x); n += 1
+      """)
+    end
+
+    test "class with inline multi-stmt body" do
+      check!("""
+      class C: x = 1; y = 2
+      print(C.x, C.y)
+      """)
+    end
+
+    # Inline-body forms for `try` and `with` are not supported by Pyex's
+    # parser (separate feature gap, predates the semicolon fix). Tests
+    # for those two would belong in a feature-coverage suite, not here.
+
+    test "match case inline multi-stmt" do
+      check!("""
+      def f(x):
+          match x:
+              case 1: a = "one"; b = 1
+              case 2: a = "two"; b = 2
+              case _: a = "other"; b = -1
+          return (a, b)
+      print(f(1))
+      print(f(2))
+      print(f(99))
+      """)
+    end
+
+    test "nested inline def inside outer def with semis" do
+      check!("""
+      def outer():
+          def inner(): a = 10; return a + 5
+          return inner() + 100
+      print(outer())
+      """)
+    end
+  end
+
+  describe "edge cases that previously hid the bug" do
+    test "trailing semicolon on inline body" do
+      check!("""
+      def f(): return 42;
+      print(f())
+      """)
+    end
+
+    test "semicolon then unreachable raise" do
+      check!("""
+      def f(): return 1; raise ValueError("never")
+      print(f())
+      """)
+    end
+
+    test "semicolons across nested compound statements" do
+      check!("""
+      def outer():
+          if True: a = 1; b = 2
+          if a == 1: c = a + b; print(c)
+      outer()
+      """)
+    end
+
+    test "augmented assigns and subscript assigns mixed via semicolons" do
+      check!("""
+      lst = [0, 0, 0]
+      d = {"k": 0}
+      lst[0] = 1; lst[1] += 10; d["k"] += 5
+      print(lst, sorted(d.items()))
+      """)
+    end
+  end
+end

--- a/test/pyex/conformance_test.exs
+++ b/test/pyex/conformance_test.exs
@@ -1707,6 +1707,42 @@ defmodule Pyex.ConformanceTest do
           print(repr("deleted"))
       """)
     end
+
+    test "nested for-loops survive closure call in inner body" do
+      # Regression: closure invocation rebuilt the closure's env from a
+      # snapshot taken at `def` time, then propagated that env back to
+      # the caller — wiping loop variables (`i`, `x`) that the for-loops
+      # had bound in the enclosing function's scope. Required all of:
+      # nested loops, an actual closure (not a top-level function), and
+      # the closure called from the inner loop body.
+      assert_conforms("""
+      def outer():
+          captured = 1
+          def inner():
+              return captured
+          for i in [1, 2]:
+              for x in ['a', 'b']:
+                  print(str(i) + ':' + str(x) + ':' + str(inner()))
+      outer()
+      """)
+    end
+
+    test "loop variables persist after closure call mutates caller scope" do
+      # Tighter variant: the inner-loop body reads `i` and `x` *after* a
+      # closure returns. A bare reference on the next line is enough to
+      # raise NameError if the caller's scope was clobbered.
+      assert_conforms("""
+      def outer():
+          val = 10
+          def get():
+              return val
+          for i in range(2):
+              for x in range(2):
+                  y = get()
+                  print(repr((i, x, y)))
+      outer()
+      """)
+    end
   end
 
   # ── Complex programs (extended) ────────────────────────────

--- a/test/pyex/error_messages_test.exs
+++ b/test/pyex/error_messages_test.exs
@@ -248,18 +248,37 @@ defmodule Pyex.ErrorMessagesTest do
   # ── Generator/iterator errors are actionable ─────────────────
 
   describe "generator error messages" do
-    test "next() on raw generator suggests iter()" do
-      {:error, %Error{message: msg}} =
+    test "next() on raw generator advances it directly (CPython parity)" do
+      # Generators are now lazy iterators — `next(gen())` works without
+      # an intermediate `iter()` call, matching CPython.
+      {:ok, result, _ctx} =
+        Pyex.run("""
+        def gen():
+            yield 1
+            yield 2
+        g = gen()
+        [next(g), next(g)]
+        """)
+
+      assert result == [1, 2]
+    end
+
+    test "next() past exhaustion raises StopIteration" do
+      {:ok, result, _ctx} =
         Pyex.run("""
         def gen():
             yield 1
         g = gen()
         next(g)
+        try:
+            next(g)
+            stopped = False
+        except StopIteration:
+            stopped = True
+        stopped
         """)
 
-      assert msg =~ "TypeError"
-      assert msg =~ "iter()"
-      refute msg =~ "not an iterator"
+      assert result == true
     end
 
     test "iter() then next() works correctly" do


### PR DESCRIPTION
## Summary

Four interpreter correctness fixes uncovered by deliberately composing features that the per-axis tests exercised in isolation. CPython conformance verified byte-for-byte; suite is **5144 tests, 0 failures**.

## What was broken

Each bug only manifested when multiple correct features were combined, which is why the existing test suite missed them:

### 1. Closure call refreshed only the global scope
A closure called from inside a nested for-loop in the enclosing function wiped the loop variables (`i`, `x`) on return — every middle scope of the captured env was a stale snapshot from `def` time, and `propagate_scopes` then replaced the caller's env with the closure's post-call view.

```python
def outer():
    captured = 1
    def inner(): return captured
    for i in [1, 2]:
        for x in ['a', 'b']:
            print(str(i) + ':' + str(inner()))   # NameError: 'i'
outer()
```

### 2. `lst[0] += 1` lost class-method captured state
`eval_name_aug_subscript_assign` rebound the name via `Env.put_at_source` instead of mutating the heap. Regular closures masked this because `update_closure_env` patched the function value's stored env on each call; class methods have no such patch path, so every method call saw a fresh `counter = [0]`:

```python
def outer():
    counter = [0]
    class C:
        def tick(self):
            counter[0] += 1
            return counter[0]
    return C
C = outer(); a = C(); b = C()
print(a.tick(), b.tick(), a.tick())   # printed 1 1 1, should be 1 2 3
```

### 3. `def f(): a; b; c` swallowed surrounding statements
The lexer rewrote `;` to `\n + current-line-indent`, which lifted body statements out into the surrounding block. Programs ran without error but produced wrong answers:

```python
def f(): return 1; print("never")
print(f())
# CPython: 1
# Pyex (before): "never\n1"  — print("never") parsed as sibling of def, not in body
```

### 4. Generators evaluated eagerly
`for x in gen():` ran the entire generator first, accumulating yields into a list, then iterated the list. Side-effect ordering was wrong, and infinite generators with `break` hung forever:

```python
def gen():
    for i in range(3):
        print("g-before", i)
        yield i
        print("g-after", i)
for x in gen():
    print("c", x)
# CPython: g-before 0, c 0, g-after 0, g-before 1, c 1, g-after 1, ...
# Pyex (before): all g-before/g-after first, then all c
```

## Fixes

- **`Env.refresh_from_caller/2`** (`lib/pyex/env.ex`) — walks both `(scope_id, scope)` lists and replaces every closure scope whose id matches a caller scope with the caller's current version. Three call sites in `interpreter/invocation.ex` updated.

- **`ref_write_back` in aug-subscript assign** (`lib/pyex/interpreter/assignments.ex`) — when the variable holds a `{:ref, id}`, write back to the heap instead of rebinding the name. Matches CPython's in-place mutation semantics for mutable objects.

- **`;` as a token** (`lib/pyex/lexer.ex`, `lib/pyex/parser.ex`) — stop rewriting `;` to a newline. `parse_block` skips `:semicolon` like `:newline`. New `parse_inline_body` chains `;`-separated small statements, returns a list. 9 call sites in `parser/{definitions,control_flow,match}.ex` updated.

- **Lazy generators** (`lib/pyex/{ctx,interpreter,interpreter/{invocation,control_flow,iterables,builtin_results},stdlib/fastapi,lambda}.ex`) — `gen()` returns `{:iterator, id}` backed by a `:gen_pending` / `:gen_done` pool entry; `for`-loops, `next()`, and `yield from` step via `resume_generator`. New `:cont_yield_from_iter` continuation frame preserves partial-yield-then-error semantics for `yield from`. Builtins drain via the same path through a no-drain allowlist for `iter`/`next`/`type`/`isinstance`/`id`/`repr`/`len`.

Three additional bugs surfaced and fixed during the work:
- `:defer_inner` mode fell through to eager accumulate, defeating laziness for inner generators called from `yield from`.
- `sync_generator_ctx` didn't propagate `iterators` / `next_iterator_id`, so the outer generator's wrap collided with the inner's pool slot.
- `call_builtin_kw` didn't drain generator-iterator args (needed for `zip(g1(), g2())`).

## Test plan

Three new conformance suites cross-axis-test the failure modes:
- [x] `test/pyex/conformance/closure_composition_conformance_test.exs` (24 tests) — closure × loop × mutation × method dispatch
- [x] `test/pyex/conformance/semicolon_conformance_test.exs` (21 tests) — every compound statement that accepts an inline body, plus `def f(): return 1; print("never")` etc.
- [x] `test/pyex/conformance/lazy_generator_conformance_test.exs` (23 tests) — side-effect interleaving, mutation across yield, infinite + break, `next()` identity, two-generator interleaving, `yield from` exception, chained pipelines

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` — 5144 tests, 0 failures, 2 skipped
- [x] `mix dialyzer` — no new warnings (one pre-existing in `dataclasses.ex` unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)