### PR TITLE
Cache MRO and stamp class IDs to make C3 linearization O(1) on cache hit

### DIFF
--- a/lib/pyex/builtins.ex
+++ b/lib/pyex/builtins.ex
@@ -2033,7 +2033,8 @@ defmodule Pyex.Builtins do
   end
 
   defp class_getattr({:class, _, _, class_attrs}, "__dict__") do
-    {:ok, PyDict.from_pairs(Enum.map(class_attrs, fn {k, v} -> {k, v} end))}
+    visible = Pyex.Interpreter.ClassLookup.visible_attrs(class_attrs)
+    {:ok, PyDict.from_pairs(Enum.map(visible, fn {k, v} -> {k, v} end))}
   end
 
   defp class_getattr({:class, _, _, _} = class, attr) do
@@ -2240,13 +2241,20 @@ defmodule Pyex.Builtins do
   @spec builtin_dir([Interpreter.pyvalue()]) :: [String.t()]
   defp builtin_dir([{:instance, {:class, _, bases, class_attrs}, instance_attrs}]) do
     inherited = collect_inherited_attrs(bases)
-    all_keys = Map.keys(class_attrs) ++ Map.keys(instance_attrs) ++ Map.keys(inherited)
+    visible_class = Pyex.Interpreter.ClassLookup.visible_attrs(class_attrs)
+    visible_inherited = Pyex.Interpreter.ClassLookup.visible_attrs(inherited)
+
+    all_keys =
+      Map.keys(visible_class) ++ Map.keys(instance_attrs) ++ Map.keys(visible_inherited)
+
     all_keys |> Enum.uniq() |> Enum.sort()
   end
 
   defp builtin_dir([{:class, _, bases, class_attrs}]) do
     inherited = collect_inherited_attrs(bases)
-    all_keys = Map.keys(class_attrs) ++ Map.keys(inherited)
+    visible_class = Pyex.Interpreter.ClassLookup.visible_attrs(class_attrs)
+    visible_inherited = Pyex.Interpreter.ClassLookup.visible_attrs(inherited)
+    all_keys = Map.keys(visible_class) ++ Map.keys(visible_inherited)
     all_keys |> Enum.uniq() |> Enum.sort()
   end
 
@@ -2291,7 +2299,8 @@ defmodule Pyex.Builtins do
   @spec builtin_vars([Interpreter.pyvalue()]) :: %{optional(String.t()) => Interpreter.pyvalue()}
   defp builtin_vars([{:instance, _class, attrs}]), do: attrs
 
-  defp builtin_vars([{:class, _, _bases, attrs}]), do: attrs
+  defp builtin_vars([{:class, _, _bases, attrs}]),
+    do: Pyex.Interpreter.ClassLookup.visible_attrs(attrs)
 
   defp builtin_vars([{:module, _, attrs}]), do: attrs
 

--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -427,6 +427,8 @@ defmodule Pyex.Interpreter do
           class_val
         end
 
+      class_val = ClassLookup.with_mro_cache(class_val)
+
       {nil, Env.smart_put(env, name, class_val), ctx}
     end
   end
@@ -864,7 +866,8 @@ defmodule Pyex.Interpreter do
                 {{:tuple, bases}, env, ctx}
 
               "__dict__" ->
-                pairs = Enum.map(class_attrs, fn {k, v} -> {k, v} end)
+                visible = ClassLookup.visible_attrs(class_attrs)
+                pairs = Enum.map(visible, fn {k, v} -> {k, v} end)
                 {PyDict.from_pairs(pairs), env, ctx}
 
               _ ->
@@ -1621,7 +1624,8 @@ defmodule Pyex.Interpreter do
 
           "__dict__" ->
             # Expose a read-only view of class attrs as a dict
-            pairs = Enum.map(class_attrs, fn {k, v} -> {k, v} end)
+            visible = ClassLookup.visible_attrs(class_attrs)
+            pairs = Enum.map(visible, fn {k, v} -> {k, v} end)
             {PyDict.from_pairs(pairs), env, ctx}
 
           _ ->

--- a/lib/pyex/interpreter/class_lookup.ex
+++ b/lib/pyex/interpreter/class_lookup.ex
@@ -38,6 +38,12 @@ defmodule Pyex.Interpreter.ClassLookup do
 
   @doc "Compute the C3 linearized MRO for a class."
   @spec c3_linearize(Interpreter.pyvalue()) :: [Interpreter.pyvalue()]
+  # Cached MRO tail (everything after self) avoids re-running C3 for
+  # deeply nested chains. The head is always the live class so attribute
+  # lookups still see the most recent attrs map; only the tail (the
+  # parents, which can't change once the class is built) is reused.
+  def c3_linearize({:class, _, _, %{"__mro_cache__" => tail}} = class), do: [class | tail]
+
   def c3_linearize({:class, _, [], _} = class), do: [class]
 
   def c3_linearize({:class, _, bases, _} = class) do
@@ -51,6 +57,33 @@ defmodule Pyex.Interpreter.ClassLookup do
   # {:class, name, [parent_exc], %{}} classes.  Reify on demand.
   def c3_linearize({:exception_class, _} = exc) do
     c3_linearize(Interpreter.exception_instance_class(exc))
