### PR TITLE
fix(ctx): match network allowlist component-wise, not by string prefix

### DIFF
--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -440,11 +440,14 @@ defmodule Pyex.Ctx do
   # matches the host on any port.
   @spec url_within_prefix?(URI.t(), URI.t(), String.t()) :: boolean()
   defp url_within_prefix?(url, prefix, raw_prefix) do
+    url_path = request_path(url.path)
+
     host_present?(url.host) and
       downcase(url.scheme) == downcase(prefix.scheme) and
       downcase(url.host) == downcase(prefix.host) and
       port_match?(url.port, prefix.port, raw_prefix) and
-      path_within_prefix?(request_path(url.path), request_path(prefix.path))
+      not dot_dot_segment?(url_path) and
+      path_within_prefix?(url_path, request_path(prefix.path))
   end
 
   @spec host_present?(term()) :: boolean()
@@ -485,6 +488,20 @@ defmodule Pyex.Ctx do
       String.ends_with?(prefix_path, "/") -> String.starts_with?(url_path, prefix_path)
       true -> String.starts_with?(url_path, prefix_path <> "/")
     end
+  end
+
+  # A ".." path segment lets a request climb above the prefix subtree once a
+  # client or server applies RFC-3986 dot-segment removal (e.g. "/v1/../../admin"
+  # resolves to "/admin"), so a path containing one is treated as outside the
+  # prefix. URI.parse does not collapse dot-segments, and the check is done on
+  # the percent-decoded path so "%2e%2e" and "%2f"-smuggled separators are
+  # caught too; matching whole segments avoids false positives like "version..1".
+  @spec dot_dot_segment?(String.t()) :: boolean()
+  defp dot_dot_segment?(path) do
+    path
+    |> URI.decode()
+    |> String.split("/")
+    |> Enum.any?(&(&1 == ".."))
   end
 
   @spec rule_specificity(network_rule()) :: non_neg_integer()

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -45,8 +45,6 @@ defmodule Pyex.Ctx do
 
   @type network_config :: [network_rule()] | nil
 
