### PR TITLE
feat(limits): enable safe-by-default resource ceilings

### DIFF
--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -72,7 +72,11 @@ defmodule Pyex do
   - `:limits` -- resource limits as a keyword list or `Pyex.Limits` struct.
     Supported keys: `:timeout`, `:max_steps`, `:max_memory_bytes`,
     `:max_output_bytes`. When `limits: [timeout: N]` is provided,
-    it supersedes a top-level `:timeout`.
+    it supersedes a top-level `:timeout`. Ceilings are **on by
+    default** (10M steps / 50 MB / 1 MB output); unspecified keys take
+    their safe defaults, so partial limits are additive. Pass
+    `limits: :none` to lift every ceiling for trusted code. See
+    `Pyex.Limits` for details.
   - `:network` -- network access policy for the `requests` module.
     A list of rule maps, each with `:allowed_url_prefix` or
     `:dangerously_allow_full_internet_access`, plus optional `:methods`

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -256,6 +256,7 @@ defmodule Pyex.Ctx do
   defp normalize_limits(opts) do
     case Keyword.get(opts, :limits) do
       nil -> %Pyex.Limits{}
+      :none -> Pyex.Limits.unbounded()
       %Pyex.Limits{} = l -> l
       kw when is_list(kw) -> Pyex.Limits.new(kw)
     end

--- a/lib/pyex/limits.ex
+++ b/lib/pyex/limits.ex
@@ -11,9 +11,32 @@ defmodule Pyex.Limits do
         max_output_bytes: 1_000_000
       ])
 
-  All fields default to `:infinity` (no limit). This struct is
-  configuration only — no mutable counters. The interpreter
-  tracks usage internally in `Pyex.Ctx`.
+  ## Defaults
+
+  Resource ceilings are **on by default** — a caller who runs
+  untrusted code with no `:limits` still gets a compute, memory,
+  and output budget:
+
+  | field              | default      | meaning                          |
+  | ------------------ | ------------ | -------------------------------- |
+  | `timeout`          | `:infinity`  | wall-clock budget (opt-in)       |
+  | `max_steps`        | `10_000_000` | interpreter step budget          |
+  | `max_memory_bytes` | `50_000_000` | cumulative allocation budget     |
+  | `max_output_bytes` | `1_000_000`  | total captured output            |
+
+  An unspecified field takes its safe default, so partial limits
+  are *additive* — `limits: [max_steps: 1_000]` still enforces the
+  default 50 MB / 1 MB memory and output ceilings. To lift a single
+  ceiling, set it to `:infinity` explicitly; to lift all of them,
+  pass `limits: :none` (see `unbounded/0`), which also restores the
+  no-budget fast path in `Pyex.Ctx.check_step/1`.
+
+  `max_memory_bytes` is a *cumulative* allocation budget, not a peak
+  live-heap measurement: an allocate-and-discard loop accrues against
+  it even when little memory is retained.
+
+  This struct is configuration only — no mutable counters. The
+  interpreter tracks usage internally in `Pyex.Ctx`.
   """
 
   @type t :: %__MODULE__{
@@ -23,14 +46,19 @@ defmodule Pyex.Limits do
           max_output_bytes: pos_integer() | :infinity
         }
 
+  @default_max_steps 10_000_000
+  @default_max_memory_bytes 50_000_000
+  @default_max_output_bytes 1_000_000
+
   defstruct timeout: :infinity,
-            max_steps: :infinity,
-            max_memory_bytes: :infinity,
-            max_output_bytes: :infinity
+            max_steps: @default_max_steps,
+            max_memory_bytes: @default_max_memory_bytes,
+            max_output_bytes: @default_max_output_bytes
 
   @doc """
   Creates a `Limits` struct from a keyword list.
 
+  Unspecified fields take their safe defaults (see the module doc).
   Raises `ArgumentError` on unknown keys.
   """
   @spec new(keyword()) :: t()
@@ -44,5 +72,23 @@ defmodule Pyex.Limits do
     end
 
     struct!(__MODULE__, opts)
+  end
+
+  @doc """
+  Returns a `Limits` struct with every ceiling lifted (`:infinity`).
+
+  This is the escape hatch for trusted code that needs unbounded
+  compute. With no timeout and all ceilings at `:infinity`, the
+  interpreter takes the no-budget fast path in
+  `Pyex.Ctx.check_step/1`.
+  """
+  @spec unbounded() :: t()
+  def unbounded do
+    %__MODULE__{
+      timeout: :infinity,
+      max_steps: :infinity,
+      max_memory_bytes: :infinity,
+      max_output_bytes: :infinity
+    }
   end
 end

--- a/test/pyex/ctx_test.exs
+++ b/test/pyex/ctx_test.exs
@@ -154,8 +154,8 @@ defmodule Pyex.CtxTest do
   # this test pins both branches' contract so future edits can't
   # silently regress.
   describe "check_step/1" do
-    test "default ctx (no limits, no timeout) hits the fast path and does not advance steps" do
-      ctx = Ctx.new()
+    test "unbounded ctx (limits: :none) hits the fast path and does not advance steps" do
+      ctx = Ctx.new(limits: :none)
       assert ctx.steps == 0
       assert {:ok, ctx2} = Ctx.check_step(ctx)
       # Fast path: identity-on-fields ctx (no `steps + 1`).
@@ -168,6 +168,16 @@ defmodule Pyex.CtxTest do
         end)
 
       assert ctx3.steps == 0
+    end
+
+    test "default ctx is bounded (safe by default) and takes the slow path" do
+      ctx = Ctx.new()
+      # Safe-by-default ceilings are finite, so the fast path does not fire.
+      assert ctx.limits.max_steps == 10_000_000
+      assert ctx.limits.max_memory_bytes == 50_000_000
+      assert ctx.limits.max_output_bytes == 1_000_000
+      assert {:ok, ctx2} = Ctx.check_step(ctx)
+      assert ctx2.steps == 1
     end
 
     test "timeout set forces the slow path and increments steps" do

--- a/test/pyex/limits_test.exs
+++ b/test/pyex/limits_test.exs
@@ -1,0 +1,82 @@
+defmodule Pyex.LimitsTest do
+  use ExUnit.Case, async: true
+
+  alias Pyex.Limits
+
+  describe "safe-by-default ceilings" do
+    test "a bare struct carries the safe finite defaults" do
+      assert %Limits{
+               timeout: :infinity,
+               max_steps: 10_000_000,
+               max_memory_bytes: 50_000_000,
+               max_output_bytes: 1_000_000
+             } = %Limits{}
+    end
+
+    test "new/0 matches the bare struct" do
+      assert Limits.new() == %Limits{}
+    end
+  end
+
+  describe "new/1 is additive" do
+    test "unspecified fields keep their safe defaults rather than going unbounded" do
+      limits = Limits.new(max_steps: 1_000)
+
+      assert limits.max_steps == 1_000
+      # The point of safe-by-default: setting one ceiling does not lift the others.
+      assert limits.max_memory_bytes == 50_000_000
+      assert limits.max_output_bytes == 1_000_000
+    end
+
+    test "a single ceiling can be lifted explicitly with :infinity" do
+      limits = Limits.new(max_steps: 1_000, max_memory_bytes: :infinity)
+
+      assert limits.max_steps == 1_000
+      assert limits.max_memory_bytes == :infinity
+      assert limits.max_output_bytes == 1_000_000
+    end
+
+    test "rejects unknown keys" do
+      assert_raise ArgumentError, ~r/unknown limit options \[:max_foo\]/, fn ->
+        Limits.new(max_foo: 1)
+      end
+    end
+  end
+
+  describe "unbounded/0 escape hatch" do
+    test "lifts every ceiling" do
+      assert %Limits{
+               timeout: :infinity,
+               max_steps: :infinity,
+               max_memory_bytes: :infinity,
+               max_output_bytes: :infinity
+             } = Limits.unbounded()
+    end
+  end
+
+  describe "end-to-end through Pyex.run/2" do
+    test "default run bounds output (no opts) — a print flood is stopped, not hung" do
+      # 1 MB default output ceiling: 200k lines of ~12 bytes each blows past it.
+      {:error, %Pyex.Error{kind: :limit, limit: :output}} =
+        Pyex.run("for i in range(200000):\n    print('x' * 10)")
+    end
+
+    test "limits: :none lifts the default ceilings" do
+      # The same flood completes once ceilings are explicitly lifted.
+      assert {:ok, _val, ctx} =
+               Pyex.run("for i in range(200000):\n    print('x' * 10)", limits: :none)
+
+      # No-budget fast path: steps do not advance.
+      assert ctx.steps == 0
+    end
+
+    test "partial limits remain additive through run/2" do
+      # Output ceiling left at the 1 MB default still trips even though the
+      # caller only set a (very high) step limit.
+      {:error, %Pyex.Error{kind: :limit, limit: :output}} =
+        Pyex.run("for i in range(200000):\n    print('x' * 10)",
+          limits: [max_steps: 1_000_000_000]
+        )
+    end
+  end
+end


### PR DESCRIPTION
## What

Resource limits previously defaulted to `:infinity`. A host running untrusted/LLM-emitted code with `Pyex.run(source)` and no opts got **no compute, memory, or output ceiling at all** — capabilities were deny-by-default while compute was allow-by-default.

This flips the `Pyex.Limits` struct defaults to conservative finite ceilings:

| field | default | meaning |
|---|---|---|
| `max_steps` | `10_000_000` | interpreter step budget (~6–7s of compute) |
| `max_memory_bytes` | `50_000_000` | cumulative allocation budget |
| `max_output_bytes` | `1_000_000` | total captured output |
| `timeout` | `:infinity` | wall-clock stays opt-in — `max_steps` already gives a *deterministic* ceiling, and a tight wall-clock default risks CI flakiness on slow runners |

## Why these values

The defaults clear the **entire suite without a single test bump**. I measured the high-water marks of every workload that runs without explicit limits:

| workload | steps | mem (cumulative) | output |
|---|---|---|---|
| `relu_net_learns_sin` (fixture) | **5.2M** | 26 MB | 108 B |
| `manhattanhenge` (fixture) | 1.5M | 2.3 MB | 2.2 KB |
| everything else | < 320K | < 800 KB | < 5 KB |
| — adversarial "tight" reference — | 5K | 1 MB | 100 KB |

10M steps is ~2× the heaviest legit workload, so nothing legitimate trips, while every adversarial bomb / infinite loop is still stopped cold.

## Semantics

- **Partial limits are additive.** `limits: [max_steps: N]` still enforces the default memory/output ceilings — omission means *protected*, not unbounded. Lift a single ceiling by setting it to `:infinity` explicitly.
- **`limits: :none`** (via the new `Pyex.Limits.unbounded/0`) lifts every ceiling for trusted code, and restores the no-budget fast path in `Ctx.check_step/1` — so opting out costs zero per-step overhead.
- `max_memory_bytes` is a **cumulative allocation budget, not peak live heap** (`track_memory/2` only ever adds). Documented in the moduledoc.

## Tests

- New `test/pyex/limits_test.exs` (9 tests): safe defaults, additive partial limits, the `:infinity` per-field opt-out, the `:none` escape hatch, and end-to-end through `Pyex.run/2`.
- `ctx_test.exs` fast-path test re-pinned: `limits: :none` hits the fast path; the **default** ctx is now bounded and takes the slow path.

## Verification

All four CI test invocations pass locally, plus the full checklist:

- `mix format --check-formatted` ✓
- `mix compile --warnings-as-errors` ✓ (clean `--force` build)
- `mix test` ✓ — **5433 tests, 0 failures**
- `mix dialyzer` ✓ — no new findings
- `--only postgres` ✓ 9 · `--only library_conformance` ✓ 9 · `--include external_http` ✓ 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)