### PR TITLE
docs: precompiled Elixir/OTP setup for cold environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,38 @@
 # Guidelines for Pyex Development
 
+## IMPORTANT: Environment setup (fresh sandbox)
+
+If `mix` is not on `PATH` — a fresh claude.ai sandbox, CI runner, or
+new container — install Elixir **before anything else**. Do NOT use
+`apt` (ships Elixir 1.14 / OTP 25) and do NOT use asdf's erlang plugin
+(compiles OTP from source — minutes on a single core). Install
+precompiled binaries from builds.hex.pm. On Ubuntu 24.04 / amd64:
+
+```bash
+OTP=28.5.0.1 EX=1.19.5-otp-28 ROOT="$HOME/beam"   # bump patch versions as needed
+mkdir -p "$ROOT"/{otp,elixir} && cd "$ROOT"
+curl -fsSL -o otp.tar.gz "https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/OTP-${OTP}.tar.gz"
+curl -fsSL -o elixir.zip "https://builds.hex.pm/builds/elixir/v${EX}.zip"
+tar xf otp.tar.gz -C otp --strip-components=1
+unzip -q elixir.zip -d elixir
+( cd otp && ./Install -minimal "$(pwd)" >/dev/null )   # bakes the abs path into the release
+```
+
+Then set these in **every** shell (each Bash call is a fresh shell —
+exports do not persist; re-apply them or write them to an env file you
+`source`):
+
+```bash
+export PATH="$HOME/beam/otp/bin:$HOME/beam/elixir/bin:$PATH"
+export ELIXIR_ERL_OPTIONS="+fnu"                            # precompiled OTP defaults to latin1; silences the locale warning
+export HEX_CACERTS_PATH=/etc/ssl/certs/ca-certificates.crt  # precompiled OTP can't find the OS CA store; without this, Hex TLS fails with unknown_ca
+```
+
+Finally `mix local.hex --force && mix local.rebar --force`, then
+`mix deps.get && mix compile`. Use `MIX_ENV=prod` to skip dev/test
+deps (ex_doc, dialyxir, benchee, bandit) when you only need to run
+code, not test it. Full prose lives in README `## Development`.
+
 ## IMPORTANT: Code Requirement
 
 **Before committing OR opening a PR, run all four:**

--- a/README.md
+++ b/README.md
@@ -395,6 +395,36 @@ analyzer's job tractable.
 This shape is deliberate. The library does not own a runtime; the
 host application does. Pyex is a value you compute with.
 
+## Development
+
+Requires Elixir `~> 1.19` on OTP 28. For local work, the repo pins
+exact versions in `.tool-versions` (use `asdf` or `mise`).
+
+In a **cold environment** — a CI runner, a fresh container, or an
+agent sandbox — install precompiled binaries from
+[builds.hex.pm](https://builds.hex.pm). Do *not* use `apt` (ships
+Elixir 1.14 / OTP 25) or asdf's erlang plugin (compiles OTP from
+source — minutes on a single core). On Ubuntu 24.04 / amd64:
+
+```bash
+OTP=28.5.0.1 EX=1.19.5-otp-28 ROOT="$HOME/beam"   # bump patch versions as needed
+mkdir -p "$ROOT"/{otp,elixir} && cd "$ROOT"
+curl -fsSL -o otp.tar.gz "https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/OTP-${OTP}.tar.gz"
+curl -fsSL -o elixir.zip "https://builds.hex.pm/builds/elixir/v${EX}.zip"
+tar xf otp.tar.gz -C otp --strip-components=1
+unzip -q elixir.zip -d elixir
+( cd otp && ./Install -minimal "$(pwd)" >/dev/null )   # bakes the abs path into the release
+
+export PATH="$ROOT/otp/bin:$ROOT/elixir/bin:$PATH"
+export ELIXIR_ERL_OPTIONS="+fnu"                        # precompiled OTP defaults to latin1; silences the locale warning
+export HEX_CACERTS_PATH=/etc/ssl/certs/ca-certificates.crt   # precompiled OTP can't find the OS CA store; without this, Hex TLS fails with unknown_ca
+```
+
+Then `mix local.hex --force && mix local.rebar --force`, followed by
+`mix deps.get && mix compile`. `MIX_ENV=prod` skips the dev/test deps
+(ex_doc, dialyxir, benchee, bandit) when you only need to run code,
+not test it.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Why

When the repo is cloned into a cold environment — a claude.ai agent sandbox, a CI runner, or a fresh container — there's no Elixir, and an agent asked to "run a program" reliably struggles with the install. The two obvious paths are both wrong:

- `apt` ships Elixir 1.14 / OTP 25 (we require `~> 1.19` / OTP 28)
- asdf's erlang plugin compiles OTP **from source** — minutes on a single-core box

The correct path (precompiled binaries from builds.hex.pm) also hides four non-obvious traps that get rediscovered from scratch every time.

## What

- **`CLAUDE.md`** — a binding `## IMPORTANT: Environment setup (fresh sandbox)` section at the **top** of the file. This is the lever: it's the file agents treat as override-everything instructions and read before improvising. Placed first because the existing four-check gate can't run without Elixir installed.
- **`README.md`** — the same recipe as prose under `## Development`, which `CLAUDE.md` points to so the two don't drift.

Both bake in the four traps:

- `amd64` (not `x86_64`) in the builds.hex.pm OTP URL
- `./Install -minimal "$(pwd)"` so `erl` resolves its own release root
- `HEX_CACERTS_PATH` — without it, Hex TLS to repo.hex.pm fails with `unknown_ca`
- `ELIXIR_ERL_OPTIONS=+fnu` to silence the latin1 locale warning

Plus an explicit note that each shell is fresh, so the exports must be re-applied (or sourced from an env file).

## Scope

Docs-only — no changes under `lib/`, so the format/compile/test/dialyzer gate does not apply. Pinned versions (`OTP=28.5.0.1`, `EX=1.19.5-otp-28`) carry a "bump as needed" comment; `AGENTS.md ## Runtime` is intentionally left asdf-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)