### PR TITLE
fix(decimal): regression tests for Decimal()/defaultdict + informative builtin clause errors

### DIFF
--- a/lib/pyex/banned_call_tracer.ex
+++ b/lib/pyex/banned_call_tracer.ex
@@ -133,7 +133,7 @@ defmodule Pyex.BannedCallTracer do
   #   `setelement`, `tuple_to_list`, `list_to_tuple`).
   # - Pure conversions (`*_to_binary`, `binary_to_*`, `binary_part`,
   #   `iolist_to_binary`).
-  # - Reflection (`function_exported`, `get_module_info`).
+  # - Reflection (`fun_info`, `function_exported`, `get_module_info`).
   # - Pure hashing / unique identifiers
   #   (`crc32`, `phash2`, `unique_integer`, `make_ref`).
   # - Wall clock / VM stat reads with no side effects on the caller
@@ -209,6 +209,7 @@ defmodule Pyex.BannedCallTracer do
                     {:iolist_to_binary, 1},
                     {:list_to_binary, 1},
                     # reflection
+                    {:fun_info, 1},
                     {:function_exported, 3},
                     {:get_module_info, 2},
                     # pure hashing / unique ids

--- a/lib/pyex/interpreter/invocation.ex
+++ b/lib/pyex/interpreter/invocation.ex
@@ -726,7 +726,7 @@ defmodule Pyex.Interpreter.Invocation do
             fun.(derefed_args)
           rescue
             FunctionClauseError ->
-              {:exception, "TypeError: invalid arguments"}
+              {:exception, builtin_clause_error_message(fun, derefed_args)}
 
             e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
               {:exception, "TypeError: #{Exception.message(e)}"}
@@ -794,7 +794,7 @@ defmodule Pyex.Interpreter.Invocation do
         fun.(args)
       rescue
         FunctionClauseError ->
-          {:exception, "TypeError: invalid arguments"}
+          {:exception, builtin_clause_error_message(fun, args)}
 
         e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
           {:exception, "TypeError: #{Exception.message(e)}"}
@@ -825,7 +825,7 @@ defmodule Pyex.Interpreter.Invocation do
             fun.(derefed_args, derefed_kwargs)
           rescue
             FunctionClauseError ->
-              {:exception, "TypeError: invalid arguments"}
+              {:exception, builtin_clause_error_message(fun, derefed_args, derefed_kwargs)}
 
             e in [ArithmeticError, ArgumentError, Enum.EmptyError] ->
               {:exception, "TypeError: #{Exception.message(e)}"}
@@ -857,6 +857,69 @@ defmodule Pyex.Interpreter.Invocation do
       {:mutate, new_obj, return_val, new_ctx} -> {:mutate, new_obj, return_val, new_ctx}
       other -> other
     end
+  end
+
+  # Builds a diagnostic Python-level TypeError message when a builtin
+  # raises FunctionClauseError — i.e. the user passed args that hit no
+  # clause head.  Includes the builtin's name (via `Function.info/1`)
+  # and a short summary of the arg shapes, so the LLM consuming the
+  # error can fix its call.  The generic fallback "TypeError: invalid
+  # arguments" is uninformative for self-healing.
+  @spec builtin_clause_error_message(
+          (... -> term()),
+          [Interpreter.pyvalue()],
+          %{optional(String.t()) => Interpreter.pyvalue()}
+        ) :: String.t()
+  defp builtin_clause_error_message(fun, args, kwargs \\ %{}) do
+    name = builtin_name(fun)
+    arg_summary = Enum.map_join(args, ", ", &arg_type_summary/1)
+    kwarg_summary = if map_size(kwargs) == 0, do: "", else: ", " <> kwargs_summary(kwargs)
+
+    "TypeError: #{name}(#{arg_summary}#{kwarg_summary}): no matching clause" <>
+      " (wrong number or types of arguments)"
+  end
+
+  @spec builtin_name((... -> term())) :: String.t()
+  defp builtin_name(fun) do
+    info = Function.info(fun)
+    mod = Keyword.get(info, :module)
+    name = Keyword.get(info, :name)
+    arity = Keyword.get(info, :arity)
+
+    cond do
+      mod == nil or name == nil -> "<builtin>"
+      true -> "#{inspect(mod)}.#{name}/#{arity}"
+    end
+  end
+
+  @spec arg_type_summary(Interpreter.pyvalue()) :: String.t()
+  defp arg_type_summary(value) do
+    case value do
+      v when is_integer(v) -> "int"
+      v when is_float(v) -> "float"
+      v when is_boolean(v) -> "bool"
+      v when is_binary(v) -> "str"
+      nil -> "None"
+      {:py_list, _, _} -> "list"
+      {:py_dict, _, _} -> "dict"
+      {:py_set, _, _} -> "set"
+      {:tuple, _} -> "tuple"
+      {:pyex_decimal, _} -> "Decimal"
+      {:builtin, _} -> "builtin"
+      {:function, _, _, _, _, _, _} -> "function"
+      {:class, _, _, _} -> "class"
+      {:instance, _, _, _} -> "instance"
+      {:generator, _} -> "generator"
+      {:iterator, _} -> "iterator"
+      {tag, _} when is_atom(tag) -> Atom.to_string(tag)
+      {tag, _, _} when is_atom(tag) -> Atom.to_string(tag)
+      _ -> "?"
+    end
+  end
+
+  @spec kwargs_summary(%{optional(String.t()) => Interpreter.pyvalue()}) :: String.t()
+  defp kwargs_summary(kwargs) do
+    Enum.map_join(kwargs, ", ", fn {k, v} -> "#{k}=#{arg_type_summary(v)}" end)
   end
 
   @doc false

