### PR TITLE
Add Docker and docker-compose for the HTTP eval server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM elixir:1.19-otp-28
+
+WORKDIR /app
+
+# Install hex and rebar
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+# Copy dependency files first for layer caching
+COPY mix.exs mix.lock ./
+COPY .formatter.exs ./
+
+# Fetch and compile dependencies
+RUN mix deps.get
+RUN mix compile
+
+# Copy the rest of the application
+COPY lib/ lib/
+COPY demo/ demo/
+COPY config/ config/
+
+# Final compile after source copy
+RUN mix compile
+
+EXPOSE 4000
+
+CMD ["mix", "run", "demo/eval_server.exs"]

--- a/README.md
+++ b/README.md
@@ -351,6 +351,55 @@ Dialyzer runs on every change. All public functions have `@spec`
 annotations. The `.dialyzer_ignore.exs` file suppresses 30 known
 warnings from NimbleParsec-generated code; real warnings are zero.
 
+## Docker Eval Server
+
+If you don't have Elixir installed, you can run the HTTP eval server
+via Docker:
+
+```bash
+docker compose up
+```
+
+Then send Python to `POST /run`:
+
+```bash
+curl -s localhost:4000/run \
+  -H 'content-type: application/json' \
+  -d '{"source":"import json\nscores = [85, 92, 78, 95, 88]\navg = sum(scores) / len(scores)\nabove = [s for s in scores if s > avg]\nresult = {\"average\": avg, \"above_average\": above, \"count\": len(above)}\nprint(json.dumps(result, indent=2))\nresult\n"}' | jq
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "value": {
+    "above_average": [92, 95, 88],
+    "average": 87.6,
+    "count": 3
+  },
+  "output": "{\n  \"average\": 87.6,\n  \"above_average\": [\n    92,\n    95,\n    88\n  ],\n  \"count\": 3\n}\n"
+}
+```
+
+The server wraps `Pyex.run/2` with a 5-second compute timeout.
+Errors are returned as JSON with a `kind` field (`:syntax`,
+`:python`, `:timeout`, etc.):
+
+```bash
+curl -s localhost:4000/run \
+  -H 'content-type: application/json' \
+  -d '{"source":"1 / 0"}' | jq
+```
+
+```json
+{
+  "ok": false,
+  "kind": "python",
+  "message": "ZeroDivisionError: division by zero (line 1)"
+}
+```
+
 ## Development
 
 Requires Elixir ~> 1.19 and OTP 28.

--- a/demo/eval_server.exs
+++ b/demo/eval_server.exs
@@ -1,0 +1,53 @@
+defmodule EvalServer.Plug do
+  use Plug.Router
+
+  plug(:match)
+  plug(Plug.Parsers, parsers: [:json], json_decoder: Jason)
+  plug(:dispatch)
+
+  post "/run" do
+    source = conn.body_params["source"] || ""
+
+    case Pyex.run(source, timeout: 5_000) do
+      {:ok, value, ctx} ->
+        body =
+          Jason.encode!(%{
+            ok: true,
+            value: value,
+            output: Pyex.output(ctx)
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(200, body)
+
+      {:error, err} ->
+        body =
+          Jason.encode!(%{
+            ok: false,
+            kind: err.kind,
+            message: err.message
+          })
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.send_resp(400, body)
+    end
+  end
+
+  match _ do
+    body =
+      Jason.encode!(%{
+        ok: false,
+        message: "Use POST /run with JSON body: {\"source\": \"...\"}"
+      })
+
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(404, body)
+  end
+end
+
+{:ok, _} = Bandit.start_link(plug: EvalServer.Plug, port: 4000)
+IO.puts("Listening on http://localhost:4000")
+Process.sleep(:infinity)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  pyex-eval:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "4000:4000"
+    environment:
+      - MIX_ENV=dev
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/run"]
+      interval: 5s
+      timeout: 3s
+      retries: 5


### PR DESCRIPTION
## Summary
- Adds `Dockerfile` based on `elixir:1.19-otp-28` so new users can run the eval server without installing Elixir or OTP locally.
- Adds `docker-compose.yml` for one-command startup (`docker compose up`).
- Adds `demo/eval_server.exs` — a Plug/Bandit server exposing `POST /run` that accepts Python source as JSON, executes it via `Pyex.run/2`, and returns `{ok, value, output}` or `{ok: false, kind, message}`.

## Usage
```bash
docker compose up
# in another shell
curl -s localhost:4000/run \
  -H 'content-type: application/json' \
  -d '{"source":"print(\"hello from pyex\")\nsum([1, 2, 3])"}'
```

## Verified
- Image builds clean and runs.
- Happy path returns `{"ok":true,"value":6,"output":"hello from pyex\n"}`.
- Error path returns `{"ok":false,"kind":"python","message":"..."}`.