### PR TITLE
fix(lexer): complete the bytes-literal prefix matrix + repr quoting

### DIFF
--- a/lib/pyex/interpreter/helpers.ex
+++ b/lib/pyex/interpreter/helpers.ex
@@ -625,18 +625,23 @@ defmodule Pyex.Interpreter.Helpers do
   @doc """
   Renders a bytes value in Python's repr form: `b'hello\\xc2\\xa9'`.
   Printable ASCII stays as-is; non-printable bytes become `\\xhh` escapes.
+
+  Quote selection follows CPython: single quotes by default, but double
+  quotes when the value contains a `'` and no `"` (so the `'` need not be
+  escaped). The chosen quote is the only quote that gets escaped.
   """
   @spec bytes_repr(binary(), String.t()) :: String.t()
   def bytes_repr(b, prefix) do
+    list = :binary.bin_to_list(b)
+    quote = if ?' in list and ?" not in list, do: ?", else: ?'
+
     inner =
-      b
-      |> :binary.bin_to_list()
-      |> Enum.map_join(fn
+      Enum.map_join(list, fn
         byte when byte == ?\\ ->
           "\\\\"
 
-        byte when byte == ?' ->
-          "\\'"
+        byte when byte == quote ->
+          <<?\\, quote>>
 
         byte when byte == ?\n ->
           "\\n"
@@ -654,7 +659,7 @@ defmodule Pyex.Interpreter.Helpers do
           "\\x" <> String.pad_leading(Integer.to_string(byte, 16) |> String.downcase(), 2, "0")
       end)
 
-    "#{prefix}'#{inner}'"
+    "#{prefix}#{<<quote>>}#{inner}#{<<quote>>}"
   end
 
   # Formats a complex component the way CPython does: strips `.0` when

--- a/lib/pyex/lexer.ex
+++ b/lib/pyex/lexer.ex
@@ -182,21 +182,22 @@ defmodule Pyex.Lexer do
   ]
 
   # ===========================================================================
-  # String-literal combinators — the full Python string-prefix matrix.
+  # String/bytes-literal combinators — the full Python prefix matrix.
   # ===========================================================================
   #
-  # Python string prefixes are case-insensitive (`r`/`R`, `f`/`F`, `u`/`U`),
-  # the raw-f prefix may appear in either order (`rf`/`fr`), and every prefix
-  # combines with all four quote styles (`"` `'` `"""` `'''`). Rather than
-  # spell out the ~40 near-identical combinators by hand, we build them at
-  # compile time from a handful of body/prefix helper closures.
+  # Python string prefixes are case-insensitive (`r`/`R`, `f`/`F`, `u`/`U`,
+  # `b`/`B`), the two-letter raw combos may appear in either order (`rf`/`fr`,
+  # `rb`/`br`), and every prefix combines with all four quote styles (`"` `'`
+  # `"""` `'''`). Rather than spell out the ~70 near-identical combinators by
+  # hand, we build them at compile time from a handful of body/prefix helper
+  # closures.
   #
   # `u`/`U` is a legacy no-op prefix: `u"x"` lexes exactly like `"x"`.
   #
-  # Bytes literals (`b"..."`, `rb"..."`, ...) are intentionally NOT handled
-  # here. They fall through to identifier + string lexing and are stitched
-  # back together by `collapse_bytes_literals/1`, which already covers every
-  # case/order variant.
+  # Bytes literals (`b"..."`, `rb"..."`, ...) get their own combinators
+  # further down. They differ from str literals in three ways: `\u`/`\U`/`\N`
+  # are NOT escapes (kept verbatim), `\xhh` is a single raw byte (not a
+  # UTF-8-encoded codepoint), and the body is assembled as raw bytes.
 
   # Accepted spellings per prefix family.
   r_prefixes = ~w(r R)
@@ -348,6 +349,121 @@ defmodule Pyex.Lexer do
   single_quoted_string =
     string_literal.(string("'"), "'", cooked_body.(?'), :string)
 
+  # --- bytes literals ------------------------------------------------------
+  # `b`/`B` cook escapes; the raw combos (`rb`/`br` and case variants) keep
+  # backslashes verbatim. Unlike str, bytes do not recognise `\u`/`\U`/`\N`,
+  # and `\xhh` is a single raw byte.
+  b_prefixes = ~w(b B)
+  rb_prefixes = ~w(rb br Rb rB bR Br RB BR)
+
+  # `\xhh` as a single raw byte (str uses a UTF-8-encoded codepoint instead).
+  bytes_hex_escape =
+    ignore(string("\\x"))
+    |> concat(hex_char)
+    |> concat(hex_char)
+    |> reduce(:__bytes_hex_escape__)
+
+  # Bytes escape table: the common single-char escapes plus `\xhh`, but NO
+  # `\u`/`\U` (those stay literal in bytes).
+  bytes_escapes = [
+    string("\\n") |> replace(?\n),
+    string("\\t") |> replace(?\t),
+    string("\\r") |> replace(?\r),
+    string("\\0") |> replace(0),
+    string("\\a") |> replace(?\a),
+    string("\\b") |> replace(?\b),
+    string("\\f") |> replace(?\f),
+    string("\\v") |> replace(?\v),
+    string("\\\\") |> replace(?\\),
+    bytes_hex_escape
+  ]
+
+  # Bytes body builders, mirroring the str ones but reducing via `__bytes__`
+  # (assemble raw bytes) and using the bytes-only escape table.
+  cooked_bytes_body = fn q ->
+    repeat(
+      choice(
+        [string(<<?\\, q>>) |> replace(q)] ++
+          bytes_escapes ++
+          [
+            string("\\") |> concat(ascii_char(not: ?\n)) |> reduce(:__bytes__),
+            ascii_char(not: q, not: ?\\, not: ?\n)
+          ]
+      )
+    )
+  end
+
+  cooked_bytes_triple_body = fn q, close3 ->
+    repeat(
+      choice(
+        [string(<<?\\, q>>) |> replace(q)] ++
+          bytes_escapes ++
+          [
+            string("\\") |> concat(ascii_char([])) |> reduce(:__bytes__),
+            lookahead_not(string(close3)) |> ascii_char([])
+          ]
+      )
+    )
+  end
+
+  raw_bytes_body = fn q ->
+    repeat(
+      choice([
+        string(<<?\\, q>>) |> reduce(:__bytes__),
+        string("\\\\") |> reduce(:__bytes__),
+        string("\\") |> concat(ascii_char(not: ?\n)) |> reduce(:__bytes__),
+        ascii_char(not: q, not: ?\n)
+      ])
+    )
+  end
+
+  raw_bytes_triple_body = fn close3 ->
+    repeat(
+      choice([
+        string("\\") |> concat(ascii_char([])) |> reduce(:__bytes__),
+        lookahead_not(string(close3)) |> ascii_char([])
+      ])
+    )
+  end
+
+  bytes_literal = fn open, close, body ->
+    ignore(open)
+    |> concat(body)
+    |> ignore(string(close))
+    |> reduce(:__bytes__)
+    |> unwrap_and_tag(:bytes_literal)
+  end
+
+  # Triple-quoted (tried before single/double, since `"""` starts with `"`).
+  raw_bytes_triple_double =
+    bytes_literal.(prefixed.(rb_prefixes, ~S["""]), ~S["""], raw_bytes_triple_body.(~S["""]))
+
+  raw_bytes_triple_single =
+    bytes_literal.(prefixed.(rb_prefixes, "'''"), "'''", raw_bytes_triple_body.("'''"))
+
+  cooked_bytes_triple_double =
+    bytes_literal.(
+      prefixed.(b_prefixes, ~S["""]),
+      ~S["""],
+      cooked_bytes_triple_body.(?", ~S["""])
+    )
+
+  cooked_bytes_triple_single =
+    bytes_literal.(prefixed.(b_prefixes, "'''"), "'''", cooked_bytes_triple_body.(?', "'''"))
+
+  # Single/double-quoted.
+  raw_bytes_double =
+    bytes_literal.(prefixed.(rb_prefixes, "\""), "\"", raw_bytes_body.(?"))
+
+  raw_bytes_single =
+    bytes_literal.(prefixed.(rb_prefixes, "'"), "'", raw_bytes_body.(?'))
+
+  cooked_bytes_double =
+    bytes_literal.(prefixed.(b_prefixes, "\""), "\"", cooked_bytes_body.(?"))
+
+  cooked_bytes_single =
+    bytes_literal.(prefixed.(b_prefixes, "'"), "'", cooked_bytes_body.(?'))
+
   identifier_or_keyword =
     ascii_char([?a..?z, ?A..?Z, ?_])
     |> repeat(ascii_char([?a..?z, ?A..?Z, ?0..?9, ?_]))
@@ -464,6 +580,10 @@ defmodule Pyex.Lexer do
       raw_triple_single,
       unicode_triple_double,
       unicode_triple_single,
+      raw_bytes_triple_double,
+      raw_bytes_triple_single,
+      cooked_bytes_triple_double,
+      cooked_bytes_triple_single,
       triple_double_string,
       triple_single_string,
       raw_fstring_double,
@@ -474,6 +594,10 @@ defmodule Pyex.Lexer do
       raw_single_string,
       unicode_double,
       unicode_single,
+      raw_bytes_double,
+      raw_bytes_single,
+      cooked_bytes_double,
+      cooked_bytes_single,
       double_quoted_string,
       single_quoted_string,
       hex_integer,
@@ -521,7 +645,6 @@ defmodule Pyex.Lexer do
 
             tokens =
               tokens
-              |> collapse_bytes_literals()
               |> collapse_complex_literals()
               |> suppress_bracketed_newlines()
               |> merge_adjacent_strings()
@@ -649,36 +772,6 @@ defmodule Pyex.Lexer do
   @spec check_tokens([raw_token() | token()]) :: :ok | {:error, String.t()}
   defp check_tokens([_ | rest]), do: check_tokens(rest)
   defp check_tokens([]), do: :ok
-
-  # Collapses `b"..."`, `rb"..."`, `br"..."` into a single `:bytes_literal`
-  # token.  The original string body is kept verbatim because bytes literals
-  # interpret escapes slightly differently (e.g. non-ASCII is rejected),
-  # but we accept UTF-8 bytes as-is for simplicity.
-  @spec collapse_bytes_literals([token()]) :: [token()]
-  defp collapse_bytes_literals(tokens), do: do_collapse_bytes(tokens, [])
-
-  defp do_collapse_bytes([], acc), do: Enum.reverse(acc)
-
-  defp do_collapse_bytes([{:name, line, prefix}, {:string, _, value} | rest], acc)
-       when prefix in ["b", "rb", "br", "B", "rB", "Rb", "BR", "bR", "Br", "RB"] do
-    # The lexer treats the string body as Unicode: `b"\xff"` becomes
-    # UTF-8 `<<0xC3, 0xBF>>`.  Bytes literals should hold raw bytes, so
-    # re-encode each codepoint as a single byte (codepoints > 0xFF
-    # would be invalid in a real bytes literal, we truncate mod 256).
-    raw = codepoints_to_bytes(value)
-    do_collapse_bytes(rest, [{:bytes_literal, line, raw} | acc])
-  end
-
-  defp do_collapse_bytes([token | rest], acc),
-    do: do_collapse_bytes(rest, [token | acc])
-
-  @spec codepoints_to_bytes(String.t()) :: binary()
-  defp codepoints_to_bytes(s) do
-    s
-    |> String.to_charlist()
-    |> Enum.map(fn cp -> rem(cp, 256) end)
-    |> :erlang.list_to_binary()
-  end
 
   # Collapses `2j`, `2.5J`, `0j` into a single `:complex_literal` token
   # carrying the imaginary part as a float.
@@ -965,6 +1058,28 @@ defmodule Pyex.Lexer do
       # as `<<c::utf8>>` would double-encode and corrupt the string.
       c when is_integer(c) and c >= 0x80 and c <= 0xFF -> <<c>>
       c when is_integer(c) -> <<c::utf8>>
+      s when is_binary(s) -> s
+    end)
+    |> IO.iodata_to_binary()
+  end
+
+  @doc false
+  @spec __bytes_hex_escape__([non_neg_integer()]) :: binary()
+  def __bytes_hex_escape__(hex_chars) do
+    # `\xhh` in a bytes literal is a single raw byte (not a UTF-8 codepoint).
+    byte = hex_chars |> List.to_string() |> String.to_integer(16)
+    <<byte>>
+  end
+
+  @doc false
+  @spec __bytes__([non_neg_integer() | binary()]) :: binary()
+  def __bytes__(parts) do
+    # Every integer here is a raw source byte (0..255) or a control byte from
+    # an escape `replace`; every binary is already raw bytes from an escape
+    # reducer. Assemble them verbatim — no UTF-8 re-encoding.
+    parts
+    |> Enum.map(fn
+      c when is_integer(c) -> <<c>>
       s when is_binary(s) -> s
     end)
     |> IO.iodata_to_binary()

--- a/test/fixtures/string_prefix_diff.json
+++ b/test/fixtures/string_prefix_diff.json
@@ -5998,5 +5998,4005 @@
 "src": "FR'''hex \\xff'''",
 "kind": "str",
 "expected": "'hex \\\\xff'"
+},
+{
+"id": "0750",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0751",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0752",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\nb'"
+},
+{
+"id": "0753",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\tb'"
+},
+{
+"id": "0754",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0755",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\b'"
+},
+{
+"id": "0756",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0757",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0758",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0759",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0760",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0761",
+"prefix": "b",
+"quote": "\"",
+"src": "b\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\xff'"
+},
+{
+"id": "0762",
+"prefix": "b",
+"quote": "'",
+"src": "b''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0763",
+"prefix": "b",
+"quote": "'",
+"src": "b'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0764",
+"prefix": "b",
+"quote": "'",
+"src": "b'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\nb'"
+},
+{
+"id": "0765",
+"prefix": "b",
+"quote": "'",
+"src": "b'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\tb'"
+},
+{
+"id": "0766",
+"prefix": "b",
+"quote": "'",
+"src": "b'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0767",
+"prefix": "b",
+"quote": "'",
+"src": "b'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\b'"
+},
+{
+"id": "0768",
+"prefix": "b",
+"quote": "'",
+"src": "b'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0769",
+"prefix": "b",
+"quote": "'",
+"src": "b'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0770",
+"prefix": "b",
+"quote": "'",
+"src": "b'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0771",
+"prefix": "b",
+"quote": "'",
+"src": "b'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0772",
+"prefix": "b",
+"quote": "'",
+"src": "b'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0773",
+"prefix": "b",
+"quote": "'",
+"src": "b'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\xff'"
+},
+{
+"id": "0774",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0775",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0776",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\nb'"
+},
+{
+"id": "0777",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\tb'"
+},
+{
+"id": "0778",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0779",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\b'"
+},
+{
+"id": "0780",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0781",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0782",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0783",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0784",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0785",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0786",
+"prefix": "b",
+"quote": "\"\"\"",
+"src": "b\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\xff'"
+},
+{
+"id": "0787",
+"prefix": "b",
+"quote": "'''",
+"src": "b''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0788",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0789",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\nb'"
+},
+{
+"id": "0790",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\tb'"
+},
+{
+"id": "0791",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0792",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\b'"
+},
+{
+"id": "0793",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0794",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0795",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0796",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0797",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0798",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0799",
+"prefix": "b",
+"quote": "'''",
+"src": "b'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\xff'"
+},
+{
+"id": "0800",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0801",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0802",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\nb'"
+},
+{
+"id": "0803",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\tb'"
+},
+{
+"id": "0804",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0805",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\b'"
+},
+{
+"id": "0806",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0807",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0808",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0809",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0810",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0811",
+"prefix": "B",
+"quote": "\"",
+"src": "B\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\xff'"
+},
+{
+"id": "0812",
+"prefix": "B",
+"quote": "'",
+"src": "B''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0813",
+"prefix": "B",
+"quote": "'",
+"src": "B'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0814",
+"prefix": "B",
+"quote": "'",
+"src": "B'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\nb'"
+},
+{
+"id": "0815",
+"prefix": "B",
+"quote": "'",
+"src": "B'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\tb'"
+},
+{
+"id": "0816",
+"prefix": "B",
+"quote": "'",
+"src": "B'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0817",
+"prefix": "B",
+"quote": "'",
+"src": "B'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\b'"
+},
+{
+"id": "0818",
+"prefix": "B",
+"quote": "'",
+"src": "B'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0819",
+"prefix": "B",
+"quote": "'",
+"src": "B'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0820",
+"prefix": "B",
+"quote": "'",
+"src": "B'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0821",
+"prefix": "B",
+"quote": "'",
+"src": "B'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0822",
+"prefix": "B",
+"quote": "'",
+"src": "B'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0823",
+"prefix": "B",
+"quote": "'",
+"src": "B'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\xff'"
+},
+{
+"id": "0824",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0825",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0826",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\nb'"
+},
+{
+"id": "0827",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\tb'"
+},
+{
+"id": "0828",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0829",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\b'"
+},
+{
+"id": "0830",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0831",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0832",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0833",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0834",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0835",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0836",
+"prefix": "B",
+"quote": "\"\"\"",
+"src": "B\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\xff'"
+},
+{
+"id": "0837",
+"prefix": "B",
+"quote": "'''",
+"src": "B''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0838",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0839",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\nb'"
+},
+{
+"id": "0840",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\tb'"
+},
+{
+"id": "0841",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0842",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\b'"
+},
+{
+"id": "0843",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0844",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0845",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0846",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0847",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0848",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0849",
+"prefix": "B",
+"quote": "'''",
+"src": "B'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\xff'"
+},
+{
+"id": "0850",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0851",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0852",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0853",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0854",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0855",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0856",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0857",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0858",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0859",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0860",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0861",
+"prefix": "rb",
+"quote": "\"",
+"src": "rb\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0862",
+"prefix": "rb",
+"quote": "'",
+"src": "rb''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0863",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0864",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0865",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0866",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0867",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0868",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0869",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0870",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0871",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0872",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0873",
+"prefix": "rb",
+"quote": "'",
+"src": "rb'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0874",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0875",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0876",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0877",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0878",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0879",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0880",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0881",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0882",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0883",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0884",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0885",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0886",
+"prefix": "rb",
+"quote": "\"\"\"",
+"src": "rb\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0887",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0888",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0889",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0890",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0891",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0892",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0893",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0894",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0895",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0896",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0897",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0898",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0899",
+"prefix": "rb",
+"quote": "'''",
+"src": "rb'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0900",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0901",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0902",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0903",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0904",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0905",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0906",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0907",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0908",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0909",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0910",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0911",
+"prefix": "br",
+"quote": "\"",
+"src": "br\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0912",
+"prefix": "br",
+"quote": "'",
+"src": "br''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0913",
+"prefix": "br",
+"quote": "'",
+"src": "br'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0914",
+"prefix": "br",
+"quote": "'",
+"src": "br'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0915",
+"prefix": "br",
+"quote": "'",
+"src": "br'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0916",
+"prefix": "br",
+"quote": "'",
+"src": "br'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0917",
+"prefix": "br",
+"quote": "'",
+"src": "br'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0918",
+"prefix": "br",
+"quote": "'",
+"src": "br'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0919",
+"prefix": "br",
+"quote": "'",
+"src": "br'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0920",
+"prefix": "br",
+"quote": "'",
+"src": "br'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0921",
+"prefix": "br",
+"quote": "'",
+"src": "br'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0922",
+"prefix": "br",
+"quote": "'",
+"src": "br'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0923",
+"prefix": "br",
+"quote": "'",
+"src": "br'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0924",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0925",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0926",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0927",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0928",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0929",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0930",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0931",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0932",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0933",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0934",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0935",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0936",
+"prefix": "br",
+"quote": "\"\"\"",
+"src": "br\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0937",
+"prefix": "br",
+"quote": "'''",
+"src": "br''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0938",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0939",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0940",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0941",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0942",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0943",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0944",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0945",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0946",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0947",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0948",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0949",
+"prefix": "br",
+"quote": "'''",
+"src": "br'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0950",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0951",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0952",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0953",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0954",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0955",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0956",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0957",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0958",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0959",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0960",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0961",
+"prefix": "Rb",
+"quote": "\"",
+"src": "Rb\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0962",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0963",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0964",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0965",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0966",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0967",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0968",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0969",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0970",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0971",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0972",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0973",
+"prefix": "Rb",
+"quote": "'",
+"src": "Rb'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0974",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0975",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0976",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0977",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0978",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0979",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0980",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0981",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0982",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "0983",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0984",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0985",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0986",
+"prefix": "Rb",
+"quote": "\"\"\"",
+"src": "Rb\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "0987",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "0988",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "0989",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "0990",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "0991",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "0992",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "0993",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "0994",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "0995",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "0996",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "0997",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "0998",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "0999",
+"prefix": "Rb",
+"quote": "'''",
+"src": "Rb'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1000",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1001",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1002",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1003",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1004",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1005",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1006",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1007",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1008",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1009",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1010",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1011",
+"prefix": "rB",
+"quote": "\"",
+"src": "rB\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1012",
+"prefix": "rB",
+"quote": "'",
+"src": "rB''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1013",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1014",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1015",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1016",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1017",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1018",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1019",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1020",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1021",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1022",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1023",
+"prefix": "rB",
+"quote": "'",
+"src": "rB'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1024",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1025",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1026",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1027",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1028",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1029",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1030",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1031",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1032",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1033",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1034",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1035",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1036",
+"prefix": "rB",
+"quote": "\"\"\"",
+"src": "rB\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1037",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1038",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1039",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1040",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1041",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1042",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1043",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1044",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1045",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1046",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1047",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1048",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1049",
+"prefix": "rB",
+"quote": "'''",
+"src": "rB'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1050",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1051",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1052",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1053",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1054",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1055",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1056",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1057",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1058",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1059",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1060",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1061",
+"prefix": "bR",
+"quote": "\"",
+"src": "bR\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1062",
+"prefix": "bR",
+"quote": "'",
+"src": "bR''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1063",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1064",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1065",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1066",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1067",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1068",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1069",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1070",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1071",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1072",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1073",
+"prefix": "bR",
+"quote": "'",
+"src": "bR'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1074",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1075",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1076",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1077",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1078",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1079",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1080",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1081",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1082",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1083",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1084",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1085",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1086",
+"prefix": "bR",
+"quote": "\"\"\"",
+"src": "bR\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1087",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1088",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1089",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1090",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1091",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1092",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1093",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1094",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1095",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1096",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1097",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1098",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1099",
+"prefix": "bR",
+"quote": "'''",
+"src": "bR'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1100",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1101",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1102",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1103",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1104",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1105",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1106",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1107",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1108",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1109",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1110",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1111",
+"prefix": "Br",
+"quote": "\"",
+"src": "Br\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1112",
+"prefix": "Br",
+"quote": "'",
+"src": "Br''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1113",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1114",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1115",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1116",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1117",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1118",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1119",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1120",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1121",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1122",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1123",
+"prefix": "Br",
+"quote": "'",
+"src": "Br'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1124",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1125",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1126",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1127",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1128",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1129",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1130",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1131",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1132",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1133",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1134",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1135",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1136",
+"prefix": "Br",
+"quote": "\"\"\"",
+"src": "Br\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1137",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1138",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1139",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1140",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1141",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1142",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1143",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1144",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1145",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1146",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1147",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1148",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1149",
+"prefix": "Br",
+"quote": "'''",
+"src": "Br'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1150",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1151",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1152",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1153",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1154",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1155",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1156",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1157",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1158",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1159",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1160",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1161",
+"prefix": "RB",
+"quote": "\"",
+"src": "RB\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1162",
+"prefix": "RB",
+"quote": "'",
+"src": "RB''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1163",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1164",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1165",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1166",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1167",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1168",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1169",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1170",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1171",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1172",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1173",
+"prefix": "RB",
+"quote": "'",
+"src": "RB'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1174",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1175",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1176",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1177",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1178",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1179",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1180",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1181",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1182",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1183",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1184",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1185",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1186",
+"prefix": "RB",
+"quote": "\"\"\"",
+"src": "RB\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1187",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1188",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1189",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1190",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1191",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1192",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1193",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1194",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1195",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1196",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1197",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1198",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1199",
+"prefix": "RB",
+"quote": "'''",
+"src": "RB'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1200",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1201",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"ab\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1202",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"a\\nb\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1203",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"a\\tb\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1204",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"\\d+\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1205",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"a\\\\b\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1206",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"{x}\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1207",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"{{x}}\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1208",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"say 'hi'\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1209",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"tab\there\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1210",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"unicode \\u00e9\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1211",
+"prefix": "BR",
+"quote": "\"",
+"src": "BR\"hex \\xff\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1212",
+"prefix": "BR",
+"quote": "'",
+"src": "BR''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1213",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'ab'",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1214",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'a\\nb'",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1215",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'a\\tb'",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1216",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'\\d+'",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1217",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'a\\\\b'",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1218",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'{x}'",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1219",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'{{x}}'",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1220",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'say \"hi\"'",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1221",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'tab\there'",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1222",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'unicode \\u00e9'",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1223",
+"prefix": "BR",
+"quote": "'",
+"src": "BR'hex \\xff'",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1224",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"\"\"\"",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1225",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"ab\"\"\"",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1226",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"a\\nb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1227",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"a\\tb\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1228",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"\\d+\"\"\"",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1229",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"a\\\\b\"\"\"",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1230",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"{x}\"\"\"",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1231",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"{{x}}\"\"\"",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1232",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"say 'hi'\"\"\"",
+"kind": "bytes",
+"expected": "b\"say 'hi'\""
+},
+{
+"id": "1233",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"line1\nline2\"\"\"",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1234",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"tab\there\"\"\"",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1235",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"unicode \\u00e9\"\"\"",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1236",
+"prefix": "BR",
+"quote": "\"\"\"",
+"src": "BR\"\"\"hex \\xff\"\"\"",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
+},
+{
+"id": "1237",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR''''''",
+"kind": "bytes",
+"expected": "b''"
+},
+{
+"id": "1238",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''ab'''",
+"kind": "bytes",
+"expected": "b'ab'"
+},
+{
+"id": "1239",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''a\\nb'''",
+"kind": "bytes",
+"expected": "b'a\\\\nb'"
+},
+{
+"id": "1240",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''a\\tb'''",
+"kind": "bytes",
+"expected": "b'a\\\\tb'"
+},
+{
+"id": "1241",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''\\d+'''",
+"kind": "bytes",
+"expected": "b'\\\\d+'"
+},
+{
+"id": "1242",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''a\\\\b'''",
+"kind": "bytes",
+"expected": "b'a\\\\\\\\b'"
+},
+{
+"id": "1243",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''{x}'''",
+"kind": "bytes",
+"expected": "b'{x}'"
+},
+{
+"id": "1244",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''{{x}}'''",
+"kind": "bytes",
+"expected": "b'{{x}}'"
+},
+{
+"id": "1245",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''say \"hi\"'''",
+"kind": "bytes",
+"expected": "b'say \"hi\"'"
+},
+{
+"id": "1246",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''line1\nline2'''",
+"kind": "bytes",
+"expected": "b'line1\\nline2'"
+},
+{
+"id": "1247",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''tab\there'''",
+"kind": "bytes",
+"expected": "b'tab\\there'"
+},
+{
+"id": "1248",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''unicode \\u00e9'''",
+"kind": "bytes",
+"expected": "b'unicode \\\\u00e9'"
+},
+{
+"id": "1249",
+"prefix": "BR",
+"quote": "'''",
+"src": "BR'''hex \\xff'''",
+"kind": "bytes",
+"expected": "b'hex \\\\xff'"
 }
 ]

--- a/test/fixtures/string_prefix_diff_gen.py
+++ b/test/fixtures/string_prefix_diff_gen.py
@@ -11,15 +11,13 @@ test side evaluates the same literal in pyex and asserts `repr()` matches
 CPython byte-for-byte. `repr` is used as a single uniform comparator that
 works for both `str` and `bytes` results.
 
-The generator enumerates the Python *str* prefix matrix:
+The generator enumerates the full Python string/bytes prefix matrix:
 
   * prefixes : '' r R f F u U  +  rf fr (all case/order variants)
+               +  b B  +  rb br (all case/order variants)
   * quotes   : "  '  \"\"\"  '''
-  * bodies   : plain / escapes (\\n \\t \\d \\\\) / braces ({x} {{x}})
-               / embedded quotes / real newlines
-
-Bytes prefixes (b/B, rb/br) are deliberately excluded for now; see the
-note on the PREFIXES list below.
+  * bodies   : plain / escapes (\\n \\t \\d \\\\ \\u00e9 \\xff) / braces
+               ({x} {{x}}) / embedded quotes / real newlines
 
 CPython is the legality oracle: any (prefix, quote, body) triple that is
 not valid Python raises SyntaxError at compile time and is skipped, so we
@@ -42,30 +40,18 @@ import warnings
 warnings.simplefilter("ignore", SyntaxWarning)
 warnings.simplefilter("ignore", DeprecationWarning)
 
-# Every str prefix we care about, including the empty (no-prefix) case. We
-# list case/order variants explicitly rather than generating them so the
-# fixture documents exactly what is covered.
-#
-# Bytes prefixes (b/B and the rb/br combos) are intentionally NOT generated
-# here yet. pyex's bytes path is a separate subsystem (identifier + string
-# tokens stitched back together by `collapse_bytes_literals/1`) with its own
-# distinct, pre-existing divergences from CPython that this fixture would
-# otherwise drown in:
-#
-#   * raw bytes (rb"\n") are cooked instead of kept raw
-#   * bytes wrongly interpret \u / \N escapes that don't exist in bytes
-#   * repr(bytes) doesn't switch to "double quotes" the way CPython does
-#
-# Those belong to a focused bytes-matrix follow-up. To extend this generator
-# to bytes once that work starts, append:
-#
-#     "b", "B", "rb", "br", "Rb", "rB", "bR", "Br", "RB", "BR",
+# Every prefix we care about, including the empty (no-prefix) case. We list
+# case/order variants explicitly rather than generating them so the fixture
+# documents exactly what is covered: str prefixes (r/f/u and the rf/fr
+# combos) and bytes prefixes (b and the rb/br combos), each case-insensitive.
 PREFIXES = [
     "",
     "r", "R",
     "f", "F",
     "u", "U",
     "rf", "fr", "Rf", "rF", "Fr", "fR", "RF", "FR",
+    "b", "B",
+    "rb", "br", "Rb", "rB", "bR", "Br", "RB", "BR",
 ]
 
 # (open, close) quote delimiters.

--- a/test/pyex/lexer_string_prefix_differential_test.exs
+++ b/test/pyex/lexer_string_prefix_differential_test.exs
@@ -1,21 +1,23 @@
 defmodule Pyex.LexerStringPrefixDifferentialTest do
   @moduledoc """
-  Differential test of string-literal lexing against CPython 3.14.
+  Differential test of string/bytes-literal lexing against CPython 3.14.
 
-  The full Python *str* prefix matrix — every prefix (`''`, `r`/`R`, `f`/`F`,
-  `u`/`U`, and the `rf`/`fr` combos in all case/order variants) crossed with
-  all four quote styles (`"`, `'`, `\"\"\"`, `'''`) and a battery of bodies
-  (escapes, braces, embedded quotes, real newlines) — was evaluated by
-  CPython once at fixture-build time and committed to
+  The full Python prefix matrix — every prefix (`''`, `r`/`R`, `f`/`F`,
+  `u`/`U`, `b`/`B`, and the `rf`/`fr` and `rb`/`br` combos in all case/order
+  variants) crossed with all four quote styles (`"`, `'`, `\"\"\"`, `'''`)
+  and a battery of bodies (escapes, braces, embedded quotes, real newlines)
+  — was evaluated by CPython once at fixture-build time and committed to
   `test/fixtures/string_prefix_diff.json`. CPython is also the legality
   oracle: any prefix/quote/body triple that is not valid Python was dropped
   at generation time, so every committed vector is real, valid Python.
 
   This test re-evaluates each literal in pyex and asserts `repr()` matches
-  CPython byte-for-byte. `repr` is a single uniform comparator that pins down
-  both the value AND its exact bytes — it catches the failure mode that a
-  token-kind check misses, e.g. a raw string that lexes to the right *kind*
-  of token but silently interprets a `\\n` it should have kept literal.
+  CPython byte-for-byte. `repr` is a single uniform comparator that works for
+  both `str` and `bytes` results and pins down both the value AND its exact
+  bytes — it catches the failure mode that a token-kind check misses, e.g. a
+  raw string that lexes to the right *kind* of token but silently interprets
+  a `\\n` it should have kept literal, or a bytes repr that picks the wrong
+  quote.
 
   To regenerate:
 
@@ -23,12 +25,6 @@ defmodule Pyex.LexerStringPrefixDifferentialTest do
 
   The generator is a fixed cross-product (no RNG), so a fresh fixture is
   byte-identical to the committed one unless the generator changes.
-
-  Bytes literals (`b"..."`, `rb"..."`, ...) are intentionally out of scope
-  here: they are a separate lexing subsystem with their own pre-existing
-  CPython divergences (raw bytes are cooked, `\\u`/`\\N` are wrongly
-  interpreted, `repr(bytes)` quoting differs). They warrant a focused
-  follow-up; the generator documents exactly how to extend to them.
   """
 
   use ExUnit.Case, async: true
@@ -67,20 +63,22 @@ defmodule Pyex.LexerStringPrefixDifferentialTest do
   end
 
   test "vector count matches what the generator emits (don't ship a stale fixture)" do
-    assert length(@vectors) == 750
+    assert length(@vectors) == 1250
   end
 
-  test "fixture spans every str prefix family and quote style we claim to cover" do
+  test "fixture spans every prefix family and quote style we claim to cover" do
     prefixes = @vectors |> Enum.map(& &1["prefix"]) |> MapSet.new()
     quotes = @vectors |> Enum.map(& &1["quote"]) |> MapSet.new()
+    kinds = @vectors |> Enum.map(& &1["kind"]) |> MapSet.new()
 
-    # Empty prefix plus every case/order variant of r, f, u and rf/fr.
-    for p <- ~w(r R f F u U rf fr Rf rF Fr fR RF FR) do
+    # Empty prefix plus every case/order variant of r, f, u, b and rf/rb.
+    for p <- ~w(r R f F u U b B rf fr Rf rF Fr fR RF FR rb br Rb rB bR Br RB BR) do
       assert p in prefixes, "fixture is missing prefix #{inspect(p)}"
     end
 
     assert "" in prefixes, "fixture is missing the no-prefix case"
     assert MapSet.equal?(quotes, MapSet.new(["\"", "'", "\"\"\"", "'''"]))
+    assert MapSet.equal?(kinds, MapSet.new(["str", "bytes"]))
   end
 
   test "the matrix actually exercises the semantics that distinguish prefixes" do
@@ -90,19 +88,44 @@ defmodule Pyex.LexerStringPrefixDifferentialTest do
     # strings, so the check stays robust to escaping subtleties.
     by_src = Map.new(@vectors, &{&1["src"], &1["expected"]})
 
-    require_keys = [~S|r"a\nb"|, ~S|"a\nb"|, ~S|f"{x}"|, ~S|"{x}"|, ~S|rf"\d+"|]
+    # The `é` keys are spelled with explicit `\\u` (a literal backslash)
+    # rather than a sigil holding the é character, so the source byte-for-byte
+    # matches the fixture (where the body is the 6 chars `é`, not é).
+    bytes_u = "b\"unicode \\u00e9\""
+    str_u = "\"unicode \\u00e9\""
+
+    require_keys = [
+      ~S|r"a\nb"|,
+      ~S|"a\nb"|,
+      ~S|f"{x}"|,
+      ~S|"{x}"|,
+      ~S|rf"\d+"|,
+      ~S|rb"a\nb"|,
+      ~S|b"a\nb"|,
+      bytes_u,
+      str_u,
+      ~S|b"say 'hi'"|
+    ]
 
     for k <- require_keys do
       assert Map.has_key?(by_src, k), "fixture is missing distinguishing vector #{inspect(k)}"
     end
 
     # Raw keeps the backslash; cooked turns `\n` into a newline. The two
-    # must differ, or raw-vs-cooked isn't being tested.
+    # must differ, or raw-vs-cooked isn't being tested (str and bytes).
     assert by_src[~S|r"a\nb"|] != by_src[~S|"a\nb"|]
+    assert by_src[~S|rb"a\nb"|] != by_src[~S|b"a\nb"|]
 
     # f-strings interpolate `{x}` -> "5"; plain strings keep it literal.
     assert by_src[~S|f"{x}"|] == "'5'"
     assert by_src[~S|"{x}"|] != by_src[~S|f"{x}"|]
+
+    # Bytes do NOT interpret `\u`: bytes keep it literal while str turns
+    # `é` into é, so the two results differ.
+    assert by_src[bytes_u] != by_src[str_u]
+
+    # repr(bytes) switches to double quotes when the value contains a `'`.
+    assert by_src[~S|b"say 'hi'"|] == ~S|b"say 'hi'"|
   end
 
   # =========================================================================

--- a/test/pyex/lexer_test.exs
+++ b/test/pyex/lexer_test.exs
@@ -494,6 +494,46 @@ defmodule Pyex.LexerTest do
     end
   end
 
+  describe "byte-string prefixes" do
+    test "plain bytes literal lexes to a bytes token" do
+      assert {:ok, [{:bytes_literal, 1, "ab"}]} = Lexer.tokenize(~S|b"ab"|)
+    end
+
+    test "uppercase B and reversed/raw combos all lex to bytes tokens" do
+      for prefix <- ~w(b B rb br Rb rB bR Br RB BR) do
+        assert {:ok, [{:bytes_literal, 1, "ab"}]} = Lexer.tokenize(prefix <> ~S|"ab"|),
+               "prefix #{prefix} did not lex as a bytes literal"
+      end
+    end
+
+    test "cooked bytes interpret escapes; raw bytes keep them literal" do
+      assert {:ok, [{:bytes_literal, 1, "a\nb"}]} = Lexer.tokenize(~S|b"a\nb"|)
+      assert {:ok, [{:bytes_literal, 1, "a\\nb"}]} = Lexer.tokenize(~S|rb"a\nb"|)
+    end
+
+    test "bytes \\xhh is a single raw byte, not a UTF-8 codepoint" do
+      assert {:ok, [{:bytes_literal, 1, <<0xFF>>}]} = Lexer.tokenize(~S|b"\xff"|)
+    end
+
+    test "bytes do not interpret \\u escapes (kept literal)" do
+      # Source is b"é"; the \u stays literal in a bytes literal.
+      assert {:ok, [{:bytes_literal, 1, "\\u00e9"}]} = Lexer.tokenize("b\"\\u00e9\"")
+    end
+
+    test "raw bytes triple-quoted keeps backslashes and embedded quotes" do
+      assert {:ok, [{:bytes_literal, 1, ~S|a "b" \d|}]} =
+               Lexer.tokenize(~S|rb"""a "b" \d"""|)
+    end
+
+    test "repr switches to double quotes when bytes contain a single quote" do
+      assert Pyex.run!(~S|repr(b"say 'hi'")|) == ~S|b"say 'hi'"|
+    end
+
+    test "repr keeps single quotes and escapes when bytes contain a double quote" do
+      assert Pyex.run!(~S|repr(b'say "hi"')|) == ~S|b'say "hi"'|
+    end
+  end
+
   describe "escape sequences" do
     test "carriage return \\r" do
       assert {:ok, [{:string, 1, "\r"}]} = Lexer.tokenize(~S|"\r"|)


### PR DESCRIPTION
Closes #82. Follow-up to #81, which completed the **str** prefix matrix; this finishes the **bytes** half.

## What was broken

Bytes literals were a separate, incomplete subsystem: `b"..."`/`rb"..."` lexed as an identifier + cooked string, then `collapse_bytes_literals/1` stitched the pair back into a `:bytes_literal` token. That post-pass runs *after* the str lexer has already interpreted escapes, so it couldn't recover bytes semantics. Three divergences from CPython remained:

1. **Raw bytes were cooked** — `rb"\n"` produced a real newline instead of a literal `\n`.
2. **Bytes interpreted `\u`/`\U`** escapes that don't exist in byte strings (`b"é"` collapsed to one byte instead of staying the 6 literal chars).
3. **`repr(bytes)` always used single quotes** instead of switching to double quotes when the value contains a `'` (CPython's rule).

## The fix

- **Bytes get their own combinators** (cooked `b`/`B`, raw `rb`/`br` and case variants, all four quote styles), built from the same body/prefix helper closures added for str in #81. A bytes-only escape table omits `\u`/`\U`/`\N` (kept literal) and treats `\xhh` as a single raw byte (not a UTF-8-encoded codepoint); a `__bytes__` reducer assembles raw bytes. The `collapse_bytes_literals/1` + `codepoints_to_bytes/1` path is retired.
- **`bytes_repr/2`** now selects the quote like CPython: single by default, double when the value contains a `'` and no `"`.

## Testing

The CPython differential generator (`test/fixtures/string_prefix_diff_gen.py`) now enumerates the **full matrix** — str *and* bytes. The fixture grows from 750 → **1250** CPython-evaluated vectors, and the differential test asserts all of them `repr()`-match byte-for-byte. The repr quote fix is validated automatically by the bytes vectors (`b"say 'hi'"` → `b"say 'hi'"`). Adds readable bytes example tests covering raw-vs-cooked, single-byte `\xhh`, `\u`-not-interpreted, raw triples, and repr quote selection.

## Checks

- `mix format --check-formatted` ✓
- `mix compile --warnings-as-errors` ✓
- `mix test` — 5492 tests, 0 failures ✓
- `mix dialyzer` — passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)