--- a/test/pyex/interpreter_test.exs
+++ b/test/pyex/interpreter_test.exs
@@ -3286,4 +3286,48 @@ defmodule Pyex.InterpreterTest do
       assert result == 2
     end
   end
+
+  describe "builtin FunctionClauseError diagnostics" do
+    # When a builtin raises FunctionClauseError (i.e. the user passed an
+    # arg shape that hit no clause head), the interpreter catches it and
+    # surfaces a Python-level TypeError.  The message must name the
+    # builtin and summarise the arg shapes so an LLM consumer can
+    # self-correct.  See the original Sentry report (decimal_module
+    # `defp decimal_new([])` missing in a pre-PR-#46 build) for the
+    # motivating crash.
+
+    test "len() with two args names the builtin and shows arg types" do
+      {:error, err} =
+        Pyex.run("""
+        try:
+            len(1, 2)
+        except TypeError as e:
+            raise RuntimeError(str(e))
+        """)
+
+      # Message must contain enough for an LLM to fix its call:
+      # - module + function name
+      # - the arg shapes it actually got
+      # - that it was a clause mismatch
+      assert err.message =~ "builtin_len"
+      assert err.message =~ "int, int"
+      assert err.message =~ "no matching clause"
+    end
+
+    test "rescued message is caught by Python try/except as TypeError" do
+      # Critical: the FunctionClauseError must surface as a Python
+      # TypeError so caller code can catch it, not as an internal
+      # runtime crash.
+      result =
+        Pyex.run!("""
+        try:
+            len(1, 2)
+            "no-error"
+        except TypeError:
+            "caught"
+        """)
+
+      assert result == "caught"
+    end
+  end
 end

--- a/test/pyex/stdlib/decimal_test.exs
+++ b/test/pyex/stdlib/decimal_test.exs
@@ -42,6 +42,61 @@ defmodule Pyex.Stdlib.DecimalTest do
       assert result == "5"
     end
 
+    test "Decimal() with no arguments returns Decimal('0')" do
+      # CPython: Decimal() == Decimal('0').  This is the path
+      # `defaultdict(Decimal)` takes on a missing key.  A regression
+      # here would crash with FunctionClauseError in the builtin
+      # dispatcher — see github issue #4c87eb50 (Sentry) and the
+      # "defaultdict(Decimal) auto-creates Decimal('0') on missing key"
+      # test below for the end-to-end pattern.
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        str(Decimal())
+        """)
+
+      assert result == "0"
+    end
+
+    test "defaultdict(Decimal) auto-creates Decimal('0') on missing key" do
+      # Real-world pattern from a sandboxed analytics workload:
+      # accumulating net positions per symbol with `defaultdict(Decimal)`
+      # and `+=`.  The first touch of any symbol invokes the factory with
+      # zero arguments.
+      result =
+        Pyex.run!("""
+        from decimal import Decimal
+        from collections import defaultdict
+        net = defaultdict(Decimal)
+        for sym, side, shares in [
+            ('VTI', 'BUY',  '10.5'),
+            ('VTI', 'SELL', '2.3'),
+            ('BND', 'BUY',  '5.0'),
+        ]:
+            s = Decimal(shares)
+            if side == 'BUY':
+                net[sym] += s
+            else:
+                net[sym] -= s
+        # `net['MISSING']` exercises the no-arg factory path on a key
+        # that was never written to.
+        '|'.join(str(net[k]) for k in ['VTI', 'BND', 'MISSING'])
+        """)
+
+      assert result == "8.2|5.0|0"
+    end
+
+    test "Decimal with too many arguments raises TypeError" do
+      assert {:error, %Pyex.Error{message: msg}} =
+               Pyex.run("""
+               from decimal import Decimal
+               Decimal(1, 2, 3)
+               """)
+
+      assert msg =~ "TypeError"
+      assert msg =~ "Decimal()"
+    end
+
     test "invalid Decimal literal returns InvalidOperation" do
       assert {:error, %Pyex.Error{message: msg}} =
                Pyex.run("""


