### PR TITLE
fix: thread yielded signals through assign + return

### DIFF
--- a/lib/pyex/interpreter.ex
+++ b/lib/pyex/interpreter.ex
@@ -554,8 +554,19 @@ defmodule Pyex.Interpreter do
 
   def eval({:return, _, [expr]}, env, ctx) do
     case eval(expr, env, ctx) do
-      {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
-      {value, env, ctx} -> {{:returned, value}, env, ctx}
+      {{:exception, _} = signal, env, ctx} ->
+        {signal, env, ctx}
+
+      {{:yielded, val, cont}, env, ctx} ->
+        # `return await coro` (or any return-of-suspending-expr): the
+        # awaited expression yielded part-way through evaluation.
+        # Propagate the yield up; on resume, the resumed value becomes
+        # the function's return.  Mirrors how `eval_assign` handles
+        # `x = yield expr` via `:cont_bind_sent`.
+        {{:yielded, val, cont ++ [{:cont_return_value}]}, env, ctx}
+
+      {value, env, ctx} ->
+        {{:returned, value}, env, ctx}
     end
   end
 
@@ -3665,6 +3676,7 @@ defmodule Pyex.Interpreter do
              [Parser.ast_node()] | nil}
           | {:cont_bind_sent, String.t()}
           | {:cont_await_iter, non_neg_integer()}
+          | {:cont_return_value}
 
   @doc """
   Resumes a suspended generator from a continuation.
@@ -3686,6 +3698,12 @@ defmodule Pyex.Interpreter do
     # next() resumes with sent_value = nil (Python semantics)
     env = Env.smart_put(env, name, nil)
     resume_generator(rest, env, ctx)
+  end
+
+  def resume_generator([{:cont_return_value} | _rest], env, ctx) do
+    # `return await coro` resumed with no sent value (e.g. via
+    # plain next()): treat as the function returning None.
+    {{:done_with_value, nil}, env, ctx}
   end
 
   def resume_generator([{:cont_stmts, stmts} | rest], env, ctx) do
@@ -3840,6 +3858,13 @@ defmodule Pyex.Interpreter do
   def resume_generator_with_send([{:cont_bind_sent, name} | rest], env, ctx, sent_value) do
     env = Env.smart_put(env, name, sent_value)
     resume_generator(rest, env, ctx)
+  end
+
+  def resume_generator_with_send([{:cont_return_value} | _rest], env, ctx, sent_value) do
+    # `return await coro` resumed with the awaited value via
+    # `:cont_await_iter` -> `resume_generator_with_send`.  The sent
+    # value IS what the function returns.
+    {{:done_with_value, sent_value}, env, ctx}
   end
 
   def resume_generator_with_send(cont, env, ctx, _sent_value) do

--- a/lib/pyex/interpreter/bindings.ex
+++ b/lib/pyex/interpreter/bindings.ex
@@ -38,10 +38,23 @@ defmodule Pyex.Interpreter.Bindings do
         {signal, env, ctx}
 
       {{:yielded, val, cont}, env, ctx} ->
-        # yield fires inside an assignment: `x = yield val`.
-        # When the generator is resumed via .send(sent_value), `sent_value`
-        # becomes the result of the yield expression and is bound to `name`.
-        {{:yielded, val, [{:cont_bind_sent, name} | cont]}, env, ctx}
+        # A yielding expression on the RHS of an assignment.  Two
+        # shapes:
+        #
+        #   `x = yield val`  — `cont` is empty.  On resume via .send,
+        #     the sent value is the result of the yield expression and
+        #     is bound to `name`.
+        #
+        #   `x = await coro` — `cont` already has `:cont_await_iter`
+        #     (and maybe nested frames) that drive the coroutine to
+        #     completion before any value is available to bind.
+        #
+        # The bind frame must run AFTER the existing cont — append,
+        # don't prepend.  When `:cont_await_iter` finishes, it routes
+        # its `:done_with_value` through `resume_generator_with_send`
+        # with the awaited value as the sent value, which is exactly
+        # what `:cont_bind_sent` consumes.
+        {{:yielded, val, cont ++ [{:cont_bind_sent, name}]}, env, ctx}
 
       {value, env, ctx} ->
         {value, Env.smart_put(env, name, value), ctx}

--- a/test/pyex/async_conformance_test.exs
+++ b/test/pyex/async_conformance_test.exs
@@ -141,6 +141,60 @@ defmodule Pyex.AsyncConformanceTest do
              asyncio.run(main())
              """) == "'k'"
     end