-  @url_prefix_pattern ~r/\A([a-z][a-z0-9+\-.]*:\/\/)([^\/?#]*)(.*)\z/i
-
   @type capability :: :boto3 | :sql | atom()
 
   @type generator_mode :: :accumulate | :defer | :defer_inner | :lazy_iter | nil
@@ -139,8 +137,13 @@ defmodule Pyex.Ctx do
   - `:network` -- network access policy for the `requests` module.
 
     A list of rule maps. Each rule may contain:
-    - `:allowed_url_prefix` -- URL prefix that is permitted
-      (use trailing slash to prevent subdomain bypass)
+    - `:allowed_url_prefix` -- absolute URL prefix that is permitted.
+      Matched component-wise: the request's scheme, host, and port must
+      match exactly and its path must fall at or below the prefix path
+      on a segment boundary, so `"https://api.example.com/"` permits
+      `"https://api.example.com/v1"` but never `"...example.com.evil.com/"`
+      or a different port. A bare trailing `":"` (e.g. `"http://localhost:"`)
+      matches the host on any port.
     - `:dangerously_allow_full_internet_access` -- `true` to match any URL
     - `:methods` -- list of HTTP methods allowed (default `["GET", "HEAD"]`)
     - `:headers` -- map of headers to inject into matching requests.
@@ -344,7 +347,17 @@ defmodule Pyex.Ctx do
   end
 
   @spec normalize_allowed_url_prefix(term()) :: String.t()
-  defp normalize_allowed_url_prefix(prefix) when is_binary(prefix) and prefix != "", do: prefix
+  defp normalize_allowed_url_prefix(prefix) when is_binary(prefix) and prefix != "" do
+    uri = URI.parse(prefix)
+
+    if is_nil(uri.scheme) or not host_present?(uri.host) do
+      raise ArgumentError,
+            "network rule :allowed_url_prefix must be an absolute URL with a scheme and host " <>
+              "(e.g. \"https://api.example.com/\"), got: #{inspect(prefix)}"
+    end
+
+    prefix
+  end
 
   defp normalize_allowed_url_prefix(_) do
     raise ArgumentError, "network rule :allowed_url_prefix must be a non-empty string"
@@ -412,21 +425,60 @@ defmodule Pyex.Ctx do
   defp rule_matches_url?(%{dangerously_allow_full_internet_access: true}, _url), do: true
 
   defp rule_matches_url?(%{allowed_url_prefix: prefix}, url),
-    do: String.starts_with?(normalize_url_prefix(url), normalize_url_prefix(prefix))
+    do: url_within_prefix?(URI.parse(url), URI.parse(prefix))
 
   defp rule_matches_url?(_, _url), do: false
+
+  # Matches component-wise rather than as a raw string prefix. Scheme, host,
+  # and port must be equal, and the URL path must lie at or below the prefix
+  # path on a segment boundary. This closes two `String.starts_with?` bypasses:
+  # the subdomain bypass ("https://api.example.com" vs
+  # "https://api.example.com.attacker.com/") and the path-segment bypass
+  # ("https://host/v1" vs "https://host/v1abc/anything"). Comparing hosts
+  # (never userinfo) also rejects the "https://api.example.com@evil.com/" trick.
+  # A prefix whose authority ends in a bare ":" (e.g. "http://localhost:")
+  # matches the host on any port.
+  @spec url_within_prefix?(URI.t(), URI.t()) :: boolean()
+  defp url_within_prefix?(url, prefix) do
+    host_present?(url.host) and
+      downcase(url.scheme) == downcase(prefix.scheme) and
+      downcase(url.host) == downcase(prefix.host) and
+      port_match?(url, prefix) and
+      path_within_prefix?(request_path(url.path), request_path(prefix.path))
+  end
+
+  @spec host_present?(term()) :: boolean()
+  defp host_present?(host), do: is_binary(host) and host != ""
+
+  @spec downcase(String.t() | nil) :: String.t() | nil
+  defp downcase(nil), do: nil
+  defp downcase(string), do: String.downcase(string)
+
+  # A bare trailing ":" in the prefix authority (no port digits) is a wildcard
+  # that matches any port; otherwise the effective ports (defaults filled in by
+  # URI.parse) must be equal.
+  @spec port_match?(URI.t(), URI.t()) :: boolean()
+  defp port_match?(url, %URI{authority: authority} = prefix) do
+    (is_binary(authority) and String.ends_with?(authority, ":")) or url.port == prefix.port
+  end
+
+  @spec request_path(String.t() | nil) :: String.t()
+  defp request_path(nil), do: "/"
+  defp request_path(""), do: "/"
+  defp request_path(path), do: path
+
+  @spec path_within_prefix?(String.t(), String.t()) :: boolean()
+  defp path_within_prefix?(url_path, prefix_path) do
+    cond do
+      url_path == prefix_path -> true
+      String.ends_with?(prefix_path, "/") -> String.starts_with?(url_path, prefix_path)
+      true -> String.starts_with?(url_path, prefix_path <> "/")
+    end
+  end
 
   @spec rule_specificity(network_rule()) :: non_neg_integer()
   defp rule_specificity(%{allowed_url_prefix: prefix}), do: byte_size(prefix)
   defp rule_specificity(%{dangerously_allow_full_internet_access: true}), do: 0
-
-  @spec normalize_url_prefix(String.t()) :: String.t()
-  defp normalize_url_prefix(url) do
-    case Regex.run(@url_prefix_pattern, url, capture: :all_but_first) do
-      [scheme, authority, rest] -> String.downcase(scheme) <> String.downcase(authority) <> rest
-      _ -> url
-    end
-  end
 
   @spec build_denial_message([network_rule()], String.t(), String.t()) :: String.t()
   defp build_denial_message(rules, method, url) do

--- a/lib/pyex/ctx.ex
+++ b/lib/pyex/ctx.ex
@@ -425,7 +425,7 @@ defmodule Pyex.Ctx do
   defp rule_matches_url?(%{dangerously_allow_full_internet_access: true}, _url), do: true
 
   defp rule_matches_url?(%{allowed_url_prefix: prefix}, url),
-    do: url_within_prefix?(URI.parse(url), URI.parse(prefix))
+    do: url_within_prefix?(URI.parse(url), URI.parse(prefix), prefix)
 
   defp rule_matches_url?(_, _url), do: false
 
@@ -438,12 +438,12 @@ defmodule Pyex.Ctx do
   # (never userinfo) also rejects the "https://api.example.com@evil.com/" trick.
   # A prefix whose authority ends in a bare ":" (e.g. "http://localhost:")
   # matches the host on any port.
-  @spec url_within_prefix?(URI.t(), URI.t()) :: boolean()
-  defp url_within_prefix?(url, prefix) do
+  @spec url_within_prefix?(URI.t(), URI.t(), String.t()) :: boolean()
+  defp url_within_prefix?(url, prefix, raw_prefix) do
     host_present?(url.host) and
       downcase(url.scheme) == downcase(prefix.scheme) and
       downcase(url.host) == downcase(prefix.host) and
-      port_match?(url, prefix) and
+      port_match?(url.port, prefix.port, raw_prefix) and
       path_within_prefix?(request_path(url.path), request_path(prefix.path))
   end
 
@@ -456,10 +456,21 @@ defmodule Pyex.Ctx do
 
   # A bare trailing ":" in the prefix authority (no port digits) is a wildcard
   # that matches any port; otherwise the effective ports (defaults filled in by
-  # URI.parse) must be equal.
-  @spec port_match?(URI.t(), URI.t()) :: boolean()
-  defp port_match?(url, %URI{authority: authority} = prefix) do
-    (is_binary(authority) and String.ends_with?(authority, ":")) or url.port == prefix.port
+  # URI.parse) must be equal. The wildcard is read off the raw prefix string so
+  # we never touch URI's opaque `authority` field.
+  @spec port_match?(non_neg_integer() | nil, non_neg_integer() | nil, String.t()) :: boolean()
+  defp port_match?(url_port, prefix_port, raw_prefix),
+    do: any_port_prefix?(raw_prefix) or url_port == prefix_port
+
+  @spec any_port_prefix?(String.t()) :: boolean()
+  defp any_port_prefix?(raw_prefix) do
+    case String.split(raw_prefix, "://", parts: 2) do
+      [_scheme, rest] ->
+        rest |> String.split(["/", "?", "#"], parts: 2) |> hd() |> String.ends_with?(":")
+
+      _ ->
+        false
+    end
   end
 
   @spec request_path(String.t() | nil) :: String.t()

--- a/test/pyex/ctx_test.exs
+++ b/test/pyex/ctx_test.exs
@@ -32,6 +32,12 @@ defmodule Pyex.CtxTest do
         Ctx.new(network: [%{allowed_url_prefix: ""}])
       end
     end
+
+    test "rejects allowed_url_prefix without a scheme and host" do
+      assert_raise ArgumentError, ~r/must be an absolute URL with a scheme and host/, fn ->
+        Ctx.new(network: [%{allowed_url_prefix: "api.example.com/v1/"}])
+      end
+    end
   end
 
   describe "check_network_access/3" do
@@ -40,6 +46,65 @@ defmodule Pyex.CtxTest do
 
       assert {:ok, []} =
                Ctx.check_network_access(ctx, "GET", "HTTPS://API.EXAMPLE.COM/v1/chat")
+    end
+
+    test "allows paths at or below the prefix path" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.openai.com/v1/"}])
+
+      assert {:ok, []} =
+               Ctx.check_network_access(ctx, "GET", "https://api.openai.com/v1/chat/completions")
+    end
+
+    test "denies a host that only shares the prefix as a leading label" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com/"}])
+
+      assert {:denied, _} =
+               Ctx.check_network_access(ctx, "GET", "https://api.example.com.attacker.com/")
+    end
+
+    test "denies the subdomain bypass even without a trailing slash on the prefix" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com"}])
+
+      assert {:denied, _} =
+               Ctx.check_network_access(ctx, "GET", "https://api.example.com.attacker.com/")
+    end
+
+    test "denies a path that shares the prefix but crosses no segment boundary" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.openai.com/v1"}])
+
+      assert {:denied, _} =
+               Ctx.check_network_access(ctx, "GET", "https://api.openai.com/v1abc/anything")
+
+      assert {:ok, []} = Ctx.check_network_access(ctx, "GET", "https://api.openai.com/v1")
+      assert {:ok, []} = Ctx.check_network_access(ctx, "GET", "https://api.openai.com/v1/chat")
+    end
+
+    test "denies a userinfo host that spoofs the allowed host" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com/"}])
+
+      assert {:denied, _} =
+               Ctx.check_network_access(ctx, "GET", "https://api.example.com@evil.com/x")
+    end
+
+    test "denies a non-matching port on the allowed host" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com/"}])
+
+      assert {:denied, _} =
+               Ctx.check_network_access(ctx, "GET", "https://api.example.com:8443/")
+    end
+
+    test "a bare trailing colon in the prefix matches the host on any port" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "http://localhost:"}])
+
+      assert {:ok, []} = Ctx.check_network_access(ctx, "GET", "http://localhost:51234/bucket/key")
+      assert {:ok, []} = Ctx.check_network_access(ctx, "GET", "http://localhost:8080/")
+    end
+
+    test "ignores the query string when matching the path" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://postman-echo.com/get"}])
+
+      assert {:ok, []} =
+               Ctx.check_network_access(ctx, "GET", "https://postman-echo.com/get?source=pyex")
     end
   end
 

