### PR TITLE
fix(requests): apply a host default receive_timeout when caller omits timeout=

### DIFF
--- a/lib/pyex/stdlib/requests.ex
+++ b/lib/pyex/stdlib/requests.ex
@@ -15,9 +15,23 @@ defmodule Pyex.Stdlib.Requests do
   All HTTP calls emit `:telemetry` events (`[:pyex, :request, :start]`
   and `[:pyex, :request, :stop]`). I/O time is excluded from the
   compute budget via `{:io_call, fn}` signals.
+
+  ## Default request timeout
+
+  When the Python caller does not pass `timeout=`, a host-side default
+  of #{30_000} ms is applied as Req's `receive_timeout`. This matters
+  because `Pyex.Limits.timeout` only bounds compute time — I/O is
+  excluded from the deadline by design — so without a default ceiling
+  here a sandboxed program calling a slow or hung endpoint would block
+  the calling process indefinitely. Pass `timeout=` from Python to
+  override.
   """
 
   @behaviour Pyex.Stdlib.Module
+
+  # Default Req receive_timeout (ms) when the Python caller omits
+  # `timeout=`.  See "Default request timeout" in the moduledoc.
+  @default_receive_timeout_ms 30_000
 
   alias Pyex.PyDict
 
@@ -308,16 +322,23 @@ defmodule Pyex.Stdlib.Requests do
     end
   end
 
+  @doc false
+  # Public for testing only.  Returns the Req option list for the
+  # `timeout=` kwarg, applying the host default when the caller omits it.
   @spec timeout_opts(%{optional(String.t()) => Pyex.Interpreter.pyvalue()}) :: keyword()
-  defp timeout_opts(kwargs) do
+  def timeout_opts(kwargs) do
     case Map.get(kwargs, "timeout") do
       seconds when is_number(seconds) and seconds > 0 ->
         [receive_timeout: round(seconds * 1000)]
 
       _ ->
-        []
+        [receive_timeout: @default_receive_timeout_ms]
     end
   end
+
+  @doc false
+  @spec default_receive_timeout_ms() :: pos_integer()
+  def default_receive_timeout_ms, do: @default_receive_timeout_ms
 
   @spec form_encode(Pyex.Interpreter.pyvalue()) :: String.t()
   defp form_encode({:py_dict, _, _} = dict) do

--- a/test/pyex/stdlib/requests_test.exs
+++ b/test/pyex/stdlib/requests_test.exs
@@ -924,4 +924,32 @@ defmodule Pyex.Stdlib.RequestsTest do
       end
     end
   end
+
+  describe "default request timeout" do
+    test "timeout_opts applies host default when caller omits timeout=" do
+      assert Pyex.Stdlib.Requests.timeout_opts(%{}) ==
+               [receive_timeout: Pyex.Stdlib.Requests.default_receive_timeout_ms()]
+    end
+
+    test "timeout_opts honors caller-supplied timeout= in seconds" do
+      assert Pyex.Stdlib.Requests.timeout_opts(%{"timeout" => 0.25}) ==
+               [receive_timeout: 250]
+    end
+
+    test "timeout_opts falls back to default on zero / negative / non-numeric" do
+      default = [receive_timeout: Pyex.Stdlib.Requests.default_receive_timeout_ms()]
+
+      assert Pyex.Stdlib.Requests.timeout_opts(%{"timeout" => 0}) == default
+      assert Pyex.Stdlib.Requests.timeout_opts(%{"timeout" => -1}) == default
+      assert Pyex.Stdlib.Requests.timeout_opts(%{"timeout" => "5s"}) == default
+      assert Pyex.Stdlib.Requests.timeout_opts(%{"timeout" => nil}) == default
+    end
+
+    test "default is bounded and reasonable" do
+      ms = Pyex.Stdlib.Requests.default_receive_timeout_ms()
+      assert is_integer(ms)
+      assert ms > 0
+      assert ms <= 60_000
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Pyex.Limits.timeout` only bounds compute time — I/O is explicitly excluded from the deadline (`Pyex.Ctx.check_deadline/1`, see `pause_compute`/`resume_compute`). Combined with `Limits.timeout` defaulting to `:infinity`, a sandboxed program calling a slow or hung endpoint without passing `timeout=` would block the calling process indefinitely with nothing draining any budget.

Today, `requests.timeout_opts/1` returns `[]` when `timeout=` is omitted, leaving Req to apply its own default. This PR applies a 30s host-side default as `receive_timeout` instead. Caller-supplied `timeout=` still overrides.

## Changes

- `lib/pyex/stdlib/requests.ex`:
  - Add `@default_receive_timeout_ms 30_000`.
  - `timeout_opts/1` now returns the default when the caller omits `timeout=` (and on zero / negative / non-numeric values).
  - Promote `timeout_opts/1` to `@doc false` public; add `default_receive_timeout_ms/0` so the contract is unit-testable without a network server.
  - Document the rationale in the moduledoc.
- `test/pyex/stdlib/requests_test.exs`: four unit tests covering default application, caller override, fallback on bad input, and that the default is bounded.

## Verification

- `mix test` — 291 properties, 5449 tests, 0 failures, 2 skipped
- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix dialyzer` — passed, 0 errors