### PR TITLE
fix(pyex): snapshot and restore caller's Decimal context across run/2

### DIFF
--- a/lib/pyex.ex
+++ b/lib/pyex.ex
@@ -153,45 +153,53 @@ defmodule Pyex do
 
     ctx = %Ctx{ctx | compute: 0.0, compute_started_at: System.monotonic_time()}
 
-    # Match CPython's default decimal context (precision 28, banker's rounding).
-    # The Elixir Decimal library defaults to :half_up; CPython uses :half_even.
+    # The Elixir Decimal library reads its context (precision, rounding mode)
+    # from the *process dictionary* — mutating it without restoring would leak
+    # Pyex's CPython-matching context into the caller's process and contradict
+    # AGENTS.md's "no process dict / no global state" rule.  Snapshot before
+    # the run, restore unconditionally after.
+    saved_decimal_ctx = Decimal.Context.get()
     Decimal.Context.set(%Decimal.Context{precision: 28, rounding: :half_even})
 
-    env = Builtins.runtime_env(ctx)
+    try do
+      env = Builtins.runtime_env(ctx)
 
-    result = Interpreter.run_with_ctx_result(ast, env, ctx)
+      result = Interpreter.run_with_ctx_result(ast, env, ctx)
 
-    case result do
-      {:ok, value, _env, final_ctx} ->
-        final_ctx = close_open_handles(final_ctx)
+      case result do
+        {:ok, value, _env, final_ctx} ->
+          final_ctx = close_open_handles(final_ctx)
 
-        duration_ms =
-          System.convert_time_unit(System.monotonic_time() - start_mono, :native, :microsecond) /
-            1000.0
+          duration_ms =
+            System.convert_time_unit(System.monotonic_time() - start_mono, :native, :microsecond) /
+              1000.0
 
-        :telemetry.execute([:pyex, :run, :stop], %{duration_ms: duration_ms}, %{
-          compute: Ctx.compute_time(final_ctx)
-        })
+          :telemetry.execute([:pyex, :run, :stop], %{duration_ms: duration_ms}, %{
+            compute: Ctx.compute_time(final_ctx)
+          })
 
-        derefed = Ctx.deep_deref(final_ctx, value)
+          derefed = Ctx.deep_deref(final_ctx, value)
 
-        {:ok, Interpreter.Helpers.to_python_view(derefed),
-         %{final_ctx | duration_ms: duration_ms}}
+          {:ok, Interpreter.Helpers.to_python_view(derefed),
+           %{final_ctx | duration_ms: duration_ms}}
 
-      {:error, msg, final_ctx} ->
-        close_open_handles(final_ctx)
+        {:error, msg, final_ctx} ->
+          close_open_handles(final_ctx)
 
-        duration_ms =
-          System.convert_time_unit(System.monotonic_time() - start_mono, :native, :microsecond) /
-            1000.0
+          duration_ms =
+            System.convert_time_unit(System.monotonic_time() - start_mono, :native, :microsecond) /
+              1000.0
 
-        error = Error.from_message(msg)
+          error = Error.from_message(msg)
 
-        :telemetry.execute([:pyex, :run, :exception], %{duration_ms: duration_ms}, %{
-          error: error
-        })
+          :telemetry.execute([:pyex, :run, :exception], %{duration_ms: duration_ms}, %{
+            error: error
+          })
 
-        {:error, error}
+          {:error, error}
+      end
+    after
+      Decimal.Context.set(saved_decimal_ctx)
     end
   end
 

--- a/test/pyex_test.exs
+++ b/test/pyex_test.exs
@@ -1351,4 +1351,61 @@ defmodule PyexTest do
       assert result =~ ~s(<span class="a">:ok</span>)
     end
   end
+
+  describe "Decimal context isolation" do
+    test "Pyex.run restores the caller's Decimal context on success" do
+      original = %Decimal.Context{precision: 5, rounding: :half_up}
+      Decimal.Context.set(original)
+
+      try do
+        {:ok, _val, _ctx} = Pyex.run("1 + 1")
+        assert Decimal.Context.get() == original
+      after
+        Decimal.Context.set(%Decimal.Context{})
+      end
+    end
+
+    test "Pyex.run restores the caller's Decimal context on Python error" do
+      original = %Decimal.Context{precision: 7, rounding: :ceiling}
+      Decimal.Context.set(original)
+
+      try do
+        {:error, _err} = Pyex.run("raise ValueError('boom')")
+        assert Decimal.Context.get() == original
+      after
+        Decimal.Context.set(%Decimal.Context{})
+      end
+    end
+
+    test "Pyex.run restores the caller's Decimal context on syntax error" do
+      original = %Decimal.Context{precision: 11, rounding: :floor}
+      Decimal.Context.set(original)
+
+      try do
+        {:error, _err} = Pyex.run("this is not python")
+        assert Decimal.Context.get() == original
+      after
+        Decimal.Context.set(%Decimal.Context{})
+      end
+    end
+
+    test "Pyex.run uses CPython-matching context (precision 28, half_even) inside the run" do
+      Decimal.Context.set(%Decimal.Context{precision: 3, rounding: :half_up})
+
+      try do
+        # 1/3 with precision 28 + half_even has many more digits than the
+        # 3-digit context the caller set.  Use the decimal stdlib to read
+        # the active context from inside the interpreter.
+        {:ok, prec, _ctx} =
+          Pyex.run("""
+          from decimal import getcontext
+          getcontext().prec
+          """)
+
+        assert prec == 28
+      after
+        Decimal.Context.set(%Decimal.Context{})
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Pyex.run/2` calls `Decimal.Context.set/1` (`lib/pyex.ex:158`) to match CPython's default decimal context (precision 28, banker's rounding) but never restores the caller's prior context. The Elixir Decimal library reads its context from the **process dictionary**, so this leaks Pyex's settings into the caller's process — surprising any caller that holds its own Decimal context, and a direct violation of AGENTS.md's 'no process dict / no global state' rule (`Pyex.run` is otherwise the only place that mutates process-dict state).

Fix: snapshot before `set/1`, restore unconditionally in `after`. The caller's context is preserved across success, Python exceptions, and syntax errors.

## Changes

- `lib/pyex.ex`:
  - Capture `saved_decimal_ctx = Decimal.Context.get()` before `set/1`.
  - Wrap the run body in `try/after` that always restores `saved_decimal_ctx`.
  - Update the rationale comment to explain *why* this matters (process-dict global state).
- `test/pyex_test.exs`: four tests
  - Caller context restored after a successful run.
  - Caller context restored after a Python-level error.
  - Caller context restored after a syntax error.
  - Inside the run, `getcontext().prec == 28` (CPython parity preserved).

## Verification

- `mix test` — 291 properties, 5449 tests, 0 failures, 2 skipped
- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix dialyzer` — passed, 0 errors