--- a/test/pyex/ctx_test.exs
+++ b/test/pyex/ctx_test.exs
@@ -106,6 +106,30 @@ defmodule Pyex.CtxTest do
       assert {:ok, []} =
                Ctx.check_network_access(ctx, "GET", "https://postman-echo.com/get?source=pyex")
     end
+
+    test "denies a path that climbs above the prefix with .. segments" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com/v1/"}])
+
+      assert {:denied, _} =
+               Ctx.check_network_access(ctx, "GET", "https://api.example.com/v1/../../admin")
+    end
+
+    test "denies percent-encoded .. traversal" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com/v1/"}])
+
+      assert {:denied, _} =
+               Ctx.check_network_access(ctx, "GET", "https://api.example.com/v1/%2e%2e/admin")
+
+      assert {:denied, _} =
+               Ctx.check_network_access(ctx, "GET", "https://api.example.com/v1/..%2f..%2fadmin")
+    end
+
+    test "allows a path segment that merely contains .. as a substring" do
+      ctx = Ctx.new(network: [%{allowed_url_prefix: "https://api.example.com/v1/"}])
+
+      assert {:ok, []} =
+               Ctx.check_network_access(ctx, "GET", "https://api.example.com/v1/version..1")
+    end
   end
 
   describe "record/3" do


