### PR TITLE
fix(banned_call_tracer): treat missing abstract code as a violation

### DIFF
--- a/lib/pyex/banned_call_tracer.ex
+++ b/lib/pyex/banned_call_tracer.ex
@@ -139,7 +139,7 @@ defmodule Pyex.BannedCallTracer do
   ]
 
   @type violation :: %{
-          call: {module(), atom(), arity()},
+          call: {module(), atom(), arity()} | :no_debug_info,
           beam: Path.t(),
           line: non_neg_integer()
         }
@@ -169,8 +169,16 @@ defmodule Pyex.BannedCallTracer do
       {:ok, {_mod, [{:abstract_code, {:raw_abstract_v1, abstract_code}}]}} ->
         walk(abstract_code, beam_path, [])
 
-      {:ok, {_mod, [{:abstract_code, :no_debug_info}]}} ->
-        []
+      {:ok, {_mod, [{:abstract_code, missing}]}}
+      when missing in [:no_debug_info, :no_abstract_code] ->
+        # A BEAM without abstract code cannot be inspected — the tracer
+        # would see *nothing* and silently report the module clean,
+        # voiding the whole security gate.  `:no_debug_info` means the
+        # module was compiled without `+debug_info`; `:no_abstract_code`
+        # means the chunk was later stripped (e.g. `strip_beams: true`
+        # in a release).  Either way, surface as a violation so the check
+        # fails loudly instead of quietly passing.
+        [%{call: :no_debug_info, beam: beam_path, line: 0}]
 
       {:error, :beam_lib, _reason} ->
         []

--- a/test/pyex/banned_call_tracer_test.exs
+++ b/test/pyex/banned_call_tracer_test.exs
@@ -43,9 +43,14 @@ defmodule Pyex.BannedCallTracerTest do
     if violations != [] do
       lines =
         violations
-        |> Enum.map(fn %{call: {mod, fun, arity}, beam: beam, line: line} ->
-          short = beam |> Path.basename() |> Path.rootname()
-          "  #{short}:#{line}  #{inspect(mod)}.#{fun}/#{arity}"
+        |> Enum.map(fn
+          %{call: :no_debug_info, beam: beam} ->
+            short = beam |> Path.basename() |> Path.rootname()
+            "  #{short}  (no debug info — tracer cannot inspect this beam)"
+
+          %{call: {mod, fun, arity}, beam: beam, line: line} ->
+            short = beam |> Path.basename() |> Path.rootname()
+            "  #{short}:#{line}  #{inspect(mod)}.#{fun}/#{arity}"
         end)
         |> Enum.join("\n")
 
@@ -61,6 +66,40 @@ defmodule Pyex.BannedCallTracerTest do
       Fix each violation, or — if the call is genuinely necessary — add it to
       the @allowed list in Pyex.BannedCallTracer with a clear justification.
       """)
+    end
+  end
+
+  test "tracer reports a beam without abstract code as a violation, not a silent pass" do
+    # If a beam ever lacks abstract code (e.g. a stripped release with
+    # `strip_beams: true`), the tracer must fail loudly — otherwise the
+    # whole security gate is vacuous: an uninspectable module is reported
+    # clean.  Synthesize a stripped beam and verify the tracer flags it.
+    tmp = Path.join(System.tmp_dir!(), "pyex_no_debug_info_test")
+    File.mkdir_p!(tmp)
+
+    src_beam = Path.join(@beam_dir, "Elixir.Pyex.Stdlib.Time.beam")
+    stripped_beam = Path.join(tmp, "Elixir.Pyex.Stdlib.Time.beam")
+
+    try do
+      # `:beam_lib.strip/1` removes the Dbgi/Abst chunk but keeps the
+      # module loadable.  After stripping, `:beam_lib.chunks/2` returns
+      # `:no_abstract_code` (vs `:no_debug_info` for never-built-with-it).
+      {:ok, bin} = File.read(src_beam)
+      {:ok, {_mod, stripped_bin}} = :beam_lib.strip(bin)
+      File.write!(stripped_beam, stripped_bin)
+
+      # Sanity: confirm the strip actually removed abstract code.
+      {:ok, {_mod, [{:abstract_code, kind}]}} =
+        :beam_lib.chunks(String.to_charlist(stripped_beam), [:abstract_code])
+
+      assert kind in [:no_abstract_code, :no_debug_info],
+             "Expected strip to remove abstract code; got #{inspect(kind)}"
+
+      violations = BannedCallTracer.check_beam(stripped_beam)
+
+      assert [%{call: :no_debug_info, beam: ^stripped_beam, line: 0}] = violations
+    after
+      File.rm_rf!(tmp)
     end
   end
 


### PR DESCRIPTION
## Summary

The tracer's entire value is *completeness*: it has to see every call from every pyex module, or its 'no banned calls' verdict is meaningless. Previously, a beam whose `:beam_lib.chunks/2` returned `:no_debug_info` was silently reported clean (`lib/pyex/banned_call_tracer.ex:172-173`).

This is a footgun: any change to compilation flags that strips debug info — `strip_beams: true` in a release, or a future compiler default change — would void the gate without the test going red. The tracer would see *nothing* and conclude there are no banned calls.

Fix: surface missing abstract code as a synthetic violation so the check fails loudly.

While auditing this, also covered `:no_abstract_code` — the symbol `:beam_lib.chunks/2` returns for a *stripped* chunk (vs `:no_debug_info` for never-built-with-it). Both cases now produce a violation.

## Changes

- `lib/pyex/banned_call_tracer.ex`:
  - `violation.call` type widened to `{module, atom, arity} | :no_debug_info`.
  - `check_beam/1` returns a synthetic `%{call: :no_debug_info, beam: ..., line: 0}` for beams whose abstract code is `:no_debug_info` or `:no_abstract_code`.
- `test/pyex/banned_call_tracer_test.exs`:
  - Existing violation formatter extended to render the new kind.
  - New test synthesises a stripped beam via `:beam_lib.strip/1` and asserts the tracer flags it.

Together these mean the existing 'no banned calls in the Pyex library' test will now flunk if any module in `_build/test/lib/pyex/ebin` lacks abstract code.

## Verification

- `mix test` — 291 properties, 5446 tests, 0 failures, 2 skipped (the existing 'no banned calls' test still passes — confirms all current pyex modules have abstract code)
- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix dialyzer` — passed, 0 errors