+
+    test "`r = await coro` binds the awaited value when coro has internal awaits" do
+      # Regression: eval_assign was prepending :cont_bind_sent in
+      # front of the await's existing :cont_await_iter cont, so the
+      # bind ran first (binding nil) before the await actually drove
+      # the coroutine to completion.  Append, don't prepend — the
+      # bind has to happen AFTER the await resolves.
+      assert Pyex.run!("""
+             import asyncio
+             async def fetch():
+                 await asyncio.sleep(0)
+                 return [1, 2, 3]
+             async def main():
+                 r = await fetch()
+                 return r
+             asyncio.run(main())
+             """) == [1, 2, 3]
+    end
+
+    test "`return await coro` surfaces the awaited value when coro has internal awaits" do
+      # Same shape of bug, parallel fix in eval_return: a yielded
+      # signal from the awaited expression has to propagate up with
+      # a :cont_return_value frame that, on resume, makes the sent
+      # value the function's return.
+      assert Pyex.run!("""
+             import asyncio
+             async def inner(v):
+                 await asyncio.sleep(0)
+                 return v
+             async def outer(v):
+                 return await inner(v)
+             asyncio.run(outer({"k": [1, 2, 3]}))
+             """) == %{"k" => [1, 2, 3]}
+    end
+
+    test "chained awaits with internal sleeps each surface their value" do
+      # Stress the yield-through-assign path: three levels of
+      # `r = await fn()` where every fn has its own internal
+      # `await asyncio.sleep(0)`.  If the cont frames are ordered
+      # wrong at any level, intermediate values get lost.
+      assert Pyex.run!("""
+             import asyncio
+             async def lvl3():
+                 await asyncio.sleep(0)
+                 return "leaf"
+             async def lvl2():
+                 r = await lvl3()
+                 return r + "-mid"
+             async def lvl1():
+                 r = await lvl2()
+                 return r + "-top"
+             asyncio.run(lvl1())
+             """) == "leaf-mid-top"
+    end
   end
 
   describe "asyncio.gather" do


### PR DESCRIPTION
\`r = await coro\` and \`return await coro\` silently lost the awaited value when the inner coroutine had its own internal \`await\` (e.g. \`await asyncio.sleep(0)\`).  Real-shape async code surfaces this fast: any helper that wraps a sync result with a cooperative yield (\`async def aw(v): await asyncio.sleep(0); return v\`) and is then awaited returned None instead of \`v\`.

## Two parallel bugs, same root cause

Continuation frames were ordered wrong relative to the awaited expression's existing cont.

### `eval_assign` was prepending `:cont_bind_sent`

\`\`\`elixir
{{:yielded, val, cont}, env, ctx} ->
  {{:yielded, val, [{:cont_bind_sent, name} | cont]}, env, ctx}
\`\`\`

Works for \`r = yield X\` because \`yield X\` returns an empty cont — prepend or append produces the same \`[cont_bind_sent(\"r\")]\`.

For \`r = await coro\`, the await's cont already contains \`:cont_await_iter\` which has to *drive the coroutine to completion* before any value exists to bind.  With prepend, resume processed \`:cont_bind_sent\` first (binding nil) and only then advanced the await — discarding the return value.

Fix: append.  The cont becomes \`[cont_await_iter(coro_id), cont_bind_sent(\"r\")]\`.  When \`:cont_await_iter\` completes it routes the coroutine's return value through \`resume_generator_with_send\`, which is exactly what \`:cont_bind_sent\` consumes.

### `eval_return` wasn't propagating yielded signals at all

\`\`\`elixir
case eval(expr, env, ctx) do
  {{:exception, _} = signal, env, ctx} -> {signal, env, ctx}
  {value, env, ctx} -> {{:returned, value}, env, ctx}
end
\`\`\`

A \`{:yielded, val, cont}\` tuple from the awaited expression matched the catch-all and got wrapped as a returned VALUE.  So the function literally returned the yielded-tuple instead of the awaited value.

Fix: yielded clause that propagates the yield with a new \`:cont_return_value\` frame appended.  Resume handlers send the awaited value through as the function's return.

## Tests

Three regression tests in \`test/pyex/async_conformance_test.exs\` covering bind-on-await, return-on-await, and a three-level await chain that stresses ordering at every level.

## Why these slipped through

Phase 1.5's conformance suite covered \`await coro\` standalone, \`await\` in expression positions (binop, f-string, comprehension), and \`gather\`.  But every existing test with a non-trivial \`await\` was using either:
- \`await asyncio.run(...)\` at the top level (no surrounding bind/return), or
- \`await fn()\` where \`fn\`'s body had no internal \`await\`

So the cont chain stayed simple — \`:cont_await_iter\` was always the last frame.  The bugs only fire when the inner coroutine itself yields, which means a \`:cont_await_iter\` frame *and* a \`:cont_bind_sent\`/\`:cont_return_value\` frame coexist.  A real-shape agent demo (parallel tool calls wrapped with \`asyncio.sleep(0)\` cooperative yields) caught it on first run.

## Test plan

- [x] \`mix format --check-formatted\` clean
- [x] \`mix compile --warnings-as-errors\` clean
- [x] \`mix test\` — 5349 tests, 0 failures, 2 skipped
- [x] \`mix dialyzer\` — 40 errors / 40 skipped (baseline unchanged)
- [x] Three new regression tests for the fixed shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)