### PR TITLE
docs: SETUP.md + top-of-README agent banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Pyex.run!("sorted([3, 1, 2])")
 # => [1, 2, 3]
 ```
 
+> **🤖 Are you an LLM agent, or setting up in a fresh sandbox / CI?**
+> Read [**`SETUP.md`**](SETUP.md) before installing anything — use the
+> precompiled builds.hex.pm recipe, not `apt` or `asdf`.
+
 ## Why this exists
 
 Pyex exists for one shape of problem: running Python written by, or
@@ -397,33 +401,10 @@ host application does. Pyex is a value you compute with.
 
 ## Development
 
-Requires Elixir `~> 1.19` on OTP 28. For local work, the repo pins
-exact versions in `.tool-versions` (use `asdf` or `mise`).
-
-In a **cold environment** — a CI runner, a fresh container, or an
-agent sandbox — install precompiled binaries from
-[builds.hex.pm](https://builds.hex.pm). Do *not* use `apt` (ships
-Elixir 1.14 / OTP 25) or asdf's erlang plugin (compiles OTP from
-source — minutes on a single core). On Ubuntu 24.04 / amd64:
-
-```bash
-OTP=28.5.0.1 EX=1.19.5-otp-28 ROOT="$HOME/beam"   # bump patch versions as needed
-mkdir -p "$ROOT"/{otp,elixir} && cd "$ROOT"
-curl -fsSL -o otp.tar.gz "https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/OTP-${OTP}.tar.gz"
-curl -fsSL -o elixir.zip "https://builds.hex.pm/builds/elixir/v${EX}.zip"
-tar xf otp.tar.gz -C otp --strip-components=1
-unzip -q elixir.zip -d elixir
-( cd otp && ./Install -minimal "$(pwd)" >/dev/null )   # bakes the abs path into the release
-
-export PATH="$ROOT/otp/bin:$ROOT/elixir/bin:$PATH"
-export ELIXIR_ERL_OPTIONS="+fnu"                        # precompiled OTP defaults to latin1; silences the locale warning
-export HEX_CACERTS_PATH=/etc/ssl/certs/ca-certificates.crt   # precompiled OTP can't find the OS CA store; without this, Hex TLS fails with unknown_ca
-```
-
-Then `mix local.hex --force && mix local.rebar --force`, followed by
-`mix deps.get && mix compile`. `MIX_ENV=prod` skips the dev/test deps
-(ex_doc, dialyxir, benchee, bandit) when you only need to run code,
-not test it.
+Requires Elixir `~> 1.19` on OTP 28. For local work, the repo pins exact
+versions in `.tool-versions` (use `asdf` or `mise`). For a cold environment
+(fresh sandbox, CI, new container), follow [`SETUP.md`](SETUP.md) — precompiled
+builds.hex.pm binaries, not `apt` or `asdf`.
 
 ## License
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,54 @@
+# Setup
+
+> **🤖 If you're an LLM agent / setting up in a fresh sandbox or CI: this is
+> the file to follow.** Don't improvise — `apt` ships Elixir 1.14 / OTP 25,
+> and asdf's erlang plugin compiles OTP from source (minutes on a single core).
+> Install precompiled binaries from builds.hex.pm as below.
+
+Pyex needs Elixir `~> 1.19` on OTP 28.
+
+For **local dev** with an existing toolchain, the repo pins exact versions in
+`.tool-versions` (use `asdf` or `mise`) — nothing else to do.
+
+For a **cold environment** (fresh sandbox, CI runner, new container) where
+`mix` is not on `PATH`, install precompiled binaries. On Ubuntu 24.04 / amd64:
+
+```bash
+OTP=28.5.0.1 EX=1.19.5-otp-28 ROOT="$HOME/beam"   # bump patch versions as needed
+mkdir -p "$ROOT"/{otp,elixir} && cd "$ROOT"
+curl -fsSL -o otp.tar.gz "https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/OTP-${OTP}.tar.gz"
+curl -fsSL -o elixir.zip "https://builds.hex.pm/builds/elixir/v${EX}.zip"
+tar xf otp.tar.gz -C otp --strip-components=1
+unzip -q elixir.zip -d elixir
+( cd otp && ./Install -minimal "$(pwd)" >/dev/null )   # bakes the abs path into the release
+```
+
+Then export these in **every** shell — each shell is fresh, so the exports
+don't persist; re-apply them or write them to an env file you `source`:
+
+```bash
+export PATH="$HOME/beam/otp/bin:$HOME/beam/elixir/bin:$PATH"
+export ELIXIR_ERL_OPTIONS="+fnu"                            # precompiled OTP defaults to latin1; silences the locale warning
+export HEX_CACERTS_PATH=/etc/ssl/certs/ca-certificates.crt  # precompiled OTP can't find the OS CA store; without this, Hex TLS fails with unknown_ca
+```
+
+Finally:
+
+```bash
+mix local.hex --force && mix local.rebar --force
+mix deps.get && mix compile
+```
+
+`MIX_ENV=prod` skips the dev/test deps (ex_doc, dialyxir, benchee, bandit)
+when you only need to run code, not test it.
+
+## The four traps this recipe handles
+
+These cost an uninformed setup real time, so they're baked in above:
+
+1. The arch directory is `amd64`, not `x86_64`, in the builds.hex.pm OTP URL.
+2. The OTP tarball is a kerl-style release — `./Install -minimal "$(pwd)"`
+   bakes its absolute path in, or `erl` can't resolve its own root.
+3. Precompiled OTP can't find the OS CA store, so Hex TLS to repo.hex.pm
+   fails with `unknown_ca` — `HEX_CACERTS_PATH` fixes it.
+4. Precompiled OTP defaults to a latin1 locale; `+fnu` silences the warning.


### PR DESCRIPTION
## Why

After #78 merged, a `clone && run` test in a fresh agent sandbox showed the fix **didn't fire**. The agent read only `head -120 README.md` (all philosophy), never opened `CLAUDE.md`, and never reached the bottom-of-README `## Development` section (~line 400). It then re-improvised the whole Elixir install — `apt` (got 1.14) → Erlang Solutions repo (no "noble" release) → eventually rediscovering builds.hex.pm from scratch.

The problem was **placement, not content**: both copies of the recipe lived where a skim-the-top-then-act agent never looks.

## What

- **`SETUP.md`** (new) — single source of truth for the precompiled builds.hex.pm recipe, with an explicit "if you're an LLM agent, follow this file" header and the four traps it handles (amd64 path, `./Install -minimal`, `HEX_CACERTS_PATH`, `+fnu`).
- **README banner** in the first ~15 lines pointing at an *explicit file to open* (`SETUP.md`) rather than an in-page anchor an agent won't jump to.
- **README `## Development`** collapsed to a one-line pointer to `SETUP.md` (no more duplicate recipe).
- **`CLAUDE.md`** left as-is — keeps its own copy for the code-modifying-agent path.

## Scope

Docs-only — no `lib/` changes, so the format/compile/test/dialyzer gate doesn't apply. Pinned versions carry a "bump as needed" comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)