### PR TITLE
fix(parser): accept paren tuple targets in comprehension for-clauses

### DIFF
--- a/lib/pyex/parser/comprehensions.ex
+++ b/lib/pyex/parser/comprehensions.ex
@@ -208,6 +208,19 @@ defmodule Pyex.Parser.Comprehensions do
     end
   end
 
+  defp parse_list_comp(expr, [{:op, _, :lparen} | rest], line) do
+    with {:ok, target, rest} <- parse_paren_for_target_and_in(rest),
+         {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, target, iterable} | clauses]
+
+      case rest do
+        [{:op, _, :rbracket} | rest] -> {:ok, {:list_comp, [line: line], [expr, clauses]}, rest}
+        _ -> {:error, "expected ']' after list comprehension at #{token_line(rest)}"}
+      end
+    end
+  end
+
   defp parse_list_comp(_expr, tokens, _line) do
     {:error, "expected variable name after 'for' in list comprehension at #{token_line(tokens)}"}
   end
@@ -235,6 +248,19 @@ defmodule Pyex.Parser.Comprehensions do
     with {:ok, iterable, rest} <- Parser.parse_or(rest),
          {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
       clauses = [{:comp_for, var_name, iterable} | clauses]
+
+      case rest do
+        [{:op, _, :rparen} | rest] -> {:ok, {:gen_expr, [line: line], [expr, clauses]}, rest}
+        _ -> {:error, "expected ')' after generator expression at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  defp parse_gen_expr(expr, [{:op, _, :lparen} | rest], line) do
+    with {:ok, target, rest} <- parse_paren_for_target_and_in(rest),
+         {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, target, iterable} | clauses]
 
       case rest do
         [{:op, _, :rparen} | rest] -> {:ok, {:gen_expr, [line: line], [expr, clauses]}, rest}
@@ -401,6 +427,19 @@ defmodule Pyex.Parser.Comprehensions do
     end
   end
 
+  defp parse_set_comp(expr, [{:op, _, :lparen} | rest], line) do
+    with {:ok, target, rest} <- parse_paren_for_target_and_in(rest),
+         {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, target, iterable} | clauses]
+
+      case rest do
+        [{:op, _, :rbrace} | rest] -> {:ok, {:set_comp, [line: line], [expr, clauses]}, rest}
+        _ -> {:error, "expected '}' after set comprehension at #{token_line(rest)}"}
+      end
+    end
+  end
+
   defp parse_set_comp(_expr, tokens, _line) do
     {:error, "expected variable name in set comprehension at #{token_line(tokens)}"}
   end