+  end
+
+  @internal_class_attrs ["__id__", "__mro_cache__"]
+
+  @doc """
+  Strip pyex-internal class attrs (`__id__`, `__mro_cache__`) from a
+  user-visible attrs map. Used by `__dict__`, `dir()`, and `vars()` so
+  the MRO cache key isn't observable from Python.
+  """
+  @spec visible_attrs(map()) :: map()
+  def visible_attrs(attrs) when is_map(attrs) do
+    Map.drop(attrs, @internal_class_attrs)
+  end
+
+  @doc """
+  Stamp a class with a fresh identity ref and cache its MRO tail.
+
+  - `__id__`: a `make_ref()` used as the cheap MRO-merge hash key.
+  - `__mro_cache__`: the linearized MRO with `self` stripped, so future
+    `c3_linearize/1` calls are O(1).
+  """
+  @spec with_mro_cache(Interpreter.pyvalue()) :: Interpreter.pyvalue()
+  def with_mro_cache({:class, name, bases, attrs}) do
+    attrs_with_id = Map.put(attrs, "__id__", make_ref())
+    tagged = {:class, name, bases, attrs_with_id}
+    [^tagged | tail] = c3_linearize(tagged)
+    {:class, name, bases, Map.put(attrs_with_id, "__mro_cache__", tail)}
   end
 
   @spec reify_base(Interpreter.pyvalue()) :: Interpreter.pyvalue()
@@ -86,16 +119,24 @@ defmodule Pyex.Interpreter.ClassLookup do
 
   @spec find_c3_head([[Interpreter.pyvalue()]]) :: {:ok, Interpreter.pyvalue()} | :error
   defp find_c3_head(lists) do
-    tails = lists |> Enum.flat_map(&tl_safe/1) |> MapSet.new()
+    # Hash by per-class identity (a `make_ref()` stored in attrs as
+    # "__id__") so MapSet ops stay O(1) — without this, hashing a
+    # class tuple walks its entire `bases` chain, and merging the MRO
+    # for a class at depth n becomes O(n³).
+    tails_ids = lists |> Enum.flat_map(&tl_safe/1) |> MapSet.new(&class_identity/1)
 
     Enum.find_value(lists, :error, fn
       [head | _] ->
-        if MapSet.member?(tails, head), do: nil, else: {:ok, head}
+        if MapSet.member?(tails_ids, class_identity(head)), do: nil, else: {:ok, head}
 
       [] ->
         nil
     end)
   end
+
+  @spec class_identity(Interpreter.pyvalue()) :: term()
+  defp class_identity({:class, _, _, %{"__id__" => id}}), do: id
+  defp class_identity(other), do: other
 
   @spec tl_safe([Interpreter.pyvalue()]) :: [Interpreter.pyvalue()]
   defp tl_safe([]), do: []

--- a/test/pyex/conformance/datetime_time_conformance_test.exs
+++ b/test/pyex/conformance/datetime_time_conformance_test.exs
@@ -9,7 +9,7 @@ defmodule Pyex.Conformance.DatetimeTimeTest do
   import Pyex.Test.Oracle
 
   describe "constructor" do
-    for {label, args} <- [
+    for {_label, args} <- [
           {"default", "0"},
           {"hour only", "12"},
           {"hour minute", "12, 30"},
@@ -29,7 +29,7 @@ defmodule Pyex.Conformance.DatetimeTimeTest do
   end
 
   describe "isoformat" do
-    for {label, args, expected} <- [
+    for {label, args, _expected} <- [
           {"basic", "12, 30", "12:30:00"},
           {"with sec", "12, 30, 45", "12:30:45"},
           {"with us", "12, 30, 45, 123456", "12:30:45.123456"},


### PR DESCRIPTION
## Summary

\`ClassLookup.c3_linearize/1\` was unmemoized, so every method/init lookup recomputed the full MRO. For a class at depth n in a single-inheritance chain:

- the recursion is O(n) calls
- each call runs \`c3_merge\`
- \`find_c3_head\` builds a \`MapSet\` over class tuples, and \`:erlang.phash2\` walks each tuple's \`bases\` chain — so each hash is O(n)

That puts one top-level \`c3_linearize\` at roughly O(n^4). On the 200-deep adversarial inheritance chain it was ~24s locally and timed out CI's 60s ExUnit deadline (#52 was the temporary mitigation).

Two changes:

1. Stamp every freshly defined class with \`__id__\` (a \`make_ref()\`) stored in attrs. \`find_c3_head\` now hashes class identities via their refs, so MapSet ops are O(1) instead of O(depth).
2. Cache the MRO tail (everything after \`self\`) in \`__mro_cache__\` at class definition. \`c3_linearize/1\` short-circuits via the cache, so subsequent lookups are O(1).

\`ClassLookup.visible_attrs/1\` strips both internal keys from \`__dict__\`, \`dir()\`, and \`vars()\` so they're not user-observable.

### Microbenchmark

Chain test: \`Cn\` inherits from \`Cn-1\`, then \`Cn().method()\`.

| n   | before  | after   |
|-----|---------|---------|
| 100 | 2007 ms | 18 ms   |
| 200 |   ~24 s | 105 ms  |
| 500 |  hours  | 1.7 s   |

### Relationship to #52

#52 mitigated the timeout by halving the adversarial test chain (200 → 100). With this fix, n=200 finishes in ~105ms, so #52 is no longer needed once this lands. Either land #52 first as a quick safety net and follow up with this, or land this and close #52 — happy to do whichever.

## Test plan
- [x] \`mix format --check-formatted\`
- [x] \`mix compile --warnings-as-errors\`
- [x] \`mix test\` — 5276 tests, 0 failures, 2 skipped
- [x] \`mix dialyzer\` — clean
- [x] Verified \`__id__\` and \`__mro_cache__\` are filtered from \`__dict__\`, \`dir()\`, \`vars()\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)