### PR TITLE
Fix class scope, methods-as-generators, and dataclass user factories

### DIFF
--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -375,7 +375,8 @@ defmodule Pyex.Interpreter do
       end)
       |> Enum.reject(&is_nil/1)
 
-    class_env = Env.push_scope(env)
+    class_env =
+      Env.push_scope_with(env, %{"__annotations__" => %{}, "__annotations_order__" => []})
 
     {class_env, ctx, error} =
       Enum.reduce_while(body, {class_env, ctx, nil}, fn stmt, {ce, c, _err} ->

--- a/lib/pyex/interpreter/invocation.ex
+++ b/lib/pyex/interpreter/invocation.ex
@@ -108,22 +108,26 @@ defmodule Pyex.Interpreter.Invocation do
         {{:exception, msg}, env, ctx}
 
       {call_env, ctx} ->
-        {result, post_call_env, ctx} = Interpreter.eval_statements(body, call_env, ctx)
-        env = Env.propagate_scopes(env, fresh_closure, post_call_env)
-        return_val = Helpers.unwrap_function_result(result)
+        if Interpreter.contains_yield?(body) do
+          eval_generator_function(body, call_env, env, ctx)
+        else
+          {result, post_call_env, ctx} = Interpreter.eval_statements(body, call_env, ctx)
+          env = Env.propagate_scopes(env, fresh_closure, post_call_env)
+          return_val = Helpers.unwrap_function_result(result)
 
-        case instance do
-          {:ref, _} ->
-            {return_val, env, ctx}
+          case instance do
+            {:ref, _} ->
+              {return_val, env, ctx}
 
-          _ ->
-            updated_self =
-              case Env.get(post_call_env, "self") do
-                {:ok, {:instance, _, _} = updated} -> updated
-                _ -> instance
-              end
+            _ ->
+              updated_self =
+                case Env.get(post_call_env, "self") do
+                  {:ok, {:instance, _, _} = updated} -> updated
+                  _ -> instance
+                end
 
-            {:mutate, updated_self, return_val, env, ctx}
+              {:mutate, updated_self, return_val, env, ctx}
+          end
         end
     end
   end
@@ -401,6 +405,23 @@ defmodule Pyex.Interpreter.Invocation do
             rebound = rebind_to_subclass(new_instance, class)
             {ref, ctx} = Ctx.heap_alloc(ctx, rebound)
             {ref, env, ctx}
+
+          # Builtin __init__ that needs to call back into the interpreter
+          # (e.g. dataclass field with default_factory=lambda: ...).
+          {:ctx_call, ctx_fun} ->
+            case ctx_fun.(env, ctx) do
+              {{:instance, _, _} = updated_instance, env, ctx} ->
+                rebound = rebind_to_subclass(updated_instance, class)
+                {ref, ctx} = Ctx.heap_alloc(ctx, rebound)
+                {ref, env, ctx}
+
+              {{:exception, _} = signal, env, ctx} ->
+                {signal, env, ctx}
+
+              {_, env, ctx} ->
+                {ref, ctx} = Ctx.heap_alloc(ctx, instance)
+                {ref, env, ctx}
+            end
 
           {:exception, _} = signal ->
             {signal, env, ctx}

--- a/lib/pyex/stdlib/dataclasses.ex
+++ b/lib/pyex/stdlib/dataclasses.ex
@@ -122,9 +122,24 @@ defmodule Pyex.Stdlib.Dataclasses do
           nil ->
             case unknown_keyword(field_names, kwargs) do
               nil ->
-                case build_dataclass_attrs(field_names, defaults, positional, kwargs) do
-                  {:ok, values} -> {:instance, class, values}
-                  {:error, msg} -> {:exception, msg}
+                if needs_factory_dispatch?(field_names, defaults, positional, kwargs) do
+                  {:ctx_call,
+                   fn env, ctx ->
+                     build_dataclass_attrs_with_ctx(
+                       class,
+                       field_names,
+                       defaults,
+                       positional,
+                       kwargs,
+                       env,
+                       ctx
+                     )
+                   end}
+                else
+                  case build_dataclass_attrs(field_names, defaults, positional, kwargs) do
+                    {:ok, values} -> {:instance, class, values}
+                    {:error, msg} -> {:exception, msg}
+                  end
                 end
 
               key ->
@@ -139,6 +154,90 @@ defmodule Pyex.Stdlib.Dataclasses do
 
   defp dataclass_init(_args, _kwargs),
     do: {:exception, "TypeError: invalid dataclass initialization"}
+
+  @spec needs_factory_dispatch?([String.t()], map(), map(), map()) :: boolean()
+  defp needs_factory_dispatch?(field_names, defaults, positional, kwargs) do
+    Enum.any?(field_names, fn field ->
+      not Map.has_key?(positional, field) and not Map.has_key?(kwargs, field) and
+        case Map.get(defaults, field) do
+          %{@field_marker => true, "default_factory" => factory} when factory != :__missing__ ->
+            user_callable?(factory)
+
+          _ ->
+            false
+        end
+    end)
+  end
+
+  @spec user_callable?(Interpreter.pyvalue()) :: boolean()
+  defp user_callable?({:function, _, _, _, _}), do: true
+  defp user_callable?({:lambda, _, _, _}), do: true
+  defp user_callable?({:bound_method, _, _}), do: true
+  defp user_callable?({:bound_method, _, _, _}), do: true
+  defp user_callable?({:class, _, _, _}), do: true
+  defp user_callable?(_), do: false
+
+  @spec build_dataclass_attrs_with_ctx(
+          Interpreter.pyvalue(),
+          [String.t()],
+          map(),
+          map(),
+          map(),
+          Pyex.Env.t(),
+          Pyex.Ctx.t()
+        ) :: {Interpreter.pyvalue(), Pyex.Env.t(), Pyex.Ctx.t()}
+  defp build_dataclass_attrs_with_ctx(class, field_names, defaults, positional, kwargs, env, ctx) do
+    Enum.reduce_while(field_names, {:ok, %{}, env, ctx}, fn field, {:ok, acc, env, ctx} ->
+      cond do
+        Map.has_key?(positional, field) ->
+          {:cont, {:ok, Map.put(acc, field, Map.fetch!(positional, field)), env, ctx}}
+
+        Map.has_key?(kwargs, field) ->
+          {:cont, {:ok, Map.put(acc, field, Map.fetch!(kwargs, field)), env, ctx}}
+
+        Map.has_key?(defaults, field) ->
+          case resolve_default_with_ctx(Map.fetch!(defaults, field), env, ctx) do
+            {{:exception, _} = signal, env, ctx} ->
+              {:halt, {:error, signal, env, ctx}}
+
+            {value, env, ctx} ->
+              {:cont, {:ok, Map.put(acc, field, value), env, ctx}}
+          end
+
+        true ->
+          {:halt,
+           {:error, {:exception, "TypeError: missing required argument '#{field}'"}, env, ctx}}
+      end
+    end)
+    |> case do
+      {:ok, values, env, ctx} -> {{:instance, class, values}, env, ctx}
+      {:error, signal, env, ctx} -> {signal, env, ctx}
+    end
+  end
+
+  @spec resolve_default_with_ctx(Interpreter.pyvalue(), Pyex.Env.t(), Pyex.Ctx.t()) ::
+          {Interpreter.pyvalue(), Pyex.Env.t(), Pyex.Ctx.t()}
+  defp resolve_default_with_ctx(
+         %{@field_marker => true, "default_factory" => factory},
+         env,
+         ctx
+       )
+       when factory != :__missing__ do
+    if user_callable?(factory) do
+      # call_function may return either {val, env, ctx} or
+      # {val, env, ctx, updated_func} (closure-refresh path).
+      case Interpreter.call_function(factory, [], %{}, env, ctx) do
+        {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
+        {{:exception, _} = signal, env, ctx, _func} -> {signal, env, ctx}
+        {value, env, ctx} -> {value, env, ctx}
+        {value, env, ctx, _updated_func} -> {value, env, ctx}
+      end
+    else
+      {run_default_factory(factory), env, ctx}
+    end
+  end
+
+  defp resolve_default_with_ctx(value, env, ctx), do: {resolve_default(value), env, ctx}
 
   @spec dataclass_repr([Interpreter.pyvalue()]) :: String.t() | {:exception, String.t()}
   defp dataclass_repr([{:instance, {:class, name, _, attrs}, inst_attrs}]) do

--- a/test/pyex/generators_test.exs
+++ b/test/pyex/generators_test.exs
@@ -301,4 +301,65 @@ defmodule Pyex.GeneratorsTest do
       assert Pyex.run!("sorted(x % 3 for x in range(6))") == [0, 0, 1, 1, 2, 2]
     end
   end
+
+  describe "yield inside class methods" do
+    test "instance method generator" do
+      code = """
+      class Counter:
+          def __init__(self):
+              self.n = 0
+          def gen(self, k):
+              for i in range(k):
+                  yield i
+
+      list(Counter().gen(3))
+      """
+
+      assert Pyex.run!(code) == [0, 1, 2]
+    end
+
+    test "instance method generator yields self attribute" do
+      code = """
+      class Box:
+          def __init__(self, items):
+              self.items = items
+          def each(self):
+              for x in self.items:
+                  yield x
+
+      list(Box([10, 20, 30]).each())
+      """
+
+      assert Pyex.run!(code) == [10, 20, 30]
+    end
+
+    test "classmethod generator" do
+      code = """
+      class C:
+          @classmethod
+          def squares(cls, n):
+              for i in range(n):
+                  yield i * i
+
+      list(C.squares(4))
+      """
+
+      assert Pyex.run!(code) == [0, 1, 4, 9]
+    end
+
+    test "staticmethod generator" do
+      code = """
+      class C:
+          @staticmethod
+          def evens(n):
+              for i in range(n):
+                  if i % 2 == 0:
+                      yield i
+
+      list(C.evens(6))
+      """
+
+      assert Pyex.run!(code) == [0, 2, 4]
+    end
+  end
 end

--- a/test/pyex/stdlib/dataclasses_test.exs
+++ b/test/pyex/stdlib/dataclasses_test.exs
@@ -1,6 +1,85 @@
 defmodule Pyex.Stdlib.DataclassesTest do
   use ExUnit.Case, async: true
 
+  test "module-level annotated constants do not leak into dataclass fields" do
+    # Regression: an annotated module-level binding (e.g.
+    # `_DEFAULT: Tuple[int, ...] = (1, 2, 3)`) was being inherited
+    # by class bodies via the scope walk, so dataclasses treated the
+    # constant name as one of their own fields.
+    result =
+      Pyex.run!("""
+      from dataclasses import dataclass
+      from typing import Sequence, Tuple
+
+      _DEFAULT_PRIORS: Tuple[int, ...] = (1, 2, 3)
+
+      @dataclass
+      class Cfg:
+          priors: Sequence[int] = _DEFAULT_PRIORS
+
+      Cfg().priors
+      """)
+
+    assert result == {:tuple, [1, 2, 3]}
+  end
+
+  test "field default_factory invokes user-defined lambda" do
+    # Regression: run_default_factory only knew how to invoke builtins,
+    # so a user lambda fell through and was stored as the field value
+    # itself instead of being called.
+    result =
+      Pyex.run!("""
+      from dataclasses import dataclass, field
+
+      @dataclass
+      class C:
+          items: list = field(default_factory=lambda: [1, 2, 3])
+
+      C().items
+      """)
+
+    assert result == [1, 2, 3]
+  end
+
+  test "field default_factory invokes user-defined def" do
+    result =
+      Pyex.run!("""
+      from dataclasses import dataclass, field
+
+      def make():
+          return {"a": 1}
+
+      @dataclass
+      class C:
+          data: dict = field(default_factory=make)
+
+      C().data
+      """)
+
+    assert result == %{"a" => 1}
+  end
+
+  test "field default_factory produces independent values per instance" do
+    # Each call to the factory must yield a fresh object — otherwise
+    # mutating one instance leaks into the next, which is the whole
+    # reason default_factory exists instead of `default=[]`.
+    result =
+      Pyex.run!("""
+      from dataclasses import dataclass, field
+
+      @dataclass
+      class C:
+          items: list = field(default_factory=lambda: [])
+
+      a = C()
+      b = C()
+      a.items.append(1)
+      (a.items, b.items, a.items is b.items)
+      """)
+
+    assert result == {:tuple, [[1], [], false]}
+  end
+
   test "dataclass decorator, field, asdict, and replace work" do
     result =
       Pyex.run!("""


### PR DESCRIPTION
## Summary

Three bugs hit while running staff-level Python under pyex. All caught by new tests; verified via the conformance harness for the visible-error pieces.

- **Module-level annotated bindings leaked into class bodies** via the scope-walk in `Env.get`. A class's first annotated assignment pulled the module's `__annotations__` into the class scope, so `@dataclass` saw module constants as class fields and raised `TypeError: missing required argument '_DEFAULT_PRIORS'`. Class bodies now start with their own empty `__annotations__` and `__annotations_order__`, matching CPython.
- **`yield` inside instance/class methods raised `SyntaxError: 'yield' outside function`**. `call_bound_method` evaluated the body straight through `eval_statements` instead of running the same `contains_yield?` dispatch as `call_user_function`. It now branches into `eval_generator_function` when the body contains yield. (Static methods already worked; they go through `call_user_function`.)
- **`field(default_factory=lambda: ...)` returned the lambda itself** instead of calling it. `run_default_factory` only knew how to invoke `:builtin_type` / `:builtin` tokens; user-defined functions/lambdas (`{:function, \"<lambda>\", ...}`) fell through the catch-all clause. Builtin `__init__`s have no env/ctx, so `dataclass_init` now returns a `:ctx_call` deferred token when a field's default is a user callable; `call_class_generic` resolves it through `Interpreter.call_function`.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` — 5276 tests, 0 failures, 2 skipped (24 excluded)
- [x] `mix dialyzer` — clean
- [x] New regression tests added in `dataclasses_test.exs` (3 cases) and `generators_test.exs` (4 cases) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)