@@ -442,6 +481,22 @@ defmodule Pyex.Parser.Comprehensions do
     with {:ok, iterable, rest} <- Parser.parse_or(rest),
          {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
       clauses = [{:comp_for, var_name, iterable} | clauses]
+
+      case rest do
+        [{:op, _, :rbrace} | rest] ->
+          {:ok, {:dict_comp, [line: line], [key_expr, val_expr, clauses]}, rest}
+
+        _ ->
+          {:error, "expected '}' after dict comprehension at #{token_line(rest)}"}
+      end
+    end
+  end
+
+  defp parse_dict_comp(key_expr, val_expr, [{:op, _, :lparen} | rest], line) do
+    with {:ok, target, rest} <- parse_paren_for_target_and_in(rest),
+         {:ok, iterable, rest} <- Parser.parse_or(rest),
+         {:ok, clauses, rest} <- parse_comp_clauses(rest, []) do
+      clauses = [{:comp_for, target, iterable} | clauses]
 
       case rest do
         [{:op, _, :rbrace} | rest] ->
@@ -530,7 +585,7 @@ defmodule Pyex.Parser.Comprehensions do
     end
   end
 
-  @type for_target :: String.t() | [for_target()]
+  @type for_target :: String.t() | {:starred, String.t()} | [for_target()]
 
   @spec collect_for_vars([Lexer.token()], [for_target()]) ::
           {:ok, [for_target()], [Lexer.token()]} | {:error, String.t()}
@@ -556,27 +611,47 @@ defmodule Pyex.Parser.Comprehensions do
     {:error, "expected variable name in for loop at #{token_line(tokens)}"}
   end
 
+  # Parses tokens inside a parenthesised for-target up to (and consuming)
+  # the matching `)`. Each comma-separated item may be a bare name, a
+  # starred name `*name`, or a recursively-parenthesised sub-pattern.
+  # A trailing comma before `)` is allowed (Python's standard 1-tuple
+  # form: `(a,)`); empty parens `()` are rejected (no zero-tuple target
+  # in CPython grammar).
   @spec collect_nested_for_pattern([Lexer.token()], [for_target()]) ::
           {:ok, [for_target()], [Lexer.token()]} | {:error, String.t()}
-  defp collect_nested_for_pattern([{:name, _, name}, {:op, _, :rparen} | rest], acc) do
-    {:ok, Enum.reverse([name | acc]), rest}
-  end
-
-  defp collect_nested_for_pattern([{:name, _, name}, {:op, _, :comma} | rest], acc) do
-    collect_nested_for_pattern(rest, [name | acc])
-  end
-
-  defp collect_nested_for_pattern([{:op, _, :lparen} | rest], acc) do
-    with {:ok, nested, rest} <- collect_nested_for_pattern(rest, []) do
+  defp collect_nested_for_pattern(tokens, acc) do
+    with {:ok, item, rest} <- parse_for_pattern_item(tokens) do
       case rest do
-        [{:op, _, :rparen} | rest] -> {:ok, Enum.reverse([nested | acc]), rest}
-        [{:op, _, :comma} | rest] -> collect_nested_for_pattern(rest, [nested | acc])
-        _ -> {:error, "expected ')' or ',' in nested for target at #{token_line(rest)}"}
+        [{:op, _, :rparen} | rest] ->
+          {:ok, Enum.reverse([item | acc]), rest}
+
+        [{:op, _, :comma}, {:op, _, :rparen} | rest] ->
+          {:ok, Enum.reverse([item | acc]), rest}
+
+        [{:op, _, :comma} | rest] ->
+          collect_nested_for_pattern(rest, [item | acc])
+
+        _ ->
+          {:error, "expected ')' or ',' in nested for target at #{token_line(rest)}"}
       end
     end
   end
 
-  defp collect_nested_for_pattern(tokens, _acc) do
+  @spec parse_for_pattern_item([Lexer.token()]) ::
+          {:ok, for_target(), [Lexer.token()]} | {:error, String.t()}
+  defp parse_for_pattern_item([{:op, _, :star}, {:name, _, name} | rest]) do
+    {:ok, {:starred, name}, rest}
+  end
+
+  defp parse_for_pattern_item([{:name, _, name} | rest]) do
+    {:ok, name, rest}
+  end
+
+  defp parse_for_pattern_item([{:op, _, :lparen} | rest]) do
+    collect_nested_for_pattern(rest, [])
+  end
+
+  defp parse_for_pattern_item(tokens) do
     {:error, "expected variable name in nested for target at #{token_line(tokens)}"}
   end
 

--- a/lib/pyex/parser/control_flow.ex
+++ b/lib/pyex/parser/control_flow.ex
@@ -251,27 +251,48 @@ defmodule Pyex.Parser.ControlFlow do
     {:error, "expected variable name in for loop at #{token_line(tokens)}"}
   end
 
+  # Mirror of `Pyex.Parser.Comprehensions.collect_nested_for_pattern/2` —
+  # kept in sync because both the `for` statement and comprehension
+  # parsers consume the same paren-target sub-grammar.  If you change
+  # one, change the other.  A small shared module would dedupe, but
+  # the rest of `collect_for_vars` (which differs per call site)
+  # blocks a pure extraction; revisit when refactoring the parser
+  # layout.
   @spec collect_nested_for_pattern([Lexer.token()], [for_target()]) ::
           {:ok, [for_target()], [Lexer.token()]} | {:error, String.t()}
-  defp collect_nested_for_pattern([{:name, _, name}, {:op, _, :rparen} | rest], acc) do
-    {:ok, Enum.reverse([name | acc]), rest}
-  end
-
-  defp collect_nested_for_pattern([{:name, _, name}, {:op, _, :comma} | rest], acc) do
-    collect_nested_for_pattern(rest, [name | acc])
-  end
-
-  defp collect_nested_for_pattern([{:op, _, :lparen} | rest], acc) do
-    with {:ok, nested, rest} <- collect_nested_for_pattern(rest, []) do
+  defp collect_nested_for_pattern(tokens, acc) do
+    with {:ok, item, rest} <- parse_for_pattern_item(tokens) do
       case rest do
-        [{:op, _, :rparen} | rest] -> {:ok, Enum.reverse([nested | acc]), rest}
-        [{:op, _, :comma} | rest] -> collect_nested_for_pattern(rest, [nested | acc])
-        _ -> {:error, "expected ')' or ',' in nested for target at #{token_line(rest)}"}
+        [{:op, _, :rparen} | rest] ->
+          {:ok, Enum.reverse([item | acc]), rest}
+
+        [{:op, _, :comma}, {:op, _, :rparen} | rest] ->
+          {:ok, Enum.reverse([item | acc]), rest}
+
+        [{:op, _, :comma} | rest] ->
+          collect_nested_for_pattern(rest, [item | acc])
+
+        _ ->
+          {:error, "expected ')' or ',' in nested for target at #{token_line(rest)}"}
       end
     end
   end
 
-  defp collect_nested_for_pattern(tokens, _acc) do
+  @spec parse_for_pattern_item([Lexer.token()]) ::
+          {:ok, for_target(), [Lexer.token()]} | {:error, String.t()}
+  defp parse_for_pattern_item([{:op, _, :star}, {:name, _, name} | rest]) do
+    {:ok, {:starred, name}, rest}
+  end
+
+  defp parse_for_pattern_item([{:name, _, name} | rest]) do
+    {:ok, name, rest}
+  end
+
+  defp parse_for_pattern_item([{:op, _, :lparen} | rest]) do
+    collect_nested_for_pattern(rest, [])
+  end
+
+  defp parse_for_pattern_item(tokens) do
     {:error, "expected variable name in nested for target at #{token_line(tokens)}"}
   end
 

--- a/test/pyex/comprehensions_test.exs
+++ b/test/pyex/comprehensions_test.exs
@@ -176,4 +176,190 @@ defmodule Pyex.ComprehensionsTest do
       assert Pyex.run!(code) == [3, 4, 5, 6]
     end
   end
+
+  # CPython grammar allows the primary `for` target of a comprehension to be
+  # a parenthesised tuple pattern — exactly the same shape allowed for `for`
+  # statements and for secondary `for` clauses inside a comprehension chain.
+  #
+  # Until the parser was made symmetric with `parse_for` / `parse_comp_for_clause`
+  # / `parse_gen_expr_body`, the primary-target case failed with
+  # "expected variable name after 'for' in {list,set,dict} comprehension".
+  # Bare-comma targets (`for a, b in xs`) were unaffected.  The runtime
+  # already handles list-shaped targets via `bind_loop_var/3` and
+  # `unpack_for_item/2`, so the fix is purely additive in the parser.
+  describe "parenthesised tuple target in primary for clause" do
+    test "list comprehension binds (a, b) target" do
+      assert Pyex.run!("[a + b for (a, b) in [(1, 2), (3, 4), (5, 6)]]") == [3, 7, 11]
+    end
+
+    test "list comprehension re-emits tuples through (a, b) target" do
+      assert Pyex.run!("[(a, b) for (a, b) in [(1, 2), (3, 4)]]") ==
+               [{:tuple, [1, 2]}, {:tuple, [3, 4]}]
+    end
+
+    test "list comprehension binds 3-element tuple target" do
+      assert Pyex.run!("[a * b * c for (a, b, c) in [(1, 2, 3), (4, 5, 6)]]") == [6, 120]
+    end
+
+    test "list comprehension binds single-element tuple target" do
+      assert Pyex.run!("[a for (a,) in [(1,), (2,), (3,)]]") == [1, 2, 3]
+    end
+
+    test "list comprehension binds nested tuple target (a, (b, c))" do
+      code = "[a + b + c for (a, (b, c)) in [(1, (2, 3)), (4, (5, 6))]]"
+      assert Pyex.run!(code) == [6, 15]
+    end
+
+    test "list comprehension binds starred tuple target (a, *rest)" do
+      assert Pyex.run!("[rest for (a, *rest) in [(1, 2, 3), (4, 5)]]") == [[2, 3], [5]]
+    end
+
+    test "list comprehension with paren target also accepts trailing filter" do
+      code = "[a + b for (a, b) in [(1, 2), (3, 4), (5, 6)] if a > 1]"
+      assert Pyex.run!(code) == [7, 11]
+    end
+
+    test "set comprehension binds (a, b) target" do
+      result = Pyex.run!("{a for (a, b) in [(1, 2), (3, 4), (1, 9)]}")
+      assert result == {:set, MapSet.new([1, 3])}
+    end
+
+    test "dict comprehension binds (k, v) target" do
+      assert Pyex.run!(~s|{k: v for (k, v) in [("x", 1), ("y", 2)]}|) ==
+               %{"x" => 1, "y" => 2}
+    end
+
+    test "standalone generator expression binds (a, b) target" do
+      # Goes through parse_gen_expr (called when a `(` opens at expression
+      # position), not parse_gen_expr_body (called from function-call args).
+      # Before the fix, only the latter accepted lparen targets.
+      code = """
+      g = (a + b for (a, b) in [(1, 2), (3, 4)])
+      list(g)
+      """
+
+      assert Pyex.run!(code) == [3, 7]
+    end
+
+    test "generator expression as function argument with (a, b) target" do
+      # parse_gen_expr_body path — was already passing.  Kept as a
+      # symmetry / regression check now that parse_gen_expr matches.
+      assert Pyex.run!("sum(a * b for (a, b) in [(1, 2), (3, 4), (5, 6)])") == 2 + 12 + 30
+    end
+
+    test "primary paren target plus secondary bare-comma clause" do
+      code = "[a + b + z for (a, b) in [(1, 2)] for z in [10, 100]]"
+      assert Pyex.run!(code) == [13, 103]
+    end
+
+    test "primary paren target plus secondary paren target" do
+      code = "[a + c for (a, b) in [(1, 2)] for (c, d) in [(10, 20), (30, 40)]]"
+      assert Pyex.run!(code) == [11, 31]
+    end
+
+    test "bare-comma primary target still works (regression)" do
+      assert Pyex.run!("[a + b for a, b in [(1, 2), (3, 4)]]") == [3, 7]
+    end
+  end
+
+  # The runtime arity / type errors are already produced by
+  # `unpack_for_item/2` for secondary `for` clauses.  These tests prove
+  # the *primary* paren target reaches the same code path — that the
+  # parser fix doesn't silently swallow targets.
+  describe "parenthesised tuple target: runtime errors match CPython" do
+    test "arity mismatch (too many) raises ValueError at runtime" do
+      {:error, %Pyex.Error{message: msg}} =
+        Pyex.run("[a + b for (a, b) in [(1, 2, 3)]]")
+
+      assert msg =~ "ValueError"
+      assert msg =~ "expected 2"
+      assert msg =~ "got 3"
+    end
+
+    test "arity mismatch (too few) raises ValueError at runtime" do
+      {:error, %Pyex.Error{message: msg}} =
+        Pyex.run("[a + b for (a, b) in [(1,)]]")
+
+      assert msg =~ "ValueError"
+      assert msg =~ "expected 2"
+      assert msg =~ "got 1"
+    end
+
+    test "non-iterable element raises TypeError at runtime" do
+      {:error, %Pyex.Error{message: msg}} =
+        Pyex.run("[a + b for (a, b) in [1, 2]]")
+
+      assert msg =~ "TypeError"
+      assert msg =~ "cannot unpack"
+    end
+  end
+
+  # AST-shape symmetry: parsing the paren-target form must produce the
+  # same `:comp_for` target shape that the bare-comma form already
+  # produces, so the downstream interpreter sees one shape, not two.
+  describe "parenthesised tuple target: AST equivalence" do
+    test "list comp: (a, b) target produces same comp_for shape as a, b target" do
+      {:ok, paren_ast} = Pyex.compile("[a + b for (a, b) in xs]")
+      {:ok, bare_ast} = Pyex.compile("[a + b for a, b in xs]")
+
+      assert comp_for_target(paren_ast) == comp_for_target(bare_ast)
+      assert comp_for_target(paren_ast) == ["a", "b"]
+    end
+
+    test "dict comp: (k, v) target produces same shape as bare k, v" do
+      {:ok, paren_ast} = Pyex.compile("{k: v for (k, v) in xs}")
+      {:ok, bare_ast} = Pyex.compile("{k: v for k, v in xs}")
+
+      assert comp_for_target(paren_ast) == comp_for_target(bare_ast)
+      assert comp_for_target(paren_ast) == ["k", "v"]
+    end
+
+    test "set comp: (a, b) target produces same shape as bare a, b" do
+      {:ok, paren_ast} = Pyex.compile("{a for (a, b) in xs}")
+      {:ok, bare_ast} = Pyex.compile("{a for a, b in xs}")
+
+      assert comp_for_target(paren_ast) == comp_for_target(bare_ast)
+    end
+
+    test "gen expr: (a, b) target produces same shape as bare a, b" do
+      {:ok, paren_ast} = Pyex.compile("(a + b for (a, b) in xs)")
+      {:ok, bare_ast} = Pyex.compile("(a + b for a, b in xs)")
+
+      assert comp_for_target(paren_ast) == comp_for_target(bare_ast)
+    end
+
+    test "list comp: nested paren target preserves nesting" do
+      {:ok, ast} = Pyex.compile("[x for (a, (b, c)) in xs]")
+      assert comp_for_target(ast) == ["a", ["b", "c"]]
+    end
+  end
+
+  # Walk the AST to the first `comp_for` clause and return its target.
+  # `Pyex.compile/1` returns `{:module, _, [{:expr, _, [inner]}, ...]}`,
+  # so peel both wrappers before matching the comprehension itself.
+  defp comp_for_target({:module, _meta, stmts}) do
+    case stmts do
+      [{:expr, _, [inner]} | _] -> comp_for_target(inner)
+      [single] -> comp_for_target(single)
+      other -> flunk("expected module with comprehension stmt, got: #{inspect(other)}")
+    end
+  end
+
+  defp comp_for_target({tag, _meta, args})
+       when tag in [:list_comp, :set_comp, :gen_expr] do
+    [_expr, clauses] = args
+    first_comp_for_target(clauses)
+  end
+
+  defp comp_for_target({:dict_comp, _meta, [_k, _v, clauses]}) do
+    first_comp_for_target(clauses)
+  end
+
+  defp comp_for_target(other) do
+    flunk("expected comprehension AST, got: #{inspect(other)}")
+  end
+
+  defp first_comp_for_target([{:comp_for, target, _iterable} | _]), do: target
+  defp first_comp_for_target([_ | rest]), do: first_comp_for_target(rest)
+  defp first_comp_for_target([]), do: flunk("no :comp_for clause in AST")
 end

--- a/test/pyex/interpreter_test.exs
+++ b/test/pyex/interpreter_test.exs
@@ -1466,6 +1466,59 @@ defmodule Pyex.InterpreterTest do
 
       assert msg =~ "ValueError"
     end
+
+    # Parenthesised tuple targets share the same `collect_nested_for_pattern`
+    # path that comprehensions now use; these tests pin the surface area
+    # where both forms must agree.
+    test "for (a, b) in pairs binds parenthesised target" do
+      assert {:ok, [3, 7, 11], _ctx} =
+               Pyex.run("""
+               result = []
+               for (a, b) in [(1, 2), (3, 4), (5, 6)]:
+                   result.append(a + b)
+               result
+               """)
+    end
+
+    test "for (a,) single-element tuple target unpacks 1-tuples" do
+      assert {:ok, [1, 2, 3], _ctx} =
+               Pyex.run("""
+               result = []
+               for (a,) in [(1,), (2,), (3,)]:
+                   result.append(a)
+               result
+               """)
+    end
+
+    test "for (a, *rest) starred target collects tail into a list" do
+      assert {:ok, [[2, 3], [5]], _ctx} =
+               Pyex.run("""
+               result = []
+               for (a, *rest) in [(1, 2, 3), (4, 5)]:
+                   result.append(rest)
+               result
+               """)
+    end
+
+    test "for (*head, last) starred target collects head into a list" do
+      assert {:ok, [[1, 2], [4]], _ctx} =
+               Pyex.run("""
+               result = []
+               for (*head, last) in [(1, 2, 3), (4, 5)]:
+                   result.append(head)
+               result
+               """)
+    end
+
+    test "for (a, (b, c)) nested parenthesised target" do
+      assert {:ok, [6, 15], _ctx} =
+               Pyex.run("""
+               result = []
+               for (a, (b, c)) in [(1, (2, 3)), (4, (5, 6))]:
+                   result.append(a + b + c)
+               result
+               """)
+    end
   end
 
   describe "chained comparisons" do


### PR DESCRIPTION
## Summary

- Pyex's four comprehension parsers (list / set / dict / generator) rejected the standard Python `[(a, b) for (a, b) in pairs]` form with a misleading error. The runtime always supported list-shaped targets; only those four parsers were missing the lparen clause.
- Restructured `collect_nested_for_pattern/2` around a single `parse_for_pattern_item/1` helper, picking up starred items (`(a, *rest)`, `(*head, last)`) and trailing commas (`(a,)`) — both already supported at runtime, just unreachable through the parser.

## Why

Three distinct asymmetries surfaced while auditing:

1. The for *statement* parser (`parser/control_flow.ex`) accepts `for (a, b) in xs:` via `collect_nested_for_pattern`.
2. *Secondary* `for` clauses inside chained comprehensions accept paren targets via `parse_comp_for_clause`.
3. The generator-expression-as-function-argument path (`parse_gen_expr_body`) also accepts them.

But the four *primary* comprehension entry points didn't. CPython grammar treats them identically.

The runtime side was already complete: `bind_loop_var/3` + `unpack_for_item/2` handled list-shaped targets, nested patterns, starred unpack, and arity-mismatch errors. The fix is purely additive in the parser.

## Test plan

- [x] 17 comprehension tests covering list / set / dict / gen flavors, single-element `(a,)`, nested `(a, (b, c))`, starred `(a, *rest)`, chained primary+secondary clauses, trailing filters
- [x] 5 AST-equivalence tests proving paren and bare-comma forms produce identical `:comp_for` shapes downstream
- [x] 3 runtime-error tests pinning ValueError / TypeError messages matching CPython
- [x] 5 for-statement tests for `for (a, b) in xs:`, `for (a,) in xs:`, `for (a, *r) in xs:`, `for (*h, l) in xs:`, `for (a, (b, c)) in xs:` — same paren-target machinery, locks in the gain there too
- [x] Bare-comma regression coverage (`for a, b in xs:` and `[x for a, b in xs]`)
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` — 5409 tests, 0 failures
- [x] `mix dialyzer` — clean

## Files

```
 lib/pyex/parser/comprehensions.ex | 103 ++++++++++++++++++++++++++++++++------
 lib/pyex/parser/control_flow.ex   |  47 ++++++++++++-----
 test/pyex/comprehensions_test.exs | 186 ++++++++++++++++++++++++++++++++++++++
 test/pyex/interpreter_test.exs    |  53 +++++++++++
 4 files changed, 362 insertions(+), 27 deletions(-)
```

## Note on duplication

`collect_nested_for_pattern` lives in both `parser/comprehensions.ex` and `parser/control_flow.ex` — the for *statement* and for *comprehension* parsers each have their own copy. They're synced in this PR (and a comment in `control_flow.ex` flags the duplication for a future shared-helper extraction). I didn't dedupe in this PR to keep the diff focused on the bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)