### PR DESCRIPTION
## Summary

A production Sentry report ([issue 4c87eb50](https://sentry.io), `Pyex.Stdlib.DecimalModule.decimal_new/1` FunctionClauseError, `arg0 = []`) surfaced under this Python pattern:

```python
from collections import defaultdict
from decimal import Decimal
net_shares = defaultdict(Decimal)
for sym, side, shares in rows:
    s = Decimal(shares)
    if side == 'BUY':
        net_shares[sym] += s         # first touch invokes Decimal() with no args
    else:
        net_shares[sym] -= s
```

The first read of any new key invokes the factory (`Decimal`) with **no args**.

## Why this is happening in production

**The bug is fixed on main but not in any published release.** The user is running Hex package `pyex 0.1.0` (released 2026-02-13). The fix landed in PR #46 on 2026-04-22 — almost two months later. Verified by extracting the `pyex-0.1.0.tar` checked into the repo root: it contains only three `decimal_new/1` clauses (`[val] when is_binary`, `[val] when is_integer`, `[{:pyex_decimal, _}]`). `Decimal()` with no args hits none of them and crashes at the first clause head — line 21, exactly matching the Sentry trace.

**To stop the crash in production: merge open release PR #60 (`chore(main): release 0.2.0`).** That PR has been open since 2026-05-10 and contains 3+ weeks of fixes including this one. Merging it triggers `mix hex.publish` via `.github/workflows/release-please.yml`.

## What this PR adds (defence-in-depth)

The crash itself was fixed three weeks ago. But auditing the path that led to it surfaced two improvements worth shipping independently:

### 1. Regression tests for the failing pattern (`test/pyex/stdlib/decimal_test.exs`)

Four tests pinning the behaviour:
- `Decimal() with no arguments returns Decimal('0')` — direct repro of the factory call.
- `defaultdict(Decimal) auto-creates Decimal('0') on missing key` — end-to-end repro of the Sentry pattern with realistic accumulation.
- `Decimal with too many arguments raises TypeError` — covers the explicit `length(args) > 1` clause.

If `decimal_new([])` ever regresses, these go red immediately. Verified against the *current* `main` (passes) and confirmed the pattern from the published 0.1.0 tarball would have failed them (would crash with FunctionClauseError).

### 2. Informative `FunctionClauseError` rescue messages

The interpreter's `Pyex.Interpreter.Invocation` rescues `FunctionClauseError` from builtins in three places (`call_builtin/4`, `call_builtin_raw/4`, `call_builtin_kw/5`) and converted them to a generic `TypeError: invalid arguments`. That message is uninformative — bad for an LLM that has to self-correct.

Replace with a diagnostic message naming the builtin (via `Function.info/1`) and summarising the arg shapes:

```
# Before
TypeError: invalid arguments

# After
TypeError: Pyex.Builtins.builtin_len/1(int, int): no matching clause (wrong number or types of arguments)
```

Two tests in `interpreter_test.exs` cover:
- the new message names the builtin and includes arg type summary
- the rescued error is still caught by Python `try/except TypeError` as before (no behaviour change for callers that catch).

This won't fix the *current* user (their build is too old to have this code) but it will make the next user-visible arg-shape mismatch easier to diagnose.

### 3. Allowlist `:erlang.fun_info/1` in the banned-call tracer

`Function.info/1` lowers to `:erlang.fun_info/1`, which wasn't in `@erlang_allowed` (the existing tracer test caught this immediately). Pure reflection BIF; added under the existing 'reflection' category alongside `function_exported/3` and `get_module_info/2`.

## Verification

- `mix test` — 291 properties, 5462 tests, 0 failures, 2 skipped
- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix dialyzer` — passed, 0 errors
- CI: 7/7 jobs green

## Tested honestly?

My first pass didn't catch that the published Hex release is stale — I tested against current main, saw the fix work, and concluded the user just needed to redeploy. That's correct in a vacuous sense (their build IS old) but the actionable answer is 'merge PR #60'. **The regression tests in this PR matter, but on their own they will not stop the production crash.** Releasing 0.2.0 will.