### PR DESCRIPTION
## Problem

`Pyex.Ctx.rule_matches_url?/2` matched a request URL against `allowed_url_prefix` with `String.starts_with?`, after only case-folding the scheme and host (`normalize_url_prefix/1`). Because the comparison was a raw string prefix, an allowlist entry leaked past its intended boundary in several ways:

| Allowlist entry | Unintended match |
|---|---|
| `https://api.example.com` | `https://api.example.com.attacker.com/` (no host boundary) |
| `https://api.openai.com/v1` | `https://api.openai.com/v1abc/anything` (no path-segment boundary) |
| `https://api.example.com/` | `https://api.example.com@evil.com/x` (userinfo spoof) |
| `https://api.example.com` | `https://api.example.com:8443/` (any port) |

The trailing-slash advice in the docs only papered over the first case, and `normalize_allowed_url_prefix/1` accepted any non-empty string, so a misconfigured prefix failed open against the wrong axis.

## Fix

Parse both the request URL and the prefix with `URI.parse/1` and match **component-wise**:

- **scheme** and **host** must be equal (host compared case-insensitively; `userinfo` is never part of the comparison, so the `@evil.com` trick resolves to `host: evil.com` and is rejected);
- **port** must be equal, using `URI.parse`'s scheme defaults — except a **bare trailing `":"`** in the prefix authority (e.g. `http://localhost:`) is kept as an explicit any-port wildcard, preserving the existing local-server test idiom;
- **path** must equal the prefix path or extend it on a **segment boundary** (`/v1/` or `/v1` allows `/v1/chat`, but `/v1` no longer allows `/v1abc`). Query and fragment are ignored (stripped by `URI.parse`).

`allowed_url_prefix` is now validated to be an absolute URL (scheme + host present) at construction time, so misconfiguration raises instead of silently never matching.

## Scope / out of scope

This addresses the **string-prefix matching** footgun from the review. It does **not** add DNS/IP-rebinding defenses (rejecting literal-IP / `.local` / `.internal` hosts, resolve-and-pin) — that's a separate, larger change and is called out here so it isn't assumed fixed.

## Tests

Added boundary cases to `test/pyex/ctx_test.exs` covering each row above (subdomain bypass with and without trailing slash, path-segment bypass, userinfo spoof, port mismatch), plus the preserved behaviors: paths below the prefix, the `http://localhost:` any-port wildcard, and query-string-insensitive path matching. The existing case-insensitive scheme/host test still passes.

## Verification

- `mix format --check-formatted` — clean
- `mix compile --warnings-as-errors` — clean
- `mix test` — 5442 tests, 0 failures (2 skipped, 33 excluded)
- `mix dialyzer` — passed (0 unskipped findings)

**Pre-existing, not introduced by this PR:** Dialyzer reports `Unnecessary Skips: 3` in `.dialyzer_ignore.exs` and a compiler type note for `lib/pyex/lambda.ex:264` (`Pyex.Lambda.interpret/2`). Both are present on `main` and untouched here; per CLAUDE.md the ignore entries are intentionally kept for the Elixir 1.19 CI version and not pruned from a 1